### PR TITLE
Improve one-to-one relationships mapping

### DIFF
--- a/Tests/Tests/Model.xcdatamodeld/Demo.xcdatamodel/contents
+++ b/Tests/Tests/Model.xcdatamodeld/Demo.xcdatamodel/contents
@@ -28,6 +28,12 @@
         <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="User" inverseName="profilePictures" inverseEntity="User" syncable="YES"/>
     </entity>
+    <entity name="Location" syncable="YES">
+        <attribute name="city" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="street" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="zipCode" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="user" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="User" inverseName="location" inverseEntity="User" syncable="YES"/>
+    </entity>
     <entity name="Note" syncable="YES">
         <attribute name="remoteID" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="text" optional="YES" attributeType="String" syncable="YES"/>
@@ -68,6 +74,7 @@
         <attribute name="remoteID" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" syncable="YES"/>
         <relationship name="company" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Company" inverseName="users" inverseEntity="Company" syncable="YES"/>
+        <relationship name="location" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Location" inverseName="user" inverseEntity="Location" syncable="YES"/>
         <relationship name="notes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Note" inverseName="user" inverseEntity="Note" syncable="YES">
             <userInfo>
                 <entry key="hyper.remoteKey" value="annotations"/>
@@ -86,5 +93,6 @@
         <element name="Summarize" positionX="-180" positionY="135" width="128" height="88"/>
         <element name="Tag" positionX="160" positionY="0" width="128" height="90"/>
         <element name="User" positionX="-207" positionY="-15" width="128" height="163"/>
+        <element name="Location" positionX="-180" positionY="135" width="128" height="103"/>
     </elements>
 </model>

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -130,6 +130,8 @@
            NSInteger profilePicturesCount = [mainContext countForFetchRequest:profilePictureRequest error:&profilePicturesError];
            if (profilePicturesError) NSLog(@"profilePicturesError: %@", profilePicturesError);
            XCTAssertEqual(profilePicturesCount, 3);
+         
+           XCTAssertTrue([[[user valueForKey:@"location"] valueForKey:@"city"] isEqualToString:@"New York"]);
        }];
 }
 

--- a/Tests/Tests/users_notes.json
+++ b/Tests/Tests/users_notes.json
@@ -6,7 +6,7 @@
     "location": {
       "city": "New York",
       "street": "Broadway",
-      "zipCode": 10012,
+      "zipCode": 10012
     },
     "annotations": [
       {

--- a/Tests/Tests/users_notes.json
+++ b/Tests/Tests/users_notes.json
@@ -3,6 +3,11 @@
     "id": 6,
     "name": "Shawn Merrill",
     "email": "firstupdate@ovium.com",
+    "location": {
+      "city": "New York",
+      "street": "Broadway",
+      "zipCode": 10012,
+    },
     "annotations": [
       {
         "id": 0,
@@ -44,6 +49,9 @@
     "id": 7,
     "name": "Bradford Duke",
     "email": "secondupdated@ovium.com",
+    "location": {
+      "city": "London"
+    },
     "annotations": [
       {
         "id": 1,
@@ -97,6 +105,9 @@
   {
     "id": 9,
     "name": "Alexis Richmond",
-    "email": "alexisrichmond@ovium.com"
+    "email": "alexisrichmond@ovium.com",
+    "location": {
+      "city": "Lille"
+    },
   }
 ]


### PR DESCRIPTION
Allow the mapping of one-to-one relationships that do not have a remoteID (This fixes the crash that was happening in that case)
This pull request also add the mapping of relationships of object resulting from a one-to-one relationship which was missing.
This is especially helpful in case you have a CoreData object that contains common properties (i.e., an Image object that contains both a thumbnail and a full image URL, which could be stored as part of every other object)