### PR TITLE
Add basic support for operation types

### DIFF
--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		1425D5A21CC65BEB00EC49D4 /* NSManagedObject+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1425D59D1CC65BEB00EC49D4 /* NSManagedObject+Sync.swift */; };
 		1425D5A31CC65BEB00EC49D4 /* NSManagedObjectContext+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1425D59E1CC65BEB00EC49D4 /* NSManagedObjectContext+Sync.swift */; };
 		1425D5A41CC65BEB00EC49D4 /* Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1425D59F1CC65BEB00EC49D4 /* Sync.swift */; };
+		1466B48D1CF4EDF1000B7CBD /* operation-types-users-a.json in Resources */ = {isa = PBXBuildFile; fileRef = 1466B48B1CF4EDF1000B7CBD /* operation-types-users-a.json */; };
+		1466B48E1CF4EDF1000B7CBD /* operation-types-users-b.json in Resources */ = {isa = PBXBuildFile; fileRef = 1466B48C1CF4EDF1000B7CBD /* operation-types-users-b.json */; };
 		1469B7F91C68D7820080FD71 /* NotesB.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 1469B7F71C68D7820080FD71 /* NotesB.xcdatamodeld */; };
 		1469B7FB1C68D7D50080FD71 /* notes_with_user_id_custom.json in Resources */ = {isa = PBXBuildFile; fileRef = 1469B7FA1C68D7D50080FD71 /* notes_with_user_id_custom.json */; };
 		146F2EB31CE1F27200543F83 /* id.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 146F2EB11CE1F27200543F83 /* id.xcdatamodeld */; };
@@ -142,6 +144,8 @@
 		1425D59D1CC65BEB00EC49D4 /* NSManagedObject+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Sync.swift"; sourceTree = "<group>"; tabWidth = 2; };
 		1425D59E1CC65BEB00EC49D4 /* NSManagedObjectContext+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Sync.swift"; sourceTree = "<group>"; tabWidth = 2; };
 		1425D59F1CC65BEB00EC49D4 /* Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Sync.swift; sourceTree = "<group>"; tabWidth = 2; };
+		1466B48B1CF4EDF1000B7CBD /* operation-types-users-a.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "operation-types-users-a.json"; sourceTree = "<group>"; };
+		1466B48C1CF4EDF1000B7CBD /* operation-types-users-b.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "operation-types-users-b.json"; sourceTree = "<group>"; };
 		1469B7F81C68D7820080FD71 /* Demo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Demo.xcdatamodel; sourceTree = "<group>"; };
 		1469B7FA1C68D7D50080FD71 /* notes_with_user_id_custom.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = notes_with_user_id_custom.json; sourceTree = "<group>"; };
 		146D72AC1AB782920058798C /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -203,14 +207,14 @@
 				14096A2F1CEAF329002690D6 /* 151-to-many-notes.json */,
 				14096A301CEAF329002690D6 /* 151-to-many-users-update.json */,
 				14096A311CEAF329002690D6 /* 151-to-many-users.json */,
+				14D7321E1CE9A6C400C28D40 /* 157-cities.json */,
+				140B0DEE1CEAFAFC00D0EE3E /* 157-locations-update.json */,
+				141D9E711CE9A4830041A7FC /* 157-locations.json */,
 				1418940B1BDD62F600EE52CE /* bug-113-comments-no-id.json */,
 				1418940C1BDD62F600EE52CE /* bug-113-custom_relationship_key_to_one.json */,
 				1418940D1BDD62F600EE52CE /* bug-113-stories-comments-no-ids.json */,
 				1418940E1BDD62F600EE52CE /* bug-125-light.json */,
 				1418940F1BDD62F600EE52CE /* bug-125.json */,
-				14D7321E1CE9A6C400C28D40 /* 157-cities.json */,
-				141D9E711CE9A4830041A7FC /* 157-locations.json */,
-				140B0DEE1CEAFAFC00D0EE3E /* 157-locations-update.json */,
 				B0B637151C6E517F00229B03 /* bug-179-places.json */,
 				B0B637161C6E517F00229B03 /* bug-179-routes.json */,
 				14A644121CD77C7A00F51E23 /* bug-202-a.json */,
@@ -228,6 +232,8 @@
 				14959D131C065350004EF790 /* notes_with_user_id.json */,
 				141894181BDD62F600EE52CE /* numbers_in_collection.json */,
 				141894171BDD62F600EE52CE /* numbers.json */,
+				1466B48B1CF4EDF1000B7CBD /* operation-types-users-a.json */,
+				1466B48C1CF4EDF1000B7CBD /* operation-types-users-b.json */,
 				141894191BDD62F600EE52CE /* organizations-tree.json */,
 				1418941A1BDD62F600EE52CE /* patients.json */,
 				1418941B1BDD62F600EE52CE /* stories-comments-no-ids.json */,
@@ -461,8 +467,10 @@
 				141894501BDD62F600EE52CE /* stories-comments-no-ids.json in Resources */,
 				1418944F1BDD62F600EE52CE /* patients.json in Resources */,
 				141894471BDD62F600EE52CE /* custom_relationship_key_to_many.json in Resources */,
+				1466B48D1CF4EDF1000B7CBD /* operation-types-users-a.json in Resources */,
 				141894451BDD62F600EE52CE /* bug-number-84.json in Resources */,
 				141D9E721CE9A4830041A7FC /* 157-locations.json in Resources */,
+				1466B48E1CF4EDF1000B7CBD /* operation-types-users-b.json in Resources */,
 				141894511BDD62F600EE52CE /* story-summarize.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo.xcodeproj/project.pbxproj
+++ b/Demo.xcodeproj/project.pbxproj
@@ -137,11 +137,11 @@
 		1418943C1BDD62F600EE52CE /* Unique.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Unique.xcdatamodel; sourceTree = "<group>"; };
 		141D9E711CE9A4830041A7FC /* 157-locations.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "157-locations.json"; sourceTree = "<group>"; };
 		141D9E741CE9A4970041A7FC /* Demo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Demo.xcdatamodel; sourceTree = "<group>"; };
-		1425D59B1CC65BEB00EC49D4 /* NSArray+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSArray+Sync.swift"; sourceTree = "<group>"; };
-		1425D59C1CC65BEB00EC49D4 /* NSEntityDescription+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSEntityDescription+Sync.swift"; sourceTree = "<group>"; };
-		1425D59D1CC65BEB00EC49D4 /* NSManagedObject+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Sync.swift"; sourceTree = "<group>"; };
-		1425D59E1CC65BEB00EC49D4 /* NSManagedObjectContext+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Sync.swift"; sourceTree = "<group>"; };
-		1425D59F1CC65BEB00EC49D4 /* Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sync.swift; sourceTree = "<group>"; };
+		1425D59B1CC65BEB00EC49D4 /* NSArray+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "NSArray+Sync.swift"; sourceTree = "<group>"; tabWidth = 2; };
+		1425D59C1CC65BEB00EC49D4 /* NSEntityDescription+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "NSEntityDescription+Sync.swift"; sourceTree = "<group>"; tabWidth = 2; };
+		1425D59D1CC65BEB00EC49D4 /* NSManagedObject+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Sync.swift"; sourceTree = "<group>"; tabWidth = 2; };
+		1425D59E1CC65BEB00EC49D4 /* NSManagedObjectContext+Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+Sync.swift"; sourceTree = "<group>"; tabWidth = 2; };
+		1425D59F1CC65BEB00EC49D4 /* Sync.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Sync.swift; sourceTree = "<group>"; tabWidth = 2; };
 		1469B7F81C68D7820080FD71 /* Demo.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Demo.xcdatamodel; sourceTree = "<group>"; };
 		1469B7FA1C68D7D50080FD71 /* notes_with_user_id_custom.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = notes_with_user_id_custom.json; sourceTree = "<group>"; };
 		146D72AC1AB782920058798C /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/README.md
+++ b/README.md
@@ -514,6 +514,24 @@ assert(remoteKey != nil, "nil value")
 
 There are two ways you can sync a JSON object that doesn't have an `id`. You can either set one of it's [attributes as the primary key](https://github.com/hyperoslo/Sync#primary-key), or you can store the JSON object as NSData, I have done this myself in a couple of apps works pretty well. You can find more information on how to store dictionaries using Sync [here](https://github.com/hyperoslo/Sync#arraydictionary).
 
+#### What if I only want inserts and updates?:
+
+You can provide the type of operations that you want too. If you don't set this parameter, insert, updates and deletes will be done.
+
+This is how setting operations should work:
+
+```swift
+let firstImport = // First import of users
+Sync.changes(firstBatch, inEntityNamed: "User", dataStack: dataStack, operations: [.All]) {
+    // All users have been imported, they are happy 
+}
+
+let secondImport = // Second import of users
+Sync.changes(secondImport, inEntityNamed: "User", dataStack: dataStack, operations: [.Insert, .Update]) {
+    // Likely after some changes have happened, here usually Sync would remove the not found items but this time
+    // new users have been imported, existing users have been updated, and not found users have been ignored
+}
+```
 
 ## Credits
 

--- a/Source/NSArray+Sync.swift
+++ b/Source/NSArray+Sync.swift
@@ -1,6 +1,7 @@
 import Foundation
 import DATAStack
 import NSManagedObject_HYPPropertyMapper
+import DATAFilter
 
 public extension NSArray {
   /**
@@ -10,26 +11,26 @@ public extension NSArray {
    - parameter parent: The parent of the entity, optional since many entities are orphans.
    - parameter dataStack: The DATAStack instance.
    */
-  func preprocessForEntityNamed(entityName: String, predicate: NSPredicate, parent: NSManagedObject?, dataStack: DATAStack) -> [[String : AnyObject]] {
+  func preprocessForEntityNamed(entityName: String, predicate: NSPredicate, parent: NSManagedObject?, dataStack: DATAStack, operations: DATAFilterOperation) -> [[String : AnyObject]] {
     var filteredChanges = [[String : AnyObject]]()
     let validClasses = [NSDate.classForCoder(), NSNumber.classForCoder(), NSString.classForCoder()]
     if let predicate = predicate as? NSComparisonPredicate, selfArray = self as? [[String : AnyObject]] where validClasses.contains({ $0 == predicate.rightExpression.classForCoder }) {
-        var objectChanges = [NSManagedObject]()
-        let context = dataStack.newDisposableMainContext()
-        if let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) {
-          selfArray.forEach {
-            let object = NSManagedObject(entity: entity, insertIntoManagedObjectContext: context)
-            object.sync_fillWithDictionary($0, parent: parent, dataStack: dataStack)
-            objectChanges.append(object)
-          }
+      var objectChanges = [NSManagedObject]()
+      let context = dataStack.newDisposableMainContext()
+      if let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) {
+        selfArray.forEach {
+          let object = NSManagedObject(entity: entity, insertIntoManagedObjectContext: context)
+          object.sync_fillWithDictionary($0, parent: parent, dataStack: dataStack, operations: operations)
+          objectChanges.append(object)
+        }
 
-          guard let filteredArray = (objectChanges as NSArray).filteredArrayUsingPredicate(predicate) as? [NSManagedObject] else { fatalError("Couldn't cast filteredArray as [NSManagedObject]: \(objectChanges), predicate: \(predicate)") }
-          for filteredObject in filteredArray  {
-            if let change = filteredObject.hyp_dictionaryUsingRelationshipType(.Array) as? [String : AnyObject] {
-              filteredChanges.append(change)
-            }
+        guard let filteredArray = (objectChanges as NSArray).filteredArrayUsingPredicate(predicate) as? [NSManagedObject] else { fatalError("Couldn't cast filteredArray as [NSManagedObject]: \(objectChanges), predicate: \(predicate)") }
+        for filteredObject in filteredArray  {
+          if let change = filteredObject.hyp_dictionaryUsingRelationshipType(.Array) as? [String : AnyObject] {
+            filteredChanges.append(change)
           }
         }
+      }
     }
 
     return filteredChanges

--- a/Source/NSManagedObject+Sync.swift
+++ b/Source/NSManagedObject+Sync.swift
@@ -24,7 +24,7 @@ public extension NSManagedObject {
 
   /**
    Syncs the entity using the received dictionary, maps one-to-many, many-to-many and one-to-one relationships.
-   It also syncs relationships where onaly the id is present, for example if your model is: Company -> Employee,
+   It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
    and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
    entire company object inside the employees dictionary.
    - parameter dictionary: The JSON with the changes to be applied to the entity.

--- a/Source/NSManagedObject+Sync.swift
+++ b/Source/NSManagedObject+Sync.swift
@@ -2,6 +2,7 @@ import CoreData
 import NSEntityDescription_SYNCPrimaryKey
 import DATAStack
 import NSString_HYPNetworking
+import DATAFilter
 
 public extension NSManagedObject {
   /**
@@ -23,14 +24,14 @@ public extension NSManagedObject {
 
   /**
    Syncs the entity using the received dictionary, maps one-to-many, many-to-many and one-to-one relationships.
-   It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+   It also syncs relationships where onaly the id is present, for example if your model is: Company -> Employee,
    and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
    entire company object inside the employees dictionary.
    - parameter dictionary: The JSON with the changes to be applied to the entity.
    - parameter parent: The parent of the entity, optional since many entities are orphans.
    - parameter dataStack: The DATAStack instance.
    */
-  func sync_fillWithDictionary(dictionary: [String : AnyObject], parent: NSManagedObject?, dataStack: DATAStack) {
+  func sync_fillWithDictionary(dictionary: [String : AnyObject], parent: NSManagedObject?, dataStack: DATAStack, operations: DATAFilterOperation) {
     hyp_fillWithDictionary(dictionary)
 
     entity.sync_relationships().forEach { relationship in
@@ -42,14 +43,14 @@ public extension NSManagedObject {
         if let localPrimaryKey = dictionary[keyName] where localPrimaryKey is Array<String> || localPrimaryKey is Array<Int> || localPrimaryKey is NSNull {
           sync_toManyRelationshipUsingIDsInsteadOfDictionary(relationship, localPrimaryKey: localPrimaryKey)
         } else {
-          sync_toManyRelationship(relationship, dictionary: dictionary, parent: parent, dataStack: dataStack)
+          sync_toManyRelationship(relationship, dictionary: dictionary, parent: parent, dataStack: dataStack, operations: operations)
         }
       } else if let parent = parent where !parent.isEqual(valueForKey(relationship.name)) && relationship.destinationEntity?.name == parent.entity.name {
         setValue(parent, forKey: relationship.name)
       } else if let localPrimaryKey = dictionary[keyName] where localPrimaryKey is NSString || localPrimaryKey is NSNumber || localPrimaryKey is NSNull {
         sync_toOneRelationshipUsingIDInsteadOfDictionary(relationship, localPrimaryKey: localPrimaryKey, dataStack: dataStack)
       } else {
-        sync_toOneRelationship(relationship, dictionary: dictionary, dataStack: dataStack)
+        sync_toOneRelationship(relationship, dictionary: dictionary, dataStack: dataStack, operations: operations)
       }
     }
   }
@@ -139,7 +140,7 @@ public extension NSManagedObject {
    - parameter parent: The parent of the entity, optional since many entities are orphans.
    - parameter dataStack: The DATAStack instance.
    */
-  func sync_toManyRelationship(relationship: NSRelationshipDescription, dictionary: [String : AnyObject], parent: NSManagedObject?, dataStack: DATAStack) {
+  func sync_toManyRelationship(relationship: NSRelationshipDescription, dictionary: [String : AnyObject], parent: NSManagedObject?, dataStack: DATAStack, operations: DATAFilterOperation) {
     guard let managedObjectContext = managedObjectContext, destinationEntity = relationship.destinationEntity, childEntityName = destinationEntity.name else { abort() }
 
     let relationshipName = relationship.userInfo?[SYNCCustomRemoteKey] as? String ?? relationship.name.hyp_remoteString()
@@ -161,7 +162,7 @@ public extension NSManagedObject {
         childPredicate = NSPredicate(format: "%K = %@", inverseEntityName, self)
       }
 
-      Sync.changes(children, inEntityNamed: childEntityName, predicate: childPredicate, parent: self, inContext: managedObjectContext, dataStack: dataStack, completion: nil)
+      Sync.changes(children, inEntityNamed: childEntityName, predicate: childPredicate, parent: self, inContext: managedObjectContext, dataStack: dataStack, operations: operations, completion: nil)
     } else if let parent = parent, entityName = parent.entity.name where inverseIsToMany && entityName == childEntityName {
       if relationship.ordered {
         let relatedObjects = mutableOrderedSetValueForKey(relationship.name)
@@ -211,7 +212,7 @@ public extension NSManagedObject {
    - parameter dictionary: The JSON with the changes to be applied to the entity.
    - parameter dataStack: The DATAStack instance.
    */
-  func sync_toOneRelationship(relationship: NSRelationshipDescription, dictionary: [String : AnyObject], dataStack: DATAStack) {
+  func sync_toOneRelationship(relationship: NSRelationshipDescription, dictionary: [String : AnyObject], dataStack: DATAStack, operations: DATAFilterOperation) {
     let relationshipName = relationship.userInfo?[SYNCCustomRemoteKey] as? String ?? relationship.name.hyp_remoteString()
 
     guard let managedObjectContext = managedObjectContext, filteredObjectDictionary = dictionary[relationshipName] as? [String : AnyObject], destinationEntity = relationship.destinationEntity, entityName = destinationEntity.name, entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: managedObjectContext) else { return }
@@ -219,7 +220,7 @@ public extension NSManagedObject {
     let localPrimaryKey = filteredObjectDictionary[entity.sync_remotePrimaryKey()]
     let object = managedObjectContext.sync_safeObject(entityName, localPrimaryKey: localPrimaryKey, parent: self, parentRelationshipName: relationship.name) ?? NSEntityDescription.insertNewObjectForEntityForName(entityName, inManagedObjectContext: managedObjectContext)
 
-    object.sync_fillWithDictionary(filteredObjectDictionary, parent: self, dataStack: dataStack)
+    object.sync_fillWithDictionary(filteredObjectDictionary, parent: self, dataStack: dataStack, operations: operations)
 
     let currentRelationship = valueForKey(relationship.name)
     if currentRelationship == nil || !currentRelationship!.isEqual(object) {

--- a/Source/Sync.swift
+++ b/Source/Sync.swift
@@ -29,12 +29,14 @@ import DATAStack
   var entityName: String
   weak var predicate: NSPredicate?
   unowned var dataStack: DATAStack
+  var filterOperations = DATAFilterOperation.All
 
-  public init(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DATAStack) {
+  public init(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DATAStack, operations: DATAFilterOperation = .All) {
     self.changes = changes
     self.entityName = entityName
     self.predicate = predicate
     self.dataStack = dataStack
+    self.filterOperations = operations
   }
 
   public override func start() {
@@ -56,7 +58,7 @@ import DATAStack
     } else {
       updateExecuting(true)
       dataStack.performInNewBackgroundContext { backgroundContext in
-        self.changes(self.changes, inEntityNamed: self.entityName, predicate: self.predicate, parent: nil, inContext: backgroundContext, dataStack: self.dataStack)
+        self.changes(self.changes, inEntityNamed: self.entityName, predicate: self.predicate, parent: nil, inContext: backgroundContext, dataStack: self.dataStack, operations: self.filterOperations)
         updateExecuting(false)
         updateFinished(true)
       }
@@ -84,7 +86,22 @@ import DATAStack
    - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
    */
   public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
-    self.changes(changes, inEntityNamed: entityName, predicate: nil, dataStack: dataStack, completion: completion)
+    self.changes(changes, inEntityNamed: entityName, predicate: nil, dataStack: dataStack, operations: .All, completion: completion)
+  }
+
+  /**
+   Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+   It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+   and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+   entire company object inside the employees dictionary.
+   - parameter changes: The array of dictionaries used in the sync process.
+   - parameter entityName: The name of the entity to be synced.
+   - parameter dataStack: The DATAStack instance.
+   - parameter operations: The type of operations to be applied to the data, Insert, Update, Delete or any possible combination.
+   - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
+   */
+  public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, dataStack: DATAStack, operations: DATAFilterOperation, completion: ((error: NSError?) -> Void)?) {
+    self.changes(changes, inEntityNamed: entityName, predicate: nil, dataStack: dataStack, operations: operations, completion: completion)
   }
 
   /**
@@ -101,7 +118,26 @@ import DATAStack
    */
   public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
     dataStack.performInNewBackgroundContext { backgroundContext in
-      self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: nil, inContext: backgroundContext, dataStack: dataStack, completion: completion)
+      self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: nil, inContext: backgroundContext, dataStack: dataStack, operations: .All, completion: completion)
+    }
+  }
+
+  /**
+   Syncs the entity using the received array of dictionaries, maps one-to-many, many-to-many and one-to-one relationships.
+   It also syncs relationships where only the id is present, for example if your model is: Company -> Employee,
+   and your employee has a company_id, it will try to sync using that ID instead of requiring you to provide the
+   entire company object inside the employees dictionary.
+   - parameter changes: The array of dictionaries used in the sync process.
+   - parameter entityName: The name of the entity to be synced.
+   - parameter predicate: The predicate used to filter out changes, if you want to exclude some local items to be taken in
+   account in the Sync process, you just need to provide this predicate.
+   - parameter dataStack: The DATAStack instance.
+   - parameter operations: The type of operations to be applied to the data, Insert, Update, Delete or any possible combination.
+   - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
+   */
+  public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, dataStack: DATAStack, operations: DATAFilterOperation, completion: ((error: NSError?) -> Void)?) {
+    dataStack.performInNewBackgroundContext { backgroundContext in
+      self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: nil, inContext: backgroundContext, dataStack: dataStack, operations: operations, completion: completion)
     }
   }
 
@@ -129,7 +165,7 @@ import DATAStack
         predicate = NSPredicate(format: "%K = %@", firstRelationship.name, safeParent)
       }
 
-      self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: safeParent, inContext: backgroundContext, dataStack: dataStack, completion: completion)
+      self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: safeParent, inContext: backgroundContext, dataStack: dataStack, operations: .All, completion: completion)
     }
   }
 
@@ -149,6 +185,10 @@ import DATAStack
    - parameter completion: The completion block, it returns an error if something in the Sync process goes wrong.
    */
   public class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, parent: NSManagedObject?, inContext context: NSManagedObjectContext, dataStack: DATAStack, completion: ((error: NSError?) -> Void)?) {
+    self.changes(changes, inEntityNamed: entityName, predicate: predicate, parent: parent, inContext: context, dataStack: dataStack, operations: .All, completion: completion)
+  }
+
+  class func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, parent: NSManagedObject?, inContext context: NSManagedObjectContext, dataStack: DATAStack, operations: DATAFilterOperation, completion: ((error: NSError?) -> Void)?) {
     guard let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) else { abort() }
 
     let localPrimaryKey = entity.sync_localPrimaryKey()
@@ -172,10 +212,10 @@ import DATAStack
       guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
 
       let created = NSEntityDescription.insertNewObjectForEntityForName(entityName, inManagedObjectContext: context)
-      created.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack)
+      created.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack, operations: operations)
     }) { objectJSON, updatedObject in
       guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
-      updatedObject.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack)
+      updatedObject.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack, operations: operations)
     }
 
     var syncError: NSError?
@@ -192,7 +232,7 @@ import DATAStack
     }
   }
 
-  func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, parent: NSManagedObject?, inContext context: NSManagedObjectContext, dataStack: DATAStack) {
+  func changes(changes: [[String : AnyObject]], inEntityNamed entityName: String, predicate: NSPredicate?, parent: NSManagedObject?, inContext context: NSManagedObjectContext, dataStack: DATAStack, operations: DATAFilterOperation) {
     guard let entity = NSEntityDescription.entityForName(entityName, inManagedObjectContext: context) else { abort() }
 
     let localPrimaryKey = entity.sync_localPrimaryKey()
@@ -212,16 +252,16 @@ import DATAStack
       fatalError("Remote primary key not found for entity: \(entityName), we were looking for id, if your remote ID has a different name consider using hyper.remoteKey to map to the right value")
     }
 
-    DATAFilter.changes(changes as [AnyObject], inEntityNamed: entityName, predicate: finalPredicate, operations: [.All], localPrimaryKey: localPrimaryKey, remotePrimaryKey: remotePrimaryKey, context: context, inserted: { objectJSON in
+    DATAFilter.changes(changes as [AnyObject], inEntityNamed: entityName, predicate: finalPredicate, operations: operations, localPrimaryKey: localPrimaryKey, remotePrimaryKey: remotePrimaryKey, context: context, inserted: { objectJSON in
       guard self.cancelled == false else { return }
       guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
 
       let created = NSEntityDescription.insertNewObjectForEntityForName(entityName, inManagedObjectContext: context)
-      created.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack)
+      created.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack, operations: operations)
     }) { objectJSON, updatedObject in
       guard self.cancelled == false else { return }
       guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
-      updatedObject.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack)
+      updatedObject.sync_fillWithDictionary(JSON, parent: parent, dataStack: dataStack, operations: operations)
     }
 
     if context.hasChanges {

--- a/Source/Sync.swift
+++ b/Source/Sync.swift
@@ -208,7 +208,7 @@ import DATAStack
       fatalError("Remote primary key not found for entity: \(entityName), we were looking for id, if your remote ID has a different name consider using hyper.remoteKey to map to the right value")
     }
 
-    DATAFilter.changes(changes as [AnyObject], inEntityNamed: entityName, predicate: finalPredicate, operations: [.All], localPrimaryKey: localPrimaryKey, remotePrimaryKey: remotePrimaryKey, context: context, inserted: { objectJSON in
+    DATAFilter.changes(changes as [AnyObject], inEntityNamed: entityName, predicate: finalPredicate, operations: operations, localPrimaryKey: localPrimaryKey, remotePrimaryKey: remotePrimaryKey, context: context, inserted: { objectJSON in
       guard let JSON = objectJSON as? [String : AnyObject] else { abort() }
 
       let created = NSEntityDescription.insertNewObjectForEntityForName(entityName, inManagedObjectContext: context)

--- a/Tests/JSONs/operation-types-users-a.json
+++ b/Tests/JSONs/operation-types-users-a.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 0,
+    "name": "Melisa White",
+    "email": "melisawhite@ovium.com"
+  },
+  {
+    "id": 1,
+    "name": "Glass Oconnor",
+    "email": "glassoconnor@ovium.com"
+  }
+]

--- a/Tests/JSONs/operation-types-users-b.json
+++ b/Tests/JSONs/operation-types-users-b.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 0,
+    "name": "Melisa White",
+    "email": "updated@ovium.com"
+  },
+  {
+    "id": 6,
+    "name": "Shawn Merrill",
+    "email": "shawnmerrill@ovium.com"
+  }
+]


### PR DESCRIPTION
```swift
let firstImport = // First import of users
Sync.changes(firstBatch, inEntityNamed: "User", dataStack: dataStack, operations: [.All]) {
    // All users have been imported, they are happy 
}

// Likely after some changes have happened, here usually Sync would remove the not found items
let secondImport = // Second import of users
Sync.changes(secondImport, inEntityNamed: "User", dataStack: dataStack, operations: [.Insert, .Update]) {
    // Here new users have been imported, existing users have been updated, and not found users have been ignored
}
```