### PR TITLE
Modernize implementation.

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -207,9 +207,9 @@
 				7022AAD62B9688833050CCBB /* Pods */,
 				515545DD1958EE5C50CA007A /* Frameworks */,
 			);
-			indentWidth = 4;
+			indentWidth = 2;
 			sourceTree = "<group>";
-			tabWidth = 4;
+			tabWidth = 2;
 		};
 		146D72941AB782920058798C /* Products */ = {
 			isa = PBXGroup;

--- a/Demo.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Source/NSArray+Sync.swift
+++ b/Source/NSArray+Sync.swift
@@ -3,39 +3,38 @@ import DATAStack
 import NSManagedObject_HYPPropertyMapper
 
 public extension NSArray {
-    /**
-     Filters the items using the provided predicate, useful to exclude JSON objects from a JSON array by using a predicate.
-     - parameter entityName: The name of the entity to be synced.
-     - parameter predicate: The predicate used to filter out changes, if you want to exclude some items, you just need to provide this predicate.
-     - parameter parent: The parent of the entity, optional since many entities are orphans.
-     - parameter dataStack: The DATAStack instance.
-     */
-    func preprocessForEntityNamed(entityName: String, predicate: NSPredicate, parent: NSManagedObject?, dataStack: DATAStack) -> [[String : AnyObject]] {
-        var filteredChanges = [[String : AnyObject]]()
-        if predicate.isKindOfClass(NSComparisonPredicate.self), let castedPredicate = predicate as? NSComparisonPredicate, selfArray = self as? [[String : AnyObject]] {
-            let rightExpression = castedPredicate.rightExpression
-            let rightValue = rightExpression.constantValue
-            let rightValueCanBeCompared = rightValue.isKindOfClass(NSDate.self) || rightValue.isKindOfClass(NSNumber.self) || rightValue.isKindOfClass(NSString.self)
-            if (rightValueCanBeCompared) {
-                var objectChanges = [NSManagedObject]()
-                let context = dataStack.newDisposableMainContext()
-                if let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) {
-                    for change in selfArray {
-                        let object = NSManagedObject(entity: entity, insertIntoManagedObjectContext: context)
-                        object.sync_fillWithDictionary(change, parent: parent, dataStack: dataStack)
-                        objectChanges.append(object)
-                    }
+  /**
+   Filters the items using the provided predicate, useful to exclude JSON objects from a JSON array by using a predicate.
+   - parameter entityName: The name of the entity to be synced.
+   - parameter predicate: The predicate used to filter out changes, if you want to exclude some items, you just need to provide this predicate.
+   - parameter parent: The parent of the entity, optional since many entities are orphans.
+   - parameter dataStack: The DATAStack instance.
+   */
+  func preprocessForEntityNamed(entityName: String, predicate: NSPredicate, parent: NSManagedObject?, dataStack: DATAStack) -> [[String : AnyObject]] {
+    var filteredChanges = [[String : AnyObject]]()
+    let validClasses = [NSDate.classForCoder(), NSNumber.classForCoder(), NSString.classForCoder()]
 
-                    let filteredArray = (objectChanges as NSArray).filteredArrayUsingPredicate(predicate)
-                    for filteredObject in filteredArray as! [NSManagedObject] {
-                        if let change = filteredObject.hyp_dictionaryUsingRelationshipType(.Array) as? [String : AnyObject] {
-                            filteredChanges.append(change)
-                        }
-                    }
-                }
+    if let predicate = predicate as? NSComparisonPredicate, selfArray = self as? [[String : AnyObject]]
+      where validClasses.contains({ $0 == predicate.rightExpression.classForCoder }) {
+        var objectChanges = [NSManagedObject]()
+        let context = dataStack.newDisposableMainContext()
+
+        if let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) {
+          selfArray.forEach {
+            let object = NSManagedObject(entity: entity, insertIntoManagedObjectContext: context)
+            object.sync_fillWithDictionary($0, parent: parent, dataStack: dataStack)
+            objectChanges.append(object)
+          }
+
+          let filteredArray = (objectChanges as NSArray).filteredArrayUsingPredicate(predicate)
+          for filteredObject in filteredArray as! [NSManagedObject] {
+            if let change = filteredObject.hyp_dictionaryUsingRelationshipType(.Array) as? [String : AnyObject] {
+              filteredChanges.append(change)
             }
+          }
         }
-
-        return filteredChanges
     }
+
+    return filteredChanges
+  }
 }

--- a/Source/NSEntityDescription+Sync.swift
+++ b/Source/NSEntityDescription+Sync.swift
@@ -14,20 +14,16 @@ extension NSEntityDescription {
       }
     }
 
-    /**
-     Finds the parent for the current entity, if there are many parents nil will be returned.
-     - returns The parent relationship for the current entity
-     */
-    func sync_parentEntity() -> NSRelationshipDescription? {
-        let relationships = self.sync_relationships()
-        var foundParentEntity: NSRelationshipDescription? = nil
-        for relationship in relationships {
-            let isParent = relationship.destinationEntity?.name == self.name && !relationship.toMany
-            if isParent {
-                foundParentEntity = relationship
-            }
-        }
+    return relationships
+  }
 
-        return foundParentEntity
-    }
+  /**
+   Finds the parent for the current entity, if there are many parents nil will be returned.
+   - returns The parent relationship for the current entity
+   */
+  func sync_parentEntity() -> NSRelationshipDescription? {
+    return sync_relationships()
+      .filter { $0.destinationEntity?.name == name && !$0.toMany }
+      .first
+  }
 }

--- a/Source/NSEntityDescription+Sync.swift
+++ b/Source/NSEntityDescription+Sync.swift
@@ -1,19 +1,17 @@
 import CoreData
 
 extension NSEntityDescription {
-    /**
-     Finds the relationships for the current entity.
-     - returns The list of relationships for the current entity.
-     */
-    func sync_relationships() -> [NSRelationshipDescription] {
-        var relationships = [NSRelationshipDescription]()
-        for propertyDescription in self.properties {
-            if propertyDescription.isKindOfClass(NSRelationshipDescription.self), let relationshipDescription = propertyDescription as? NSRelationshipDescription {
-                relationships.append(relationshipDescription)
-            }
-        }
+  /**
+   Finds the relationships for the current entity.
+   - returns The list of relationships for the current entity.
+   */
+  func sync_relationships() -> [NSRelationshipDescription] {
+    var relationships = [NSRelationshipDescription]()
 
-        return relationships
+    properties.forEach { propertyDescription in
+      if let relationshipDescription = propertyDescription as? NSRelationshipDescription {
+        relationships.append(relationshipDescription)
+      }
     }
 
     /**

--- a/Source/NSManagedObject+Sync.swift
+++ b/Source/NSManagedObject+Sync.swift
@@ -94,23 +94,24 @@ public extension NSManagedObject {
     }
   }
 
-    /**
-     Syncs relationships where only the id is present, for example if your model is: Company -> Employee,
-     and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
-     entire company object inside the employees dictionary.
-     - parameter relationship: The relationship to be synced.
-     - parameter remoteID: The remoteID of the relationship to be synced.
-     - parameter dataStack: The DATAStack instance.
-     */
-    func sync_relationshipUsingIDInsteadOfDictionary(relationship: NSRelationshipDescription, remoteID: AnyObject, dataStack: DATAStack) {
-        let entityName = relationship.destinationEntity!.name!
-        guard let object = self.managedObjectContext!.sync_safeObject(entityName, remoteID: remoteID, parent: self, parentRelationshipName: relationship.name) else { abort() }
-        
-        let currentRelationship = self.valueForKey(relationship.name)
-        if currentRelationship == nil || !currentRelationship!.isEqual(object) {
-            self.setValue(object, forKey: relationship.name)
-        }
+  /**
+   Syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+   and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+   entire company object inside the employees dictionary.
+   - parameter relationship: The relationship to be synced.
+   - parameter remoteID: The remoteID of the relationship to be synced.
+   - parameter dataStack: The DATAStack instance.
+   */
+  func sync_relationshipUsingIDInsteadOfDictionary(relationship: NSRelationshipDescription, remoteID: AnyObject, dataStack: DATAStack) {
+    guard let entityName = relationship.destinationEntity!.name,
+      object = managedObjectContext!.sync_safeObject(entityName, remoteID: remoteID, parent: self, parentRelationshipName: relationship.name)
+      else { abort() }
+
+    let currentRelationship = valueForKey(relationship.name)
+    if currentRelationship == nil || !currentRelationship!.isEqual(object) {
+      setValue(object, forKey: relationship.name)
     }
+  }
 
     /**
      Syncs the entity's to-one relationship, it will also sync the child of this entity.

--- a/Source/NSManagedObject+Sync.swift
+++ b/Source/NSManagedObject+Sync.swift
@@ -4,22 +4,10 @@ import DATAStack
 import NSString_HYPNetworking
 
 public extension NSManagedObject {
-    /**
-     Using objectID to fetch an NSManagedObject from a NSManagedContext is quite unsafe,
-     and has unexpected behaviour most of the time, although it has gotten better throught
-     the years, it's a simple method with not many moving parts.
-     
-     Copy in context gives you a similar behaviour, just a bit safer.
-     - parameter context: The context where the NSManagedObject will be taken
-     - returns: A NSManagedObject copied in the provided context.
-     */
-    func sync_copyInContext(context: NSManagedObjectContext) -> NSManagedObject {
-        let entity = NSEntityDescription.entityForName(self.entity.name!, inManagedObjectContext: context)!
-        let localKey = entity.sync_localKey()
-        let remoteID = self.valueForKey(localKey)
-
-        return context.sync_safeObject(self.entity.name!, remoteID: remoteID, parent: nil, parentRelationshipName: nil)!
-    }
+  /**
+   Using objectID to fetch an NSManagedObject from a NSManagedContext is quite unsafe,
+   and has unexpected behaviour most of the time, although it has gotten better throught
+   the years, it's a simple method with not many moving parts.
 
     /**
      Syncs the entity using the received dictionary, maps one-to-many, many-to-many and one-to-one relationships.
@@ -50,6 +38,16 @@ public extension NSManagedObject {
                 self.sync_toOneRelationship(relationship, dictionary: dictionary, dataStack: dataStack)
             }
         }
+   Copy in context gives you a similar behaviour, just a bit safer.
+   - parameter context: The context where the NSManagedObject will be taken
+   - returns: A NSManagedObject copied in the provided context.
+   */
+  func sync_copyInContext(context: NSManagedObjectContext) -> NSManagedObject {
+    guard let entityName = entity.name, entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context)
+      else { abort() }
+
+    return context.sync_safeObject(entityName, remoteID: valueForKey(entity.sync_localKey()), parent: nil, parentRelationshipName: nil)!
+  }
     }
 
     /**

--- a/Source/NSManagedObjectContext+Sync.swift
+++ b/Source/NSManagedObjectContext+Sync.swift
@@ -3,27 +3,26 @@ import NSEntityDescription_SYNCPrimaryKey
 import NSString_HYPNetworking
 
 public extension NSManagedObjectContext {
-    /**
-     Safely fetches a NSManagedObject in the current context. If no remoteID is provided then it will check for the parent entity and use that. Otherwise it will return nil.
-     - parameter entityName: The name of the Core Data entity.
-     - parameter remoteID: The primary key.
-     - parameter parent: The parent of the object.
-     - parameter parentRelationshipName: The name of the relationship with the parent.
-     - returns: A NSManagedObject contained in the provided context.
-     */
-    public func sync_safeObject(entityName: String, remoteID: AnyObject?, parent: NSManagedObject?, parentRelationshipName: String?) -> NSManagedObject? {
-        if let remoteID = remoteID {
-            let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: self)!
-            let request = NSFetchRequest(entityName: entityName)
-            let localKey = entity.sync_localKey()
-            request.predicate = NSPredicate(format: "%K = %@", localKey, (remoteID as! NSObject))
-            let objects = try! self.executeFetchRequest(request)
-            return objects.first as? NSManagedObject
-        } else if let parentRelationshipName = parentRelationshipName {
-            // More info: https://github.com/hyperoslo/Sync/pull/72
-            return parent?.valueForKey(parentRelationshipName) as? NSManagedObject
-        } else {
-            return nil
-        }
+  /**
+   Safely fetches a NSManagedObject in the current context. If no remoteID is provided then it will check for the parent entity and use that. Otherwise it will return nil.
+   - parameter entityName: The name of the Core Data entity.
+   - parameter remoteID: The primary key.
+   - parameter parent: The parent of the object.
+   - parameter parentRelationshipName: The name of the relationship with the parent.
+   - returns: A NSManagedObject contained in the provided context.
+   */
+  public func sync_safeObject(entityName: String, remoteID: AnyObject?, parent: NSManagedObject?, parentRelationshipName: String?) -> NSManagedObject? {
+    if let remoteID = remoteID as? NSObject, entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: self) {
+      let request = NSFetchRequest(entityName: entityName)
+      request.predicate = NSPredicate(format: "%K = %@", entity.sync_localKey(), remoteID)
+      let objects = try! executeFetchRequest(request)
+
+      return objects.first as? NSManagedObject
+    } else if let parentRelationshipName = parentRelationshipName {
+      // More info: https://github.com/hyperoslo/Sync/pull/72
+      return parent?.valueForKey(parentRelationshipName) as? NSManagedObject
+    } else {
+      return nil
     }
+  }
 }

--- a/Source/Sync.swift
+++ b/Source/Sync.swift
@@ -5,115 +5,119 @@ import NSManagedObject_HYPPropertyMapper
 import DATAStack
 
 @objc public class Sync: NSObject {
-    /**
-     Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
-     It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
-     and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
-     entire company object inside the employees dictionary.
-     - parameter changes: The array of dictionaries used in the sync process.
-     - parameter entityName: The name of the entity to be synced.
-     - parameter dataStack: The DATAStack instance.
-     - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
-     */
-    public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
-        self.changes(changes, inEntityNamed: entityName, predicate: nil, dataStack: dataStack, completion: completion)
+  /**
+   Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+   It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+   and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+   entire company object inside the employees dictionary.
+   - parameter changes: The array of dictionaries used in the sync process.
+   - parameter entityName: The name of the entity to be synced.
+   - parameter dataStack: The DATAStack instance.
+   - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
+   */
+  public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
+    self.changes(changes, inEntityNamed: entityName, predicate: nil, dataStack: dataStack, completion: completion)
+  }
+
+  /**
+   Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+   It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+   and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+   entire company object inside the employees dictionary.
+   - parameter changes: The array of dictionaries used in the sync process.
+   - parameter entityName: The name of the entity to be synced.
+   - parameter predicate: The predicate used to filter out changes, if you want to exclude some local items to be taken in
+   account in the Sync process, you just need to provide this predicate.
+   - parameter dataStack: The DATAStack instance.
+   - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
+   */
+  public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
+    dataStack.performInNewBackgroundContext { backgroundContext in
+      self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: nil, inContext: backgroundContext, dataStack: dataStack, completion: completion)
+    }
+  }
+
+  /**
+   Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+   It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+   and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+   entire company object inside the employees dictionary.
+   - parameter changes: The array of dictionaries used in the sync process.
+   - parameter entityName: The name of the entity to be synced.
+   - parameter parent: The parent of the synced items, useful if you are syncing the childs of an object, for example
+   an Album has many photos, if this photos don't incldue the album's JSON object, syncing the photos JSON requires
+   you to send the parent album to do the proper mapping.
+   - parameter dataStack: The DATAStack instance.
+   - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
+   */
+  public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, parent: NSManagedObject, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
+    dataStack.performInNewBackgroundContext { backgroundContext in
+      let safeParent = parent.sync_copyInContext(backgroundContext)
+      let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: backgroundContext)!
+      let relationships = entity.relationshipsWithDestinationEntity(parent.entity)
+      var predicate: NSPredicate? = nil
+
+      if let firstRelationship = relationships.first {
+        predicate = NSPredicate(format: "%K = %@", firstRelationship.name, safeParent)
+      }
+
+      self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: safeParent, inContext: backgroundContext, dataStack: dataStack, completion: completion)
+    }
+  }
+
+  /**
+   Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+   It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+   and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+   entire company object inside the employees dictionary.
+   - parameter changes: The array of dictionaries used in the sync process.
+   - parameter entityName: The name of the entity to be synced.
+   - parameter predicate: The predicate used to filter out changes, if you want to exclude some local items to be taken in
+   account in the Sync process, you just need to provide this predicate.
+   - parameter parent: The parent of the synced items, useful if you are syncing the childs of an object, for example
+   an Album has many photos, if this photos don't incldue the album's JSON object, syncing the photos JSON requires
+   - parameter context: The context where the items will be created, in general this should be a background context.
+   - parameter dataStack: The DATAStack instance.
+   - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
+   */
+  public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, var predicate: NSPredicate?, parent: NSManagedObject?, inContext context: NSManagedObjectContext, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
+    guard let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) else { abort() }
+
+    let localKey = entity.sync_localKey()
+    let remoteKey = entity.sync_remoteKey()
+    let shouldLookForParent = parent == nil && predicate == nil
+
+    if let parentEntity = entity.sync_parentEntity() where shouldLookForParent {
+      predicate = NSPredicate(format: "%K = nil", parentEntity.name)
     }
 
-    /**
-     Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
-     It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
-     and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
-     entire company object inside the employees dictionary.
-     - parameter changes: The array of dictionaries used in the sync process.
-     - parameter entityName: The name of the entity to be synced.
-     - parameter predicate: The predicate used to filter out changes, if you want to exclude some local items to be taken in
-     account in the Sync process, you just need to provide this predicate.
-     - parameter dataStack: The DATAStack instance.
-     - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
-     */
-    public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
-        dataStack.performInNewBackgroundContext { backgroundContext in
-            self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: nil, inContext: backgroundContext, dataStack: dataStack, completion: completion)
-        }
+    if localKey.isEmpty {
+      fatalError("Local primary key not found for entity: \(entityName), add a primary key named remoteID or mark an existing attribute using hyper.isPrimaryKey")
     }
 
-    /**
-     Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
-     It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
-     and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
-     entire company object inside the employees dictionary.
-     - parameter changes: The array of dictionaries used in the sync process.
-     - parameter entityName: The name of the entity to be synced.
-     - parameter parent: The parent of the synced items, useful if you are syncing the childs of an object, for example
-     an Album has many photos, if this photos don't incldue the album's JSON object, syncing the photos JSON requires 
-     you to send the parent album to do the proper mapping.
-     - parameter dataStack: The DATAStack instance.
-     - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
-     */
-    public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, parent: NSManagedObject, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
-        dataStack.performInNewBackgroundContext { backgroundContext in
-            let safeParent = parent.sync_copyInContext(backgroundContext)
-            let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: backgroundContext)!
-            let relationships = entity.relationshipsWithDestinationEntity(parent.entity)
-            var predicate: NSPredicate? = nil
-            if let firstRelationship = relationships.first {
-                predicate = NSPredicate(format: "%K = %@", firstRelationship.name, safeParent)
-            }
-            self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: safeParent, inContext: backgroundContext, dataStack: dataStack, completion: completion)
-        }
+    if remoteKey.isEmpty {
+      fatalError("Remote primary key not found for entity: \(entityName), we were looking for id, if your remote ID has a different name consider using hyper.remoteKey to map to the right value")
     }
 
-    /**
-     Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
-     It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
-     and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
-     entire company object inside the employees dictionary.
-     - parameter changes: The array of dictionaries used in the sync process.
-     - parameter entityName: The name of the entity to be synced.
-     - parameter predicate: The predicate used to filter out changes, if you want to exclude some local items to be taken in
-     account in the Sync process, you just need to provide this predicate.
-     - parameter parent: The parent of the synced items, useful if you are syncing the childs of an object, for example
-     an Album has many photos, if this photos don't incldue the album's JSON object, syncing the photos JSON requires
-     - parameter context: The context where the items will be created, in general this should be a background context.
-     - parameter dataStack: The DATAStack instance.
-     - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
-     */
-    public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, var predicate: NSPredicate?, parent: NSManagedObject?, inContext context: NSManagedObjectContext, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
-        let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context)!
-        let localKey = entity.sync_localKey()
-        let remoteKey = entity.sync_remoteKey()
-        let shouldLookForParent = (parent == nil && predicate == nil)
-        if shouldLookForParent {
-            if let parentEntity = entity.sync_parentEntity() {
-                predicate = NSPredicate(format: "%K = nil", parentEntity.name)
-            }
-        }
+    DATAFilter.changes(changes as [AnyObject], inEntityNamed: entityName, predicate: predicate, operations: [.All], localKey: localKey, remoteKey: remoteKey, context: context, inserted: { objectJSON in
+      guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
 
-        if localKey.characters.count == 0 {
-            fatalError("Local primary key not found for entity: \(entityName), add a primary key named remoteID or mark an existing attribute using hyper.isPrimaryKey")
-        }
-
-        if remoteKey.characters.count == 0 {
-            fatalError("Remote primary key not found for entity: \(entityName), we were looking for id, if your remote ID has a different name consider using hyper.remoteKey to map to the right value")
-        }
-
-        DATAFilter.changes(changes as [AnyObject], inEntityNamed: entityName, predicate: predicate, operations: [.All], localKey: localKey, remoteKey: remoteKey, context: context, inserted: { objectJSON in
-            guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
-            let created = NSEntityDescription.insertNewObjectForEntityForName(entityName, inManagedObjectContext: context)
-            created.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack)
-            }) { objectJSON, updatedObject in
-                guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
-                updatedObject.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack)
-        }
-
-        var syncError: NSError?
-        do {
-            try context.save()
-        } catch let error as NSError {
-            syncError = error
-        }
-        dataStack.persistWithCompletion {
-            completion?(error: syncError)
-        }
+      let created = NSEntityDescription.insertNewObjectForEntityForName(entityName, inManagedObjectContext: context)
+      created.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack)
+      }) { objectJSON, updatedObject in
+        guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
+        updatedObject.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack)
     }
+
+    var syncError: NSError?
+    do {
+      try context.save()
+    } catch let error as NSError {
+      syncError = error
+    }
+
+    dataStack.persistWithCompletion {
+      completion?(error: syncError)
+    }
+  }
 }


### PR DESCRIPTION
I was bored and couldn't sleep so this happened. I thought that `Sync` could use a bit of Swift lovin.

I saw that we had a nack for force unwrapping optional values and that the implementation did not conform to our guidelines. This PR is an attempt to correct those faulty thingies.

As an added bonus; code coverage is now enabled in the Xcode project :rocket: 

## Changes

#### NSEntityDescription.sync_relationships() https://github.com/hyperoslo/Sync/pull/190/commits/6a65f7e549f82427090c702d647a6187e89013cb
- Use forEach instead of for-loop
- Remove redundant isKindClass check
- Fix indentation

#### NSEntityDescription.sync_parentEntity() https://github.com/hyperoslo/Sync/pull/190/commits/9f9991dfa9325135eeb555eefc8e56889f5df976
- [Use filter instead of for-loop with if statement](https://github.com/hyperoslo/Sync/blob/feature/modern-implementation/Source/NSEntityDescription%2BSync.swift#L25-L27)

#### NSArray.preprocessForEntityNamed https://github.com/hyperoslo/Sync/pull/190/commits/d4f04271ddb1c784ffe48fc13f899d9ea3daddfe
- Remove unnecessary object declaration
- Improve readability of valid class comparison
- Use forEach instead of for-loop
- Remove force unwrapping of objects when type casting
- Fix indentation

#### NSManagedObjectContext.sync_safeObject https://github.com/hyperoslo/Sync/pull/190/commits/71ef281a8dbaff152403db58d65f1b4c28a2cfe4
- Remove force unwrapping of objects and when type casting
- Fix indentation

#### NSManagedObject.sync_copyInContext https://github.com/hyperoslo/Sync/pull/190/commits/6a462e88b7853cf72d5e336db6cdde8b657b4a0c
- Add guard statement
- Remove force unwrapping
- Remove unnecessary variable declarations
- Fix indentation

#### NSManangedObject.sync_fillWithDictionary https://github.com/hyperoslo/Sync/pull/190/commits/eb806a83e244164c8522be87739005c2313b7b42
- Use forEach instead of for-loop
- Use Swift string append instead of `stringByAppendingString`
- Optionally unwrap values instead of checking for `nil`
- Fix indentation

#### NSManagedObject.sync_toManyRelationship https://github.com/hyperoslo/Sync/pull/190/commits/76688ec197c989bd7b25daf7f1137e25c1ee3579
- General cleanup to let the code breath
- Add guard statement
- Remove force unwrapping of objects

#### NSManagedObject.sync_relationshipUsingIDInsteadOfDictionary https://github.com/hyperoslo/Sync/pull/190/commits/26ad0c6d8816dbad85ce131dcb4325c8d5cd3c30
 - Remove force unwrapping on optionals
- Fix indentation

#### NSManagedObject.sync_toOneRelationship https://github.com/hyperoslo/Sync/pull/190/commits/8664cae667a81de05c91cda28b74b4a98eb308b7
- Remove force unwrapping of optional values
- Add guard statement
- Improve readability by decreasing the amount of nested if-statements

#### Sync.changes https://github.com/hyperoslo/Sync/pull/190/commits/c8baaa313a388b5ad79a64562a065bf16889e6a4
 - Fix indentation
- Remove force unwrapping