### PR TITLE
Expose some utility methods so that they can be used by anybody

### DIFF
--- a/Source/Sync.h
+++ b/Source/Sync.h
@@ -5,6 +5,21 @@
 static NSString * const SyncCustomPrimaryKey = @"hyper.isPrimaryKey";
 static NSString * const SyncCustomRemoteKey = @"hyper.remoteKey";
 
+@interface NSEntityDescription (Sync)
+
+- (NSString *)sync_remoteKey;
+- (NSString *)sync_localKey;
+
+@end
+
+@interface NSManagedObject (Sync)
+
+- (void)sync_processRelationshipsUsingDictionary:(NSDictionary *)objectDict
+                                       andParent:(NSManagedObject *)parent
+                                       dataStack:(DATAStack *)dataStack;
+
+@end
+
 @interface Sync : NSObject
 
 + (void)changes:(NSArray *)changes

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -10,14 +10,7 @@
 static NSString * const SyncDefaultLocalPrimaryKey = @"remoteID";
 static NSString * const SyncDefaultRemotePrimaryKey = @"id";
 
-@interface NSEntityDescription (Sync)
-
-- (NSString *)sync_remoteKey;
-- (NSString *)sync_localKey;
-
-@end
-
-@interface NSManagedObject (Sync)
+@interface NSManagedObject (SyncPrivate)
 
 - (NSManagedObject *)sync_copyInContext:(NSManagedObjectContext *)context;
 


### PR DESCRIPTION
I found myself having to use some private methods you use in Sync:
- For getting the remote key and the local key of a NSManagedObject
- For processing the relationships on a NSManagedObject (In case you have a dictionary of a single object, that you would to merge into an existing object including the relationships)