### PR TITLE
Make it so the relationships name are correctly converted to the corresponding JSON name

### DIFF
--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -210,7 +210,7 @@ static NSString * const SyncDefaultRemotePrimaryKey = @"id";
                              dataStack:(DATAStack *)dataStack
 {
     NSString *relationshipKey = relationship.userInfo[SyncCustomRemoteKey];
-    NSString *relationshipName = (relationshipKey) ?: relationship.name;
+    NSString *relationshipName = (relationshipKey) ?: [relationship.name hyp_remoteString];
     NSString *childEntityName = relationship.destinationEntity.name;
     NSString *parentEntityName = parent.entity.name;
     NSString *inverseEntityName = relationship.inverseRelationship.name;
@@ -256,7 +256,7 @@ static NSString * const SyncDefaultRemotePrimaryKey = @"id";
                       usingDictionary:(NSDictionary *)objectDict
 {
     NSString *relationshipKey = [[relationship userInfo] valueForKey:SyncCustomRemoteKey];
-    NSString *relationshipName = (relationshipKey) ?: relationship.name;
+    NSString *relationshipName = (relationshipKey) ?: [relationship.name hyp_remoteString];
     NSString *entityName = relationship.destinationEntity.name;
     NSEntityDescription *entity = [NSEntityDescription entityForName:entityName
                                               inManagedObjectContext:self.managedObjectContext];

--- a/Tests/Tests/Model.xcdatamodeld/Demo.xcdatamodel/contents
+++ b/Tests/Tests/Model.xcdatamodeld/Demo.xcdatamodel/contents
@@ -26,6 +26,7 @@
             </userInfo>
         </attribute>
         <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="profilePictures" inverseEntity="User" syncable="YES"/>
     </entity>
     <entity name="Note" syncable="YES">
         <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
@@ -72,17 +73,18 @@
                 <entry key="hyper.remoteKey" value="annotations"/>
             </userInfo>
         </relationship>
+        <relationship name="profilePictures" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Image" inverseName="user" inverseEntity="Image" syncable="YES"/>
     </entity>
     <elements>
         <element name="Collection" positionX="-252" positionY="360" width="128" height="73"/>
         <element name="Comment" positionX="-180" positionY="135" width="128" height="88"/>
         <element name="Company" positionX="-389" positionY="27" width="128" height="88"/>
+        <element name="Image" positionX="-180" positionY="135" width="128" height="88"/>
         <element name="Note" positionX="-20" positionY="18" width="128" height="103"/>
         <element name="Number" positionX="-72" positionY="360" width="128" height="118"/>
         <element name="Story" positionX="-180" positionY="135" width="128" height="103"/>
         <element name="Summarize" positionX="-180" positionY="135" width="128" height="88"/>
         <element name="Tag" positionX="160" positionY="0" width="128" height="90"/>
-        <element name="User" positionX="-207" positionY="-15" width="128" height="150"/>
-        <element name="Image" positionX="-180" positionY="135" width="128" height="75"/>
+        <element name="User" positionX="-207" positionY="-15" width="128" height="163"/>
     </elements>
 </model>

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -123,6 +123,13 @@
            NSInteger notesCount = [mainContext countForFetchRequest:noteRequest error:&notesError];
            if (notesError) NSLog(@"notesError: %@", notesError);
            XCTAssertEqual(notesCount, 5);
+         
+           NSError *profilePicturesError = nil;
+           NSFetchRequest *profilePictureRequest = [[NSFetchRequest alloc] initWithEntityName:@"Image"];
+           profilePictureRequest.predicate = [NSPredicate predicateWithFormat:@"user = %@", user];
+           NSInteger profilePicturesCount = [mainContext countForFetchRequest:profilePictureRequest error:&profilePicturesError];
+           if (profilePicturesError) NSLog(@"profilePicturesError: %@", profilePicturesError);
+           XCTAssertEqual(profilePicturesCount, 3);
        }];
 }
 

--- a/Tests/Tests/users_notes.json
+++ b/Tests/Tests/users_notes.json
@@ -24,7 +24,21 @@
         "id": 9,
         "text": "Shawn Merril's diary, episode 5"
       }
-    ]
+    ],
+    "profile_pictures": [
+      {
+        "ImageId": 0,
+        "url": "http://sample.com/sample0.png"
+      },
+      {
+        "ImageId": 1,
+        "url": "http://sample.com/sample1.png"
+      },
+      {
+        "ImageId": 2,
+        "url": "http://sample.com/sample2.png"
+      }
+    ],
   },
   {
     "id": 7,
@@ -51,7 +65,17 @@
         "id": 5,
         "text": "Bradford Duke's diary, episode 5"
       }
-    ]
+    ],
+    "profile_pictures": [
+      {
+        "ImageId": 0,
+        "url": "http://sample.com/sample0.png"
+      },
+      {
+        "ImageId": 1,
+        "url": "http://sample.com/sample1.png"
+      }
+    ],
   },
   {
     "id": 8,
@@ -62,7 +86,13 @@
         "id": 10,
         "text": "Bradford Duke's diary, episode 1"
       }
-    ]
+    ],
+    "profile_pictures": [
+      {
+        "ImageId": 0,
+        "url": "http://sample.com/sample0.png"
+      }
+    ],
   },
   {
     "id": 9,


### PR DESCRIPTION
Before, if you had any relationship whose name contained more than a single word, such as "profilePictures", Sync would try to fetch the key "profilePictures" from the JSON dictionary, instead of trying the key "profile_pictures".
This pull request fixes this issue and add a test case for this.