### PR TITLE
Add DemoCore regression test for SyncContainer.export(Task)

### DIFF
--- a/DemoCore/Tests/DemoCoreTests/TaskExportRegressionTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/TaskExportRegressionTests.swift
@@ -1,0 +1,58 @@
+import SwiftData
+import SwiftSync
+import XCTest
+
+@testable import DemoCore
+
+// Guards `SyncContainer.export(_:)` for a Task draft — the payload the task-form
+// save path builds before calling the API. A stale export API call here once
+// broke the DemoCore build silently (it was never exercised by a test).
+final class TaskExportRegressionTests: XCTestCase {
+
+    @MainActor
+    func testExportTaskProducesRemoteKeyedPayload() throws {
+        let syncContainer = try makeSyncContainer()
+        let task = Task(
+            id: "T-1",
+            projectID: "P-1",
+            assigneeID: "U-2",
+            authorID: "U-1",
+            title: "Ship it",
+            descriptionText: "Body text",
+            state: "open",
+            stateLabel: "Open"
+        )
+        syncContainer.mainContext.insert(task)
+
+        let body = syncContainer.export(task)
+
+        XCTAssertEqual(body["id"] as? String, "T-1")
+        XCTAssertEqual(body["title"] as? String, "Ship it")
+        XCTAssertEqual(body["description"] as? String, "Body text")
+        XCTAssertEqual(body["project_id"] as? String, "P-1")
+        XCTAssertEqual(body["author_id"] as? String, "U-1")
+        XCTAssertEqual(body["assignee_id"] as? String, "U-2")
+
+        let state = body["state"] as? [String: Any]
+        XCTAssertEqual(state?["id"] as? String, "open")
+        XCTAssertEqual(state?["label"] as? String, "Open")
+
+        // @NotExport relationships must be excluded from the payload.
+        XCTAssertNil(body["reviewers"])
+        XCTAssertNil(body["watchers"])
+        XCTAssertNil(body["assignee"])
+    }
+
+    @MainActor
+    private func makeSyncContainer() throws -> SyncContainer {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try SyncContainer(
+            for: Project.self,
+            User.self,
+            Task.self,
+            Item.self,
+            TaskStateOption.self,
+            configurations: configuration
+        )
+    }
+}


### PR DESCRIPTION
## What

Adds a regression test for `SyncContainer.export(_:)` on the DemoCore `Task` model — the export call the task-form save path (`ScreenMachines.swift`) uses to build its API payload.

## Why

That call site previously broke the DemoCore build (stale `draft.exportObject(for:)` API, removed by the export refactor and repaired in `435752e8`). It slipped through because **no test exercised the export path**. This test closes that gap.

## Coverage

Exports a `Task` and asserts the payload contract:
- `@RemoteKey` mapping: `description`, nested `state.id` / `state.label`
- snake_cased fields: `project_id`, `author_id`, `assignee_id`
- `@NotExport` relationships (`reviewers`, `watchers`, `assignee`) excluded

## Verification (red-first)

- **RED**: reintroducing `draft.exportObject(for: syncContainer)` reproduces the exact original build failure (`'Task' has no member 'exportObject'`).
- **GREEN**: with `syncContainer.export(draft)` restored, the test passes.
- Full DemoCore suite green (21 tests).

No production code changes — the fix is already on `master`; this only adds the missing test.