### PR TITLE
Add nullability marks

### DIFF
--- a/Examples/AppNet/AppNet/Networking.swift
+++ b/Examples/AppNet/AppNet/Networking.swift
@@ -18,7 +18,8 @@ class Networking {
         if let data = data, json = NSJSONSerialization.JSONObjectWithData(data,
           options: NSJSONReadingOptions.MutableContainers,
           error: nil) as? Dictionary<String, AnyObject> {
-            Sync.changes(json["data"] as! Array,
+            Sync.changes(
+              json["data"] as! Array,
               inEntityNamed: "Data",
               dataStack: self.dataStack,
               completion: { error in

--- a/Examples/AppNet/Podfile.lock
+++ b/Examples/AppNet/Podfile.lock
@@ -25,7 +25,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Sync:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
   DATAFilter: 3f89692f7c52dd3c3973287ee8c9bb2c0e76d344

--- a/Source/Sync.h
+++ b/Source/Sync.h
@@ -1,5 +1,7 @@
 @import CoreData;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class DATAStack;
 
 @interface Sync : NSObject
@@ -7,26 +9,28 @@
 + (void)changes:(NSArray *)changes
   inEntityNamed:(NSString *)entityName
       dataStack:(DATAStack *)dataStack
-     completion:(void (^)(NSError *error))completion;
+     completion:(void (^ __nullable)(NSError * __nullable error))completion;
 
 + (void)changes:(NSArray *)changes
   inEntityNamed:(NSString *)entityName
-      predicate:(NSPredicate *)predicate
+      predicate:(nullable NSPredicate *)predicate
       dataStack:(DATAStack *)dataStack
-     completion:(void (^)(NSError *error))completion;
+     completion:(void (^ __nullable)(NSError * __nullable error))completion;
 
 + (void)changes:(NSArray *)changes
   inEntityNamed:(NSString *)entityName
          parent:(NSManagedObject *)parent
       dataStack:(DATAStack *)dataStack
-     completion:(void (^)(NSError *error))completion;
+     completion:(void (^ __nullable)(NSError * __nullable error))completion;
 
 + (void)changes:(NSArray *)changes
   inEntityNamed:(NSString *)entityName
-      predicate:(NSPredicate *)predicate
-         parent:(NSManagedObject *)parent
+      predicate:(nullable NSPredicate *)predicate
+         parent:(nullable NSManagedObject *)parent
       inContext:(NSManagedObjectContext *)context
       dataStack:(DATAStack *)dataStack
-     completion:(void (^)(NSError *error))completion;
+     completion:(void (^ __nullable)(NSError * __nullable error))completion;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This breaks Travis. It also doesn't change much the way you call this API from Swift. Maybe we would just wait until Travis supports Xcode 6.3.