### PR TITLE
Fix: SQLite mode errors

### DIFF
--- a/Source/NSManagedObject+Sync.m
+++ b/Source/NSManagedObject+Sync.m
@@ -109,10 +109,8 @@
             NSString *destinationRemoteKey = [entity sync_remoteKey];
             NSArray *childIDs = [children valueForKey:destinationRemoteKey];
             NSString *destinationLocalKey = [entity sync_localKey];
-            if (childIDs.count == 1) {
+            if (childIDs) {
                 childPredicate = [NSPredicate predicateWithFormat:@"%K = %@", destinationLocalKey, [[children valueForKey:destinationRemoteKey] firstObject]];
-            } else {
-                childPredicate = [NSPredicate predicateWithFormat:@"ANY %K.%K = %@", relationshipName, destinationLocalKey, [children valueForKey:destinationRemoteKey]];
             }
         } else {
             childPredicate = [NSPredicate predicateWithFormat:@"%K = %@", inverseEntityName, self];

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -48,7 +48,7 @@
 
         NSError *error = nil;
         NSManagedObject *safeParent = [parent sync_copyInContext:backgroundContext
-                                       error:&error];
+                                                           error:&error];
         NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@", parent.entity.name, safeParent];
 
         [self changes:changes

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -49,7 +49,7 @@
         NSError *error = nil;
         NSManagedObject *safeParent = [parent sync_copyInContext:backgroundContext
                                                            error:&error];
-        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@", parent.entity.name, safeParent];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@", [parent.entity.name lowercaseString], safeParent];
 
         [self changes:changes
         inEntityNamed:entityName

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -30,11 +30,12 @@
 }
 
 - (DATAStack *)dataStackWithModelName:(NSString *)modelName {
-    [self dropSQLiteFileForModelNamed:modelName];
+    // Uncomment when using DATAStackSQLiteStoreType:
+    // [self dropSQLiteFileForModelNamed:modelName];
 
     DATAStack *dataStack = [[DATAStack alloc] initWithModelName:modelName
                                                          bundle:[NSBundle bundleForClass:[self class]]
-                                                      storeType:DATAStackSQLiteStoreType];
+                                                      storeType:DATAStackInMemoryStoreType];
 
     return dataStack;
 }

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -392,7 +392,7 @@
            NSFetchRequest *commentsRequest = [[NSFetchRequest alloc] initWithEntityName:@"Comment"];
            NSInteger numberOfComments = [mainContext countForFetchRequest:commentsRequest error:&commentsError];
            if (commentsError) NSLog(@"commentsError: %@", commentsError);
-           XCTAssertEqual(numberOfComments, 5);
+           XCTAssertEqual(numberOfComments, 7);
 
            NSError *commentsFetchError = nil;
            commentsRequest.predicate = [NSPredicate predicateWithFormat:@"body = %@", @"comment 1"];

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -392,7 +392,7 @@
            NSFetchRequest *commentsRequest = [[NSFetchRequest alloc] initWithEntityName:@"Comment"];
            NSInteger numberOfComments = [mainContext countForFetchRequest:commentsRequest error:&commentsError];
            if (commentsError) NSLog(@"commentsError: %@", commentsError);
-           XCTAssertEqual(numberOfComments, 8);
+           XCTAssertEqual(numberOfComments, 5);
 
            NSError *commentsFetchError = nil;
            commentsRequest.predicate = [NSPredicate predicateWithFormat:@"body = %@", @"comment 1"];

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -14,10 +14,27 @@
 
 #pragma mark - Helpers
 
+- (void)dropSQLiteFileForModelNamed:(NSString *)modelName {
+    NSURL *url = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
+                                                         inDomains:NSUserDomainMask] lastObject];
+    NSString *filePath = [NSString stringWithFormat:@"%@.sqlite", modelName];
+    NSURL *storeURL = [url URLByAppendingPathComponent:filePath];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSError *error = nil;
+    if ([fileManager fileExistsAtPath:storeURL.path]) [fileManager removeItemAtURL:storeURL error:&error];
+
+    if (error) {
+        NSLog(@"error deleting sqlite file");
+        abort();
+    }
+}
+
 - (DATAStack *)dataStackWithModelName:(NSString *)modelName {
+    [self dropSQLiteFileForModelNamed:modelName];
+
     DATAStack *dataStack = [[DATAStack alloc] initWithModelName:modelName
                                                          bundle:[NSBundle bundleForClass:[self class]]
-                                                      storeType:DATAStackInMemoryStoreType];
+                                                      storeType:DATAStackSQLiteStoreType];
 
     return dataStack;
 }

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -240,37 +240,34 @@
         [backgroundContext save:&userError];
         if (userError) NSLog(@"userError: %@", userError);
 
-        NSManagedObjectContext *mainContext = [dataStack mainContext];
-        [mainContext performBlockAndWait:^{
-            [dataStack persistWithCompletion:^{
-                NSFetchRequest *userRequest = [[NSFetchRequest alloc] initWithEntityName:@"User"];
-                userRequest.predicate = [NSPredicate predicateWithFormat:@"remoteID = %@", @6];
-                NSArray *users = [mainContext executeFetchRequest:userRequest error:nil];
-                if (users.count != 1) abort();
+        [dataStack persistWithCompletion:^{
+            NSFetchRequest *userRequest = [[NSFetchRequest alloc] initWithEntityName:@"User"];
+            userRequest.predicate = [NSPredicate predicateWithFormat:@"remoteID = %@", @6];
+            NSArray *users = [dataStack.mainContext executeFetchRequest:userRequest error:nil];
+            if (users.count != 1) abort();
 
-                [Sync changes:objects
-                inEntityNamed:@"Note"
-                       parent:[users firstObject]
-                    dataStack:dataStack
-                   completion:^(NSError *error) {
-                       NSManagedObjectContext *mainContext = [dataStack mainContext];
+            [Sync changes:objects
+            inEntityNamed:@"Note"
+                   parent:[users firstObject]
+                dataStack:dataStack
+               completion:^(NSError *error) {
+                   NSManagedObjectContext *mainContext = [dataStack mainContext];
 
-                       NSError *userFetchError = nil;
-                       NSFetchRequest *userRequest = [[NSFetchRequest alloc] initWithEntityName:@"User"];
-                       userRequest.predicate = [NSPredicate predicateWithFormat:@"remoteID = %@", @6];
-                       NSArray *users = [mainContext executeFetchRequest:userRequest error:&userFetchError];
-                       if (userFetchError) NSLog(@"userFetchError: %@", userFetchError);
-                       NSManagedObject *user = [users firstObject];
-                       XCTAssertEqualObjects([user valueForKey:@"name"], @"Shawn Merrill");
+                   NSError *userFetchError = nil;
+                   NSFetchRequest *userRequest = [[NSFetchRequest alloc] initWithEntityName:@"User"];
+                   userRequest.predicate = [NSPredicate predicateWithFormat:@"remoteID = %@", @6];
+                   NSArray *users = [mainContext executeFetchRequest:userRequest error:&userFetchError];
+                   if (userFetchError) NSLog(@"userFetchError: %@", userFetchError);
+                   NSManagedObject *user = [users firstObject];
+                   XCTAssertEqualObjects([user valueForKey:@"name"], @"Shawn Merrill");
 
-                       NSError *notesError = nil;
-                       NSFetchRequest *noteRequest = [[NSFetchRequest alloc] initWithEntityName:@"Note"];
-                       noteRequest.predicate = [NSPredicate predicateWithFormat:@"user = %@", user];
-                       NSInteger notesCount = [mainContext countForFetchRequest:noteRequest error:&notesError];
-                       if (notesError) NSLog(@"notesError: %@", notesError);
-                       XCTAssertEqual(notesCount, 5);
-                   }];
-            }];
+                   NSError *notesError = nil;
+                   NSFetchRequest *noteRequest = [[NSFetchRequest alloc] initWithEntityName:@"Note"];
+                   noteRequest.predicate = [NSPredicate predicateWithFormat:@"user = %@", user];
+                   NSInteger notesCount = [mainContext countForFetchRequest:noteRequest error:&notesError];
+                   if (notesError) NSLog(@"notesError: %@", notesError);
+                   XCTAssertEqual(notesCount, 5);
+               }];
         }];
     }];
 }


### PR DESCRIPTION
Switching to SQLite mode triggered many errors, this PR hopefully fixes all of them.

- Switched to SQLite mode
- Removed .sqlite file before creating new one
- Fixed errors
- Went back to InMemory mode

Using custom primary keys on a many-to-many relationship is still a known issue.