### PR TITLE
update local and remote key handling for entities

### DIFF
--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -321,7 +321,12 @@ static NSString * const SyncDefaultRemotePrimaryKey = @"id";
     NSString *remoteKey = primaryAttribute.userInfo[HYPPropertyMapperCustomRemoteKey];
     
     if (!remoteKey) {
-        remoteKey = SyncDefaultRemotePrimaryKey;
+        if ([primaryAttribute.name isEqualToString:SyncDefaultLocalPrimaryKey]) {
+            remoteKey = SyncDefaultRemotePrimaryKey;
+        } else {
+            remoteKey = [primaryAttribute.name hyp_remoteString];
+        }
+        
     }
 
     return remoteKey;

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -283,35 +283,45 @@ static NSString * const SyncDefaultRemotePrimaryKey = @"id";
 
 @implementation NSEntityDescription (Sync)
 
-- (NSString *)sync_localKey
+- (NSAttributeDescription *)sync_primaryAttribute
 {
-    __block NSString *localKey;
-    [self.propertiesByName enumerateKeysAndObjectsUsingBlock:^(NSString *key,
-                                                               NSAttributeDescription *attributeDescription,
-                                                               BOOL *stop) {
+    __block NSAttributeDescription *primaryAttribute = nil;
+    
+    [self.propertiesByName enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSAttributeDescription *attributeDescription, BOOL *stop) {
         NSString *isPrimaryKey = attributeDescription.userInfo[SyncCustomPrimaryKey];
         BOOL hasCustomPrimaryKey = (isPrimaryKey &&
                                     [isPrimaryKey isEqualToString:@"YES"]);
+        
         if (hasCustomPrimaryKey) {
-            localKey = key;
+            primaryAttribute = attributeDescription;
+            *stop = YES;
+        }
+        
+        if ([key isEqualToString:SyncDefaultLocalPrimaryKey]) {
+            primaryAttribute = attributeDescription;
         }
     }];
+    
+    return primaryAttribute;
+}
 
-    if (!localKey) {
-        localKey = SyncDefaultLocalPrimaryKey;
-    }
+- (NSString *)sync_localKey
+{
+    NSString *localKey;
+    NSAttributeDescription *primaryAttribute = [self sync_primaryAttribute];
+    
+    localKey = primaryAttribute.name;
 
     return localKey;
 }
 
 - (NSString *)sync_remoteKey
 {
-    NSString *remoteKey;
-    NSString *localKey = [self sync_localKey];
-    if ([localKey isEqualToString:SyncDefaultLocalPrimaryKey]) {
+    NSAttributeDescription *primaryAttribute = [self sync_primaryAttribute];
+    NSString *remoteKey = primaryAttribute.userInfo[HYPPropertyMapperCustomRemoteKey];
+    
+    if (!remoteKey) {
         remoteKey = SyncDefaultRemotePrimaryKey;
-    } else {
-        remoteKey = [localKey hyp_remoteString];
     }
 
     return remoteKey;


### PR DESCRIPTION
Rather than the previous process that only used the actual attribute for the local key, this now uses the actual primary attribute (either the marked attribute or the default remoteID attribute) and pulls out the provided remote key. 

Unfortunately this doesn't add additional tests for this case. 

Fixes #58.