### PR TITLE
Remove "performance" improvement

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - DATAObjectIDs (~> 0.5.1)
   - DATAObjectIDs (0.5.1)
   - DATASource (5.8.0)
-  - DATAStack (5.1.0)
+  - DATAStack (5.2.0)
   - JSON (4.0.2)
   - NSDictionary-ANDYSafeValue (0.3.1)
   - NSEntityDescription-SYNCPrimaryKey (1.1.0):
@@ -14,7 +14,7 @@ PODS:
   - NSString-HYPNetworking (0.4.0)
   - Sync (1.7.1):
     - DATAFilter (~> 0.10.0)
-    - DATAStack (~> 5.1.0)
+    - DATAStack (~> 5.2.0)
     - NSDictionary-ANDYSafeValue (~> 0.3.1)
     - NSEntityDescription-SYNCPrimaryKey (~> 1.1.0)
     - NSManagedObject-HYPPropertyMapper (~> 3.6.4)
@@ -32,13 +32,13 @@ SPEC CHECKSUMS:
   DATAFilter: b6662b05dd0dcf658d526aa0f9095bb202d7b10e
   DATAObjectIDs: 33db74dd1c858c2d22a45a4013c95f1082182e4e
   DATASource: d5ecdfa4be7d73d41f58746d3346e5238766c86d
-  DATAStack: 3cabc03a3870023f11640e987d05e079477a213a
+  DATAStack: 191884208ad864299d079c4350f78696ad4c9e6b
   JSON: d08f22c3e523be050d5d5f40bca43ec02d95b2cc
   NSDictionary-ANDYSafeValue: 2d7adf339b6e302d71fec5f1d71ae00aacda993e
   NSEntityDescription-SYNCPrimaryKey: 66f1b5393ee3b6c8b12700d4c86ba6e5ad2bcfe9
   NSManagedObject-HYPPropertyMapper: 01ea4945879774201011260f6e309b1ae347b6fb
   NSString-HYPNetworking: 24c3828eebde8a37cc16101a475934a56ac820c0
-  Sync: 76262e8819af2dd3d9c84a5494d5ab4f7eae67b7
+  Sync: 532219c01f48480fe5a3bbb5ded538182fad6fc3
 
 PODFILE CHECKSUM: a4ce83b9a5d0f8218c6d94acc4cfa26b0d4000d6
 

--- a/Source/NSManagedObject+Sync.swift
+++ b/Source/NSManagedObject+Sync.swift
@@ -78,7 +78,7 @@ public extension NSManagedObject {
         childPredicate = NSPredicate(format: "%K = %@", inverseEntityName, self)
       }
 
-      Sync.changes(children, inEntityNamed: childEntityName, predicate: childPredicate, parent: self, inContext: managedObjectContext, dataStack: dataStack, mergingWithMainContext: false, completion: nil)
+      Sync.changes(children, inEntityNamed: childEntityName, predicate: childPredicate, parent: self, inContext: managedObjectContext, dataStack: dataStack, completion: nil)
     } else if let parent = parent, entityName = parent.entity.name where inverseIsToMany && entityName == childEntityName {
       if relationship.ordered {
         let relatedObjects = mutableOrderedSetValueForKey(relationship.name)

--- a/Source/Sync.swift
+++ b/Source/Sync.swift
@@ -81,10 +81,6 @@ import DATAStack
    - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
    */
   public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, parent: NSManagedObject?, inContext context: NSManagedObjectContext, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
-    self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: parent, inContext: context, dataStack: dataStack, mergingWithMainContext: true, completion: completion)
-  }
-
-  class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, parent: NSManagedObject?, inContext context: NSManagedObjectContext, dataStack: DATAStack, mergingWithMainContext: Bool, completion: ((error: NSError?) -> Void)?) {
     guard let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) else { abort() }
 
     let localPrimaryKey = entity.sync_localPrimaryKey()
@@ -116,11 +112,7 @@ import DATAStack
 
     var syncError: NSError?
     do {
-      if mergingWithMainContext {
-        try context.save()
-      } else {
-        try dataStack.saveBackgroundContextWithoutMergingWithMainContext(context)
-      }
+      try context.save()
     } catch let error as NSError {
       syncError = error
     }

--- a/Sync.podspec
+++ b/Sync.podspec
@@ -29,7 +29,7 @@ s.source_files = 'Source/**/*'
 s.frameworks = 'Foundation', 'CoreData'
 
 s.dependency 'DATAFilter', '~> 0.10.0'
-s.dependency 'DATAStack', '~> 5.1.0'
+s.dependency 'DATAStack', '~> 5.2.0'
 s.dependency 'NSDictionary-ANDYSafeValue', '~> 0.3.1'
 s.dependency 'NSEntityDescription-SYNCPrimaryKey', '~> 1.1.0'
 s.dependency 'NSManagedObject-HYPPropertyMapper', '~> 3.6.4'


### PR DESCRIPTION
The previous change certainly improves things in a way since it will save less frequently and sends less notifications but it breaks when using NSFetchedResultsControllers since it doesn't merge all the notifications.