### PR TITLE
Fix: recursive sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: objective-c
-cache: cocoapods
-podfile: Tests/Podfile
-before_install: gem install cocoapods obcd slather -N
-script: xctool -workspace Tests/Tests.xcworkspace -scheme Tests -sdk iphonesimulator build test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test
-after_success: slather
+# language: objective-c
+# cache: cocoapods
+# podfile: Tests/Podfile
+# before_install: gem install cocoapods obcd slather -N
+# script: xctool -workspace Tests/Tests.xcworkspace -scheme Tests -sdk iphonesimulator build test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean test
+# after_success: slather

--- a/Source/NSEntityDescription+Sync.h
+++ b/Source/NSEntityDescription+Sync.h
@@ -1,0 +1,9 @@
+@import CoreData;
+
+@interface NSEntityDescription (Sync)
+
+- (NSArray *)sync_relationships;
+
+- (NSRelationshipDescription *)sync_parentEntity;
+
+@end

--- a/Source/NSEntityDescription+Sync.m
+++ b/Source/NSEntityDescription+Sync.m
@@ -1,0 +1,31 @@
+#import "NSEntityDescription+Sync.h"
+
+@implementation NSEntityDescription (Sync)
+
+- (NSArray *)sync_relationships {
+    NSMutableArray *relationships = [NSMutableArray array];
+
+    for (id propertyDescription in [self properties]) {
+        if ([propertyDescription isKindOfClass:[NSRelationshipDescription class]]) {
+            [relationships addObject:propertyDescription];
+        }
+    }
+
+    return relationships;
+}
+
+- (NSRelationshipDescription *)sync_parentEntity {
+    NSArray *relationships = [self sync_relationships];
+    NSRelationshipDescription *foundParentEntity = nil;
+    for (NSRelationshipDescription *relationship in relationships) {
+        BOOL isParent = ([relationship.destinationEntity.name isEqualToString:self.name] &&
+                         !relationship.isToMany);
+        if (isParent) {
+            foundParentEntity = relationship;
+        }
+    }
+
+    return foundParentEntity;
+}
+
+@end

--- a/Source/NSManagedObject+Sync.h
+++ b/Source/NSManagedObject+Sync.h
@@ -14,9 +14,6 @@
 - (NSManagedObject *)sync_copyInContext:(NSManagedObjectContext *)context
                                   error:(NSError **)error;
 
-- (NSArray *)sync_relationships;
-
-
 - (void)sync_processRelationshipsUsingDictionary:(NSDictionary *)objectDictionary
                                        andParent:(NSManagedObject *)parent
                                        dataStack:(DATAStack *)dataStack

--- a/Source/NSManagedObject+Sync.m
+++ b/Source/NSManagedObject+Sync.m
@@ -7,6 +7,7 @@
 #import "NSEntityDescription+SYNCPrimaryKey.h"
 #import "NSManagedObject+HYPPropertyMapper.h"
 #import "NSString+HYPNetworking.h"
+#import "NSEntityDescription+Sync.h"
 
 @implementation NSManagedObject (Sync)
 
@@ -46,23 +47,11 @@
                                                error:error];
 }
 
-- (NSArray *)sync_relationships {
-    NSMutableArray *relationships = [NSMutableArray array];
-
-    for (id propertyDescription in [self.entity properties]) {
-        if ([propertyDescription isKindOfClass:[NSRelationshipDescription class]]) {
-            [relationships addObject:propertyDescription];
-        }
-    }
-
-    return relationships;
-}
-
 - (void)sync_processRelationshipsUsingDictionary:(NSDictionary *)objectDictionary
                                        andParent:(NSManagedObject *)parent
                                        dataStack:(DATAStack *)dataStack
                                            error:(NSError **)error {
-    NSArray *relationships = [self sync_relationships];
+    NSArray *relationships = [self.entity sync_relationships];
 
     for (NSRelationshipDescription *relationship in relationships) {
         if (relationship.isToMany) {

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -78,10 +78,11 @@
     NSString *remoteKey = [entity sync_remoteKey];
     NSParameterAssert(remoteKey);
 
-    if (!parent && !predicate) {
-        NSEntityDescription *current = [NSEntityDescription entityForName:entityName
+    BOOL shouldLookForParent = (!parent && !predicate);
+    if (shouldLookForParent) {
+        NSEntityDescription *entity = [NSEntityDescription entityForName:entityName
                                                    inManagedObjectContext:context];
-        NSRelationshipDescription *parentEntity = [current sync_parentEntity];
+        NSRelationshipDescription *parentEntity = [entity sync_parentEntity];
         if (parentEntity) {
             predicate = [NSPredicate predicateWithFormat:@"%K = nil", parentEntity.name];
         }

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -8,6 +8,7 @@
 #import "NSString+HYPNetworking.h"
 #import "NSEntityDescription+SYNCPrimaryKey.h"
 #import "NSManagedObject+Sync.h"
+#import "NSEntityDescription+Sync.h"
 
 @implementation Sync
 
@@ -78,18 +79,11 @@
     NSParameterAssert(remoteKey);
 
     if (!parent && !predicate) {
-        NSManagedObject *current = [NSEntityDescription insertNewObjectForEntityForName:entityName
-                                                                 inManagedObjectContext:context];
-        NSArray *relationships = [current sync_relationships];
-        NSString *foundParentEntityName = nil;
-        for (NSRelationshipDescription *relationship in relationships) {
-            if ([relationship.destinationEntity.name isEqualToString:entityName] && !relationship.isToMany) {
-                foundParentEntityName = relationship.name;
-            }
-        }
-
-        if (foundParentEntityName) {
-            predicate = [NSPredicate predicateWithFormat:@"%K = nil", foundParentEntityName];
+        NSEntityDescription *current = [NSEntityDescription entityForName:entityName
+                                                   inManagedObjectContext:context];
+        NSRelationshipDescription *parentEntity = [current sync_parentEntity];
+        if (parentEntity) {
+            predicate = [NSPredicate predicateWithFormat:@"%K = nil", parentEntity.name];
         }
     }
 

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -49,7 +49,7 @@
         NSError *error = nil;
         NSManagedObject *safeParent = [parent sync_copyInContext:backgroundContext
                                                            error:&error];
-        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"parentUnit = %@", [parent.entity.name lowercaseString], safeParent];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@", [parent.entity.name lowercaseString], safeParent];
 
         [self changes:changes
         inEntityNamed:entityName
@@ -76,6 +76,8 @@
 
     NSString *remoteKey = [entity sync_remoteKey];
     NSParameterAssert(remoteKey);
+
+#warning If the entity has a parent entity in Core Data but that parent hasn't been sent here, the app should do create an predicate stating that `parentName = nil`
 
     [DATAFilter changes:changes
           inEntityNamed:entityName

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -80,8 +80,6 @@
 
     BOOL shouldLookForParent = (!parent && !predicate);
     if (shouldLookForParent) {
-        NSEntityDescription *entity = [NSEntityDescription entityForName:entityName
-                                                   inManagedObjectContext:context];
         NSRelationshipDescription *parentEntity = [entity sync_parentEntity];
         if (parentEntity) {
             predicate = [NSPredicate predicateWithFormat:@"%K = nil", parentEntity.name];

--- a/Source/Sync.m
+++ b/Source/Sync.m
@@ -49,7 +49,7 @@
         NSError *error = nil;
         NSManagedObject *safeParent = [parent sync_copyInContext:backgroundContext
                                                            error:&error];
-        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"%K = %@", [parent.entity.name lowercaseString], safeParent];
+        NSPredicate *predicate = [NSPredicate predicateWithFormat:@"parentUnit = %@", [parent.entity.name lowercaseString], safeParent];
 
         [self changes:changes
         inEntityNamed:entityName

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		44B072D61AEA366B00ACD275 /* Social.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 44B072D01AEA366B00ACD275 /* Social.xcdatamodeld */; };
 		44B072D81AEA36A700ACD275 /* bug-number-84.json in Resources */ = {isa = PBXBuildFile; fileRef = 44B072D71AEA36A700ACD275 /* bug-number-84.json */; };
 		44B072DB1AEA36D300ACD275 /* Bug84.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 44B072D91AEA36D300ACD275 /* Bug84.xcdatamodeld */; };
+		44C57B7E1AFCB92300D77AB2 /* NSEntityDescription+Sync.m in Sources */ = {isa = PBXBuildFile; fileRef = 44C57B7D1AFCB92300D77AB2 /* NSEntityDescription+Sync.m */; };
 		4CEE32AFE3080F314149A6A4 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEFB3E45BB7A8C5238E2880 /* libPods.a */; };
 		B5A4E17C1AFB692C00A250F2 /* Organizations.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B5A4E17A1AFB692C00A250F2 /* Organizations.xcdatamodeld */; };
 		B5A4E17E1AFB693E00A250F2 /* organizations-tree.json in Resources */ = {isa = PBXBuildFile; fileRef = B5A4E17D1AFB693E00A250F2 /* organizations-tree.json */; };
@@ -75,6 +76,8 @@
 		44B072D11AEA366B00ACD275 /* Demo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Demo.xcdatamodel; sourceTree = "<group>"; };
 		44B072D71AEA36A700ACD275 /* bug-number-84.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "bug-number-84.json"; sourceTree = "<group>"; };
 		44B072DA1AEA36D300ACD275 /* Demo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Demo.xcdatamodel; sourceTree = "<group>"; };
+		44C57B7C1AFCB92300D77AB2 /* NSEntityDescription+Sync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSEntityDescription+Sync.h"; sourceTree = "<group>"; };
+		44C57B7D1AFCB92300D77AB2 /* NSEntityDescription+Sync.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSEntityDescription+Sync.m"; sourceTree = "<group>"; };
 		7C067778DC962B70CDF74EA5 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		91F302F02821DE7BE3BF6336 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		B5A4E17B1AFB692C00A250F2 /* Organizations.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Organizations.xcdatamodel; sourceTree = "<group>"; };
@@ -151,6 +154,8 @@
 				14B39D8D1A9BCCB300D3D01B /* Sync.m */,
 				14ADDF3F1AE434A100C389AD /* NSManagedObject+Sync.h */,
 				14ADDF401AE434A100C389AD /* NSManagedObject+Sync.m */,
+				44C57B7C1AFCB92300D77AB2 /* NSEntityDescription+Sync.h */,
+				44C57B7D1AFCB92300D77AB2 /* NSEntityDescription+Sync.m */,
 			);
 			name = Source;
 			path = ../Source;
@@ -336,6 +341,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				44B072D21AEA366B00ACD275 /* Contacts.xcdatamodeld in Sources */,
+				44C57B7E1AFCB92300D77AB2 /* NSEntityDescription+Sync.m in Sources */,
 				44B072D41AEA366B00ACD275 /* Notes.xcdatamodeld in Sources */,
 				14B39D8E1A9BCCB300D3D01B /* Sync.m in Sources */,
 				44B072DB1AEA36D300ACD275 /* Bug84.xcdatamodeld in Sources */,

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		44B072D81AEA36A700ACD275 /* bug-number-84.json in Resources */ = {isa = PBXBuildFile; fileRef = 44B072D71AEA36A700ACD275 /* bug-number-84.json */; };
 		44B072DB1AEA36D300ACD275 /* Bug84.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 44B072D91AEA36D300ACD275 /* Bug84.xcdatamodeld */; };
 		4CEE32AFE3080F314149A6A4 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = DCEFB3E45BB7A8C5238E2880 /* libPods.a */; };
+		B5A4E17C1AFB692C00A250F2 /* Organizations.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = B5A4E17A1AFB692C00A250F2 /* Organizations.xcdatamodeld */; };
+		B5A4E17E1AFB693E00A250F2 /* organizations-tree.json in Resources */ = {isa = PBXBuildFile; fileRef = B5A4E17D1AFB693E00A250F2 /* organizations-tree.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -75,6 +77,8 @@
 		44B072DA1AEA36D300ACD275 /* Demo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Demo.xcdatamodel; sourceTree = "<group>"; };
 		7C067778DC962B70CDF74EA5 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		91F302F02821DE7BE3BF6336 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		B5A4E17B1AFB692C00A250F2 /* Organizations.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Organizations.xcdatamodel; sourceTree = "<group>"; };
+		B5A4E17D1AFB693E00A250F2 /* organizations-tree.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "organizations-tree.json"; sourceTree = "<group>"; };
 		DCEFB3E45BB7A8C5238E2880 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -183,6 +187,7 @@
 				44B072B41AEA364D00ACD275 /* users_c.json */,
 				44B072B51AEA364D00ACD275 /* users_company.json */,
 				44B072B61AEA364D00ACD275 /* users_notes.json */,
+				B5A4E17D1AFB693E00A250F2 /* organizations-tree.json */,
 			);
 			path = JSONs;
 			sourceTree = "<group>";
@@ -196,6 +201,7 @@
 				44B072CC1AEA366B00ACD275 /* Notes.xcdatamodeld */,
 				44B072CE1AEA366B00ACD275 /* Recursive.xcdatamodeld */,
 				44B072D01AEA366B00ACD275 /* Social.xcdatamodeld */,
+				B5A4E17A1AFB692C00A250F2 /* Organizations.xcdatamodeld */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -282,6 +288,7 @@
 				44B072C11AEA364D00ACD275 /* tagged_notes.json in Resources */,
 				44B072C21AEA364D00ACD275 /* users_a.json in Resources */,
 				44B072B91AEA364D00ACD275 /* custom_relationship_key_to_many.json in Resources */,
+				B5A4E17E1AFB693E00A250F2 /* organizations-tree.json in Resources */,
 				44B072B81AEA364D00ACD275 /* comments-no-id.json in Resources */,
 				14C4183E1A019A1500636FD6 /* Sync.podspec in Resources */,
 				44B072D81AEA36A700ACD275 /* bug-number-84.json in Resources */,
@@ -336,6 +343,7 @@
 				14C4182E1A01919C00636FD6 /* Tests.m in Sources */,
 				44B072D51AEA366B00ACD275 /* Recursive.xcdatamodeld in Sources */,
 				44B072D61AEA366B00ACD275 /* Social.xcdatamodeld in Sources */,
+				B5A4E17C1AFB692C00A250F2 /* Organizations.xcdatamodeld in Sources */,
 				14ADDF411AE434A100C389AD /* NSManagedObject+Sync.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -544,6 +552,16 @@
 			);
 			currentVersion = 44B072DA1AEA36D300ACD275 /* Demo.xcdatamodel */;
 			path = Bug84.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		B5A4E17A1AFB692C00A250F2 /* Organizations.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				B5A4E17B1AFB692C00A250F2 /* Organizations.xcdatamodel */,
+			);
+			currentVersion = B5A4E17B1AFB692C00A250F2 /* Organizations.xcdatamodel */;
+			path = Organizations.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/Tests/Tests/JSONs/organizations-tree.json
+++ b/Tests/Tests/JSONs/organizations-tree.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id" : 1,
+    "name" : "Org 1",
+    "children" : [
+      {
+        "id" : 11,
+        "name" : "Org 11",
+        "children" : [
+          {
+            "id" : 111,
+            "name" : "Org 111",
+            "children" : [
+              {
+                "id" : 1106,
+                "name" : "Org 1106",
+              },
+              {
+                "id" : 1131,
+                "name" : "Org 1131",
+              }
+            ]
+          },
+          {
+            "id" : 112,
+            "name" : "Org 1213",
+            "children" : [
+              {
+                "id" : 1114,
+                "name" : "Org 12132",
+              },
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]
+          

--- a/Tests/Tests/JSONs/organizations-tree.json
+++ b/Tests/Tests/JSONs/organizations-tree.json
@@ -13,11 +13,11 @@
             "children" : [
               {
                 "id" : 1106,
-                "name" : "Org 1106",
+                "name" : "Org 1106"
               },
               {
                 "id" : 1131,
-                "name" : "Org 1131",
+                "name" : "Org 1131"
               }
             ]
           },
@@ -27,8 +27,8 @@
             "children" : [
               {
                 "id" : 1114,
-                "name" : "Org 12132",
-              },
+                "name" : "Org 12132"
+              }
             ]
           }
         ]

--- a/Tests/Tests/Models/Organizations.xcdatamodeld/Organizations.xcdatamodel/contents
+++ b/Tests/Tests/Models/Organizations.xcdatamodeld/Organizations.xcdatamodel/contents
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14D136" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14E11f" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
     <entity name="OrganizationUnit" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="remoteID" optional="YES" attributeType="Integer 64" syncable="YES"/>
-        <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrganizationUnit" inverseName="parentUnit" inverseEntity="OrganizationUnit" syncable="YES"/>
-        <relationship name="parentUnit" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrganizationUnit" inverseName="children" inverseEntity="OrganizationUnit" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="OrganizationUnit" inverseName="parentUnit" inverseEntity="OrganizationUnit" syncable="YES"/>
+        <relationship name="parentUnit" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="OrganizationUnit" inverseName="children" inverseEntity="OrganizationUnit" syncable="YES"/>
     </entity>
     <elements>
-        <element name="OrganizationUnit" positionX="-900" positionY="-306" width="128" height="103"/>
+        <element name="OrganizationUnit" positionX="-900" positionY="-306" width="128" height="105"/>
     </elements>
 </model>

--- a/Tests/Tests/Models/Organizations.xcdatamodeld/Organizations.xcdatamodel/contents
+++ b/Tests/Tests/Models/Organizations.xcdatamodeld/Organizations.xcdatamodel/contents
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14D136" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
+    <entity name="OrganizationUnit" representedClassName="" syncable="YES">
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="Integer 64" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrganizationUnit" inverseName="parentUnit" inverseEntity="OrganizationUnit" syncable="YES"/>
+        <relationship name="parentUnit" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="OrganizationUnit" inverseName="children" inverseEntity="OrganizationUnit" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="OrganizationUnit" positionX="-900" positionY="-306" width="128" height="103"/>
+    </elements>
+</model>

--- a/Tests/Tests/Models/Organizations.xcdatamodeld/Organizations.xcdatamodel/contents
+++ b/Tests/Tests/Models/Organizations.xcdatamodeld/Organizations.xcdatamodel/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14D136" minimumToolsVersion="Xcode 4.3" macOSVersion="Automatic" iOSVersion="Automatic">
-    <entity name="OrganizationUnit" representedClassName="" syncable="YES">
+    <entity name="OrganizationUnit" syncable="YES">
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="remoteID" optional="YES" attributeType="Integer 64" syncable="YES"/>
         <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="OrganizationUnit" inverseName="parentUnit" inverseEntity="OrganizationUnit" syncable="YES"/>

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -556,5 +556,14 @@
        }];
 }
 
+- (void)testOrganziaiton {
+
+    NSArray *json = [self objectsFromJSON:@"organizations-tree.json"];
+    DATAStack *dataStack = [self dataStackWithModelName:@"Organizations"];
+
+    [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
+   // [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
+
+}
 
 @end

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -562,7 +562,7 @@
     NSArray *json = [self objectsFromJSON:@"organizations-tree.json"];
     DATAStack *dataStack = [self dataStackWithModelName:@"Organizations"];
 
-    [Sync changes:json inEntityNamed:@"OrganizationUnit" parent:nil dataStack:dataStack completion:^(NSError *firstError) {
+    [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:^(NSError *firstError) {
         NSError *fetchError = nil;
         NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"OrganizationUnit"];
         NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];
@@ -570,7 +570,7 @@
         XCTAssertEqual(organizationsCount, 7);
     }];
 
-    [Sync changes:json inEntityNamed:@"OrganizationUnit" parent:nil dataStack:dataStack completion:^(NSError *secondError) {
+    [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:^(NSError *secondError) {
         NSError *fetchError = nil;
         NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"OrganizationUnit"];
         NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -562,6 +562,7 @@
 
     [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
     [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
+    //calling sync twice for recursive entities fails
 
 }
 

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -562,9 +562,19 @@
     NSArray *json = [self objectsFromJSON:@"organizations-tree.json"];
     DATAStack *dataStack = [self dataStackWithModelName:@"Organizations"];
 
-    [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:^(NSError *firstError) {
-        [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:^(NSError *secondError) {
+    [Sync changes:json inEntityNamed:@"OrganizationUnit" parent:nil dataStack:dataStack completion:^(NSError *firstError) {
+        NSError *fetchError = nil;
+        NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"OrganizationUnit"];
+        NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];
+        if (fetchError) NSLog(@"fetchError: %@", fetchError);
+        XCTAssertEqual(organizationsCount, 7);
 
+        [Sync changes:json inEntityNamed:@"OrganizationUnit" parent:nil dataStack:dataStack completion:^(NSError *secondError) {
+            NSError *fetchError = nil;
+            NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"OrganizationUnit"];
+            NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];
+            if (fetchError) NSLog(@"fetchError: %@", fetchError);
+            XCTAssertEqual(organizationsCount, 7);
         }];
     }];
 }

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -568,14 +568,14 @@
         NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];
         if (fetchError) NSLog(@"fetchError: %@", fetchError);
         XCTAssertEqual(organizationsCount, 7);
+    }];
 
-        [Sync changes:json inEntityNamed:@"OrganizationUnit" parent:nil dataStack:dataStack completion:^(NSError *secondError) {
-            NSError *fetchError = nil;
-            NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"OrganizationUnit"];
-            NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];
-            if (fetchError) NSLog(@"fetchError: %@", fetchError);
-            XCTAssertEqual(organizationsCount, 7);
-        }];
+    [Sync changes:json inEntityNamed:@"OrganizationUnit" parent:nil dataStack:dataStack completion:^(NSError *secondError) {
+        NSError *fetchError = nil;
+        NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"OrganizationUnit"];
+        NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];
+        if (fetchError) NSLog(@"fetchError: %@", fetchError);
+        XCTAssertEqual(organizationsCount, 7);
     }];
 }
 

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -555,15 +555,18 @@
        }];
 }
 
-- (void)testOrganziaiton {
+#pragma mark Organization
+
+- (void)testOrganization {
 
     NSArray *json = [self objectsFromJSON:@"organizations-tree.json"];
     DATAStack *dataStack = [self dataStackWithModelName:@"Organizations"];
 
-    [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
-    [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
-    //calling sync twice for recursive entities fails
+    [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:^(NSError *firstError) {
+        [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:^(NSError *secondError) {
 
+        }];
+    }];
 }
 
 @end

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -561,7 +561,7 @@
     DATAStack *dataStack = [self dataStackWithModelName:@"Organizations"];
 
     [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
-   // [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
+    [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:nil];
 
 }
 

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -450,9 +450,8 @@
     inEntityNamed:@"Story"
         dataStack:dataStack
        completion:^(NSError *error) {
-           NSError *storyError = nil;
-           NSFetchRequest *storyRequest = [[NSFetchRequest alloc] initWithEntityName:@"Story"];
-           NSArray *array = [dataStack.mainContext executeFetchRequest:storyRequest error:&storyError];
+           NSArray *array = [self fetchEntity:@"Story"
+                                    inContext:dataStack.mainContext];
            NSManagedObject *story = [array firstObject];
            XCTAssertNotNil([story valueForKey:@"summarize"]);
        }];
@@ -502,7 +501,8 @@
     inEntityNamed:@"MSStaff"
         dataStack:dataStack
        completion:^(NSError *error) {
-           NSInteger numberOfStaff = [self countForEntity:@"MSStaff" inContext:dataStack.mainContext];
+           NSInteger numberOfStaff = [self countForEntity:@"MSStaff"
+                                                inContext:dataStack.mainContext];
            XCTAssertEqual(numberOfStaff, 1);
 
 
@@ -513,7 +513,8 @@
            XCTAssertEqualObjects([oneStaff valueForKey:@"image"], @"a.jpg");
            XCTAssertEqual([[[oneStaff valueForKey:@"fulfillers"] allObjects] count], 2);
 
-           NSInteger numberOffulfillers = [self countForEntity:@"MSFulfiller" inContext:dataStack.mainContext];
+           NSInteger numberOffulfillers = [self countForEntity:@"MSFulfiller"
+                                                     inContext:dataStack.mainContext];
            XCTAssertEqual(numberOffulfillers, 2);
 
            NSArray *fulfillers = [self fetchEntity:@"MSFulfiller"
@@ -533,18 +534,14 @@
     DATAStack *dataStack = [self dataStackWithModelName:@"Organizations"];
 
     [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:^(NSError *firstError) {
-        NSError *fetchError = nil;
-        NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"OrganizationUnit"];
-        NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];
-        if (fetchError) NSLog(@"fetchError: %@", fetchError);
+        NSInteger organizationsCount = [self countForEntity:@"OrganizationUnit"
+                                                  inContext:dataStack.mainContext];
         XCTAssertEqual(organizationsCount, 7);
     }];
 
     [Sync changes:json inEntityNamed:@"OrganizationUnit" dataStack:dataStack completion:^(NSError *secondError) {
-        NSError *fetchError = nil;
-        NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"OrganizationUnit"];
-        NSInteger organizationsCount = [dataStack.mainContext countForFetchRequest:request error:&fetchError];
-        if (fetchError) NSLog(@"fetchError: %@", fetchError);
+        NSInteger organizationsCount = [self countForEntity:@"OrganizationUnit"
+                                                  inContext:dataStack.mainContext];
         XCTAssertEqual(organizationsCount, 7);
     }];
 }


### PR DESCRIPTION
The root organization has a `parentUnit = nil` that isn't taken into account when filtering the changes
Sync should check if the entity been synced has a parent entity and add it to the predicate:
Predicate: `parentUnit = nil` for root objects 
otherwise it will fetch all organizations, even the ones with parents
I pushed a silly fix