### PR TITLE
Add support to use id as primary key

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		1425D5A41CC65BEB00EC49D4 /* Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1425D59F1CC65BEB00EC49D4 /* Sync.swift */; };
 		1469B7F91C68D7820080FD71 /* NotesB.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1469B7F71C68D7820080FD71 /* NotesB.xcdatamodeld */; };
 		1469B7FB1C68D7D50080FD71 /* notes_with_user_id_custom.json in Resources */ = {isa = PBXBuildFile; fileRef = 1469B7FA1C68D7D50080FD71 /* notes_with_user_id_custom.json */; };
+		146F2EB31CE1F27200543F83 /* id.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 146F2EB11CE1F27200543F83 /* id.xcdatamodeld */; };
+		146F2EB51CE1F2C500543F83 /* id.json in Resources */ = {isa = PBXBuildFile; fileRef = 146F2EB41CE1F2C500543F83 /* id.json */; };
 		14959D141C065350004EF790 /* notes_with_user_id.json in Resources */ = {isa = PBXBuildFile; fileRef = 14959D131C065350004EF790 /* notes_with_user_id.json */; };
 		14A644111CD77A4C00F51E23 /* Bug202.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 14A6440F1CD77A4C00F51E23 /* Bug202.xcdatamodeld */; };
 		14A644151CD77C7A00F51E23 /* bug-202-a.json in Resources */ = {isa = PBXBuildFile; fileRef = 14A644121CD77C7A00F51E23 /* bug-202-a.json */; };
@@ -117,6 +119,8 @@
 		1469B7FA1C68D7D50080FD71 /* notes_with_user_id_custom.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = notes_with_user_id_custom.json; sourceTree = "<group>"; };
 		146D72AC1AB782920058798C /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		146D72B11AB782920058798C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		146F2EB21CE1F27200543F83 /* Demo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Demo.xcdatamodel; sourceTree = "<group>"; };
+		146F2EB41CE1F2C500543F83 /* id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = id.json; sourceTree = "<group>"; };
 		14959D131C065350004EF790 /* notes_with_user_id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = notes_with_user_id.json; sourceTree = "<group>"; };
 		14A644101CD77A4C00F51E23 /* Demo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Demo.xcdatamodel; sourceTree = "<group>"; };
 		14A644121CD77C7A00F51E23 /* bug-202-a.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "bug-202-a.json"; sourceTree = "<group>"; };
@@ -164,6 +168,7 @@
 		1418940A1BDD62F600EE52CE /* JSONs */ = {
 			isa = PBXGroup;
 			children = (
+				146F2EB41CE1F2C500543F83 /* id.json */,
 				1418940B1BDD62F600EE52CE /* bug-113-comments-no-id.json */,
 				1418940C1BDD62F600EE52CE /* bug-113-custom_relationship_key_to_one.json */,
 				1418940D1BDD62F600EE52CE /* bug-113-stories-comments-no-ids.json */,
@@ -203,6 +208,7 @@
 		141894241BDD62F600EE52CE /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				146F2EB11CE1F27200543F83 /* id.xcdatamodeld */,
 				1418942B1BDD62F600EE52CE /* Bug84.xcdatamodeld */,
 				141894251BDD62F600EE52CE /* Bug113.xcdatamodeld */,
 				141894291BDD62F600EE52CE /* Bug125.xcdatamodeld */,
@@ -390,6 +396,7 @@
 				141894401BDD62F600EE52CE /* bug-113-comments-no-id.json in Resources */,
 				141894431BDD62F600EE52CE /* bug-125-light.json in Resources */,
 				1418944A1BDD62F600EE52CE /* markets_items.json in Resources */,
+				146F2EB51CE1F2C500543F83 /* id.json in Resources */,
 				141894561BDD62F600EE52CE /* users_c.json in Resources */,
 				141894541BDD62F600EE52CE /* users_a.json in Resources */,
 				141894461BDD62F600EE52CE /* comments-no-id.json in Resources */,
@@ -466,6 +473,7 @@
 				140FBF1C1CB91A5D0026484E /* Camelcase.xcdatamodeld in Sources */,
 				1425D5A21CC65BEB00EC49D4 /* NSManagedObject+Sync.swift in Sources */,
 				14D943591C51844C00F90DC2 /* NSArray+SyncTests.swift in Sources */,
+				146F2EB31CE1F27200543F83 /* id.xcdatamodeld in Sources */,
 				14FDB4D11C511A5B0061D9FA /* SyncTests.swift in Sources */,
 				141894611BDD62F600EE52CE /* Patients.xcdatamodeld in Sources */,
 				1425D5A41CC65BEB00EC49D4 /* Sync.swift in Sources */,
@@ -754,6 +762,16 @@
 			);
 			currentVersion = 1469B7F81C68D7820080FD71 /* Demo.xcdatamodel */;
 			path = NotesB.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		146F2EB11CE1F27200543F83 /* id.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				146F2EB21CE1F27200543F83 /* Demo.xcdatamodel */,
+			);
+			currentVersion = 146F2EB21CE1F27200543F83 /* Demo.xcdatamodel */;
+			path = id.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,16 +6,16 @@ PODS:
   - DATAStack (5.0.0)
   - JSON (4.0.2)
   - NSDictionary-ANDYSafeValue (0.3.1)
-  - NSEntityDescription-SYNCPrimaryKey (0.1.2):
+  - NSEntityDescription-SYNCPrimaryKey (1.0.0):
     - NSString-HYPNetworking (~> 0.4.0)
   - NSManagedObject-HYPPropertyMapper (3.6.2):
     - NSString-HYPNetworking (~> 0.4.0)
   - NSString-HYPNetworking (0.4.0)
-  - Sync (1.6.7):
+  - Sync (1.6.8):
     - DATAFilter (~> 0.9.1)
     - DATAStack (~> 5.0.0)
     - NSDictionary-ANDYSafeValue (~> 0.3.1)
-    - NSEntityDescription-SYNCPrimaryKey (~> 0.1.2)
+    - NSEntityDescription-SYNCPrimaryKey (~> 1.0.0)
     - NSManagedObject-HYPPropertyMapper (~> 3.6.2)
 
 DEPENDENCIES:
@@ -34,9 +34,9 @@ SPEC CHECKSUMS:
   DATAStack: e0111e1db6044c8b355e68311e002cbec8963b28
   JSON: d08f22c3e523be050d5d5f40bca43ec02d95b2cc
   NSDictionary-ANDYSafeValue: 2d7adf339b6e302d71fec5f1d71ae00aacda993e
-  NSEntityDescription-SYNCPrimaryKey: 9a2b2f7b838913eb445f20cc2f2edca7281fcfa5
+  NSEntityDescription-SYNCPrimaryKey: 3c6c6a49964a6a2e11e42709bd92e2f02b19fe79
   NSManagedObject-HYPPropertyMapper: b47eb32a4e9b0feeab69bc42f98fc425aa6428f7
   NSString-HYPNetworking: 24c3828eebde8a37cc16101a475934a56ac820c0
-  Sync: 62327caa5c8eab7d0af9aa7e9bfbccb793ccf86d
+  Sync: 4a6ee4dd59fa8c6804f1e76d56886f137f1eb397
 
 COCOAPODS: 0.39.0

--- a/Sync.podspec
+++ b/Sync.podspec
@@ -27,6 +27,6 @@ s.frameworks = 'Foundation', 'CoreData'
 s.dependency 'DATAFilter', '~> 0.9.1'
 s.dependency 'DATAStack', '~> 5.0.0'
 s.dependency 'NSDictionary-ANDYSafeValue', '~> 0.3.1'
-s.dependency 'NSEntityDescription-SYNCPrimaryKey', '~> 0.1.2'
+s.dependency 'NSEntityDescription-SYNCPrimaryKey', '~> 1.0.0'
 s.dependency 'NSManagedObject-HYPPropertyMapper', '~> 3.6.2'
 end

--- a/Tests/JSONs/id.json
+++ b/Tests/JSONs/id.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "a",
+    "name": "Legen Dary"
+  },
+  {
+    "id": "b",
+    "name": "Wait Forit"
+  }
+]

--- a/Tests/Models/id.xcdatamodeld/.xccurrentversion
+++ b/Tests/Models/id.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>Demo.xcdatamodel</string>
+</dict>
+</plist>

--- a/Tests/Models/id.xcdatamodeld/Demo.xcdatamodel/contents
+++ b/Tests/Models/id.xcdatamodeld/Demo.xcdatamodel/contents
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15E65" minimumToolsVersion="Automatic">
+    <entity name="User" syncable="YES">
+        <attribute name="id" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="User" positionX="117" positionY="-7" width="128" height="75"/>
+    </elements>
+</model>

--- a/Tests/SyncTests.swift
+++ b/Tests/SyncTests.swift
@@ -611,4 +611,16 @@ class SyncTests: XCTestCase {
 
     try! dataStack.drop()
   }
+
+  // MARK: - Automatic use of id as remoteID
+
+  func testIDAsRemoteID() {
+    let dataStack = Helper.dataStackWithModelName("id")
+
+    let users = Helper.objectsFromJSON("id.json") as! [[String : AnyObject]]
+    Sync.changes(users, inEntityNamed: "User", dataStack: dataStack, completion: nil)
+    XCTAssertEqual(Helper.countForEntity("User", inContext:dataStack.mainContext), 2)
+
+    try! dataStack.drop()
+  }
 }


### PR DESCRIPTION
`id` wasn't considered in the first round because is a reserved word on Objective-C, in Swift it isn't. 💥 

I have kept the old `remoteID` for compatibility reasons, although I'll update everything to mention `id` as the preferred way.