### PR TITLE
perf: narrow relationship foreign-key fetch to referenced ids

### DIFF
--- a/SwiftSync/Sources/MacrosImplementation/SyncableMacro.swift
+++ b/SwiftSync/Sources/MacrosImplementation/SyncableMacro.swift
@@ -114,6 +114,17 @@ public struct SyncableMacro: ExtensionMacro {
                             )
                         }
                     }
+                    \(raw: memberAccessModifier)static func syncIdentityPredicate(matchingAny identities: [\(raw: identityProperty.typeSource)]) -> Predicate<\(raw: typeName)>? {
+                        Predicate<\(raw: typeName)> { row in
+                            PredicateExpressions.build_contains(
+                                PredicateExpressions.build_Arg(identities),
+                                PredicateExpressions.build_KeyPath(
+                                    root: row,
+                                    keyPath: \\.\(raw: identityProperty.name)
+                                )
+                            )
+                        }
+                    }
                     \(raw: memberAccessModifier)static func syncParentPredicate(
                         parentPersistentID: PersistentIdentifier,
                         relationship: PartialKeyPath<\(raw: typeName)>

--- a/SwiftSync/Sources/SwiftSync/Core.swift
+++ b/SwiftSync/Sources/SwiftSync/Core.swift
@@ -51,6 +51,7 @@ public protocol SyncModelable: PersistentModel {
     associatedtype SyncID: Hashable & Codable & Sendable
     static var syncIdentity: KeyPath<Self, SyncID> { get }
     static func syncIdentityPredicate(matching identity: SyncID) -> Predicate<Self>?
+    static func syncIdentityPredicate(matchingAny identities: [SyncID]) -> Predicate<Self>?
     static func syncParentPredicate(
         parentPersistentID: PersistentIdentifier,
         relationship: PartialKeyPath<Self>
@@ -64,6 +65,7 @@ public protocol SyncModelable: PersistentModel {
 extension SyncModelable {
     public static var syncIdentityRemoteKeys: [String] { ["id", "remote_id", "remoteID"] }
     public static func syncIdentityPredicate(matching _: SyncID) -> Predicate<Self>? { nil }
+    public static func syncIdentityPredicate(matchingAny _: [SyncID]) -> Predicate<Self>? { nil }
     public static func syncParentPredicate(
         parentPersistentID _: PersistentIdentifier,
         relationship _: PartialKeyPath<Self>
@@ -159,6 +161,9 @@ extension SyncUpdatableModel {
 final class SyncRelationshipLookupCache: @unchecked Sendable {
     private var rowsByType: [ObjectIdentifier: Any] = [:]
     private var rowsByIdentityType: [ObjectIdentifier: Any] = [:]
+    // Partial identity maps from id-narrowed fetches. Kept separate from the full-table
+    // `rowsByIdentityType` so a partial map is never mistaken for a complete one.
+    private var narrowedRowsByIdentityType: [ObjectIdentifier: Any] = [:]
 
     func rows<Model: PersistentModel>(
         for modelType: Model.Type,
@@ -198,17 +203,52 @@ final class SyncRelationshipLookupCache: @unchecked Sendable {
         return indexed
     }
 
+    func rowsByIdentity<Model: SyncModelable>(
+        for modelType: Model.Type,
+        matching identities: [Model.SyncID],
+        in context: ModelContext
+    ) throws -> [String: Model] {
+        let key = ObjectIdentifier(modelType)
+        var map = (narrowedRowsByIdentityType[key] as? [String: Model]) ?? [:]
+
+        // Unresolved ids are intentionally not memoized: a later pass may have inserted them,
+        // and the re-fetch is a narrow predicate query over the few still-missing ids.
+        let missing = identities.filter { map[syncIdentityKey(from: $0)] == nil }
+        guard !missing.isEmpty else { return map }
+
+        guard let predicate = Model.syncIdentityPredicate(matchingAny: missing) else {
+            return try rowsByIdentity(for: modelType, in: context)
+        }
+
+        let fetched = try syncProfile("relationship-fetch-by-identity") {
+            try context.fetch(FetchDescriptor<Model>(predicate: predicate))
+        }
+        syncProfile("relationship-index-by-id") {
+            for row in fetched {
+                if let identity = resolveIdentity(from: row) {
+                    map[identity] = row
+                }
+            }
+        }
+        narrowedRowsByIdentityType[key] = map
+        return map
+    }
+
     func append<Model: SyncModelable>(_ row: Model, as modelType: Model.Type) {
         let key = ObjectIdentifier(modelType)
         if var cached = rowsByType[key] as? [Model] {
             cached.append(row)
             rowsByType[key] = cached
         }
-        if var cached = rowsByIdentityType[key] as? [String: Model],
-            let identity = resolveIdentity(from: row)
-        {
-            cached[identity] = row
-            rowsByIdentityType[key] = cached
+        if let identity = resolveIdentity(from: row) {
+            if var cached = rowsByIdentityType[key] as? [String: Model] {
+                cached[identity] = row
+                rowsByIdentityType[key] = cached
+            }
+            if var cached = narrowedRowsByIdentityType[key] as? [String: Model] {
+                cached[identity] = row
+                narrowedRowsByIdentityType[key] = cached
+            }
         }
     }
 }
@@ -265,7 +305,7 @@ public func syncApplyToOneForeignKey<Owner, Related: SyncModelable>(
             return false
         }
 
-        let relatedByID = try syncFetchRelatedRowsByIdentity(Related.self, in: context)
+        let relatedByID = try syncFetchRelatedRowsByIdentity(Related.self, matching: [nextID], in: context)
         guard let nextRelated = relatedByID[syncIdentityKey(from: nextID)] else {
             // Old Sync parity: unknown FK row is a soft no-op.
             return false
@@ -320,7 +360,7 @@ public func syncApplyToOneForeignKey<Owner, Related: SyncModelable>(
             return false
         }
 
-        let relatedByID = try syncFetchRelatedRowsByIdentity(Related.self, in: context)
+        let relatedByID = try syncFetchRelatedRowsByIdentity(Related.self, matching: [nextID], in: context)
         guard let nextRelated = relatedByID[syncIdentityKey(from: nextID)] else {
             return false
         }
@@ -397,7 +437,7 @@ public func syncApplyToManyForeignKeys<Owner: SyncUpdatableModel, Related: SyncM
 
         // Old Sync behavior avoids duplicate membership; dedupe input deterministically.
         let desiredIDs = dedupePreservingOrder(rawIDs)
-        let relatedByID = try syncFetchRelatedRowsByIdentity(Related.self, in: context)
+        let relatedByID = try syncFetchRelatedRowsByIdentity(Related.self, matching: desiredIDs, in: context)
         let desiredRelated = desiredIDs.compactMap { relatedByID[syncIdentityKey(from: $0)] }
 
         // SwiftData does not expose ordered-relationship metadata; treat to-many as unordered membership.
@@ -647,6 +687,32 @@ private func syncFetchRelatedRowsByIdentity<Model: SyncModelable>(
             }
         )
         return indexed
+    }
+}
+
+private func syncFetchRelatedRowsByIdentity<Model: SyncModelable>(
+    _ modelType: Model.Type,
+    matching identities: [Model.SyncID],
+    in context: ModelContext
+) throws -> [String: Model] {
+    if let cache = SyncRelationshipLookupState.current {
+        return try cache.rowsByIdentity(for: modelType, matching: identities, in: context)
+    }
+
+    guard let predicate = Model.syncIdentityPredicate(matchingAny: identities) else {
+        return try syncFetchRelatedRowsByIdentity(modelType, in: context)
+    }
+
+    let fetched = try syncProfile("relationship-fetch-by-identity") {
+        try context.fetch(FetchDescriptor<Model>(predicate: predicate))
+    }
+    return syncProfile("relationship-index-by-id") {
+        Dictionary(
+            uniqueKeysWithValues: fetched.compactMap { row in
+                guard let identity = resolveIdentity(from: row) else { return nil }
+                return (identity, row)
+            }
+        )
     }
 }
 

--- a/SwiftSync/Tests/SwiftSyncMacrosTests/SyncableMacroDiagnosticsTests.swift
+++ b/SwiftSync/Tests/SwiftSyncMacrosTests/SyncableMacroDiagnosticsTests.swift
@@ -68,6 +68,17 @@ final class SyncableMacroDiagnosticsTests: XCTestCase {
                             )
                         }
                     }
+                    public static func syncIdentityPredicate(matchingAny identities: [String]) -> Predicate<Ticket>? {
+                        Predicate<Ticket> { row in
+                            PredicateExpressions.build_contains(
+                                PredicateExpressions.build_Arg(identities),
+                                PredicateExpressions.build_KeyPath(
+                                    root: row,
+                                    keyPath: \\.id
+                                )
+                            )
+                        }
+                    }
                     public static func syncParentPredicate(
                         parentPersistentID: PersistentIdentifier,
                         relationship: PartialKeyPath<Ticket>

--- a/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
@@ -3654,6 +3654,100 @@ final class SyncTests: XCTestCase {
     }
 
     @MainActor
+    func testToOneForeignKeyResolutionUsesIdentityTargetedFetchWhenPredicateExists() async throws {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: AutoCompany.self,
+            AutoEmployee.self,
+            configurations: configuration
+        )
+        let context = ModelContext(container)
+
+        try await SwiftSync.sync(
+            payload: [
+                ["id": 10, "name": "Acme"],
+                ["id": 11, "name": "Globex"],
+            ],
+            as: AutoCompany.self,
+            in: context
+        )
+
+        let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
+            try await SwiftSync.sync(
+                item: ["id": 1, "name": "Ava", "company_id": 10],
+                as: AutoEmployee.self,
+                in: context
+            )
+        }
+
+        XCTAssertNotNil(profile.totalsByPhase["relationship-fetch-by-identity"])
+        XCTAssertNil(profile.totalsByPhase["relationship-fetch"])
+    }
+
+    @MainActor
+    func testToManyForeignKeyResolutionUsesIdentityTargetedFetchWhenPredicateExists() async throws {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: ScenarioTag.self,
+            ScenarioTask.self,
+            configurations: configuration
+        )
+        let context = ModelContext(container)
+
+        try await SwiftSync.sync(
+            payload: [
+                ["id": 1, "name": "Tag 1"],
+                ["id": 2, "name": "Tag 2"],
+                ["id": 3, "name": "Tag 3"],
+            ],
+            as: ScenarioTag.self,
+            in: context
+        )
+
+        let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
+            try await SwiftSync.sync(
+                item: ["id": 10, "title": "Task 10", "tag_ids": [1, 2]],
+                as: ScenarioTask.self,
+                in: context
+            )
+        }
+
+        XCTAssertNotNil(profile.totalsByPhase["relationship-fetch-by-identity"])
+        XCTAssertNil(profile.totalsByPhase["relationship-fetch"])
+    }
+
+    @MainActor
+    func testForeignKeyResolutionFallsBackToTableFetchForManualConformerWithoutPredicate() async throws {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: AutoTag.self,
+            AutoTask.self,
+            configurations: configuration
+        )
+        let context = ModelContext(container)
+
+        try await SwiftSync.sync(
+            payload: [
+                ["id": 1, "name": "Tag 1"],
+                ["id": 2, "name": "Tag 2"],
+            ],
+            as: AutoTag.self,
+            in: context
+        )
+
+        let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
+            try await SwiftSync.sync(
+                item: ["id": 10, "title": "Task 10", "tag_ids": [1, 2]],
+                as: AutoTask.self,
+                in: context
+            )
+        }
+
+        XCTAssertNotNil(profile.totalsByPhase["relationship-fetch"])
+        XCTAssertNil(profile.totalsByPhase["relationship-fetch-by-identity"])
+    }
+
+    @MainActor
     func testParentScopedBatchSyncUsesParentTargetedFetchWhenPredicateExists() async throws {
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: NoteFolder.self, MacroScopedNote.self, configurations: configuration)

--- a/docs/planning/performance-attribution-follow-ups.md
+++ b/docs/planning/performance-attribution-follow-ups.md
@@ -2,13 +2,21 @@
 
 ## Open items
 
-- [ ] Instruments stack attribution of `relationship-fetch` — only needed once someone decides to optimize the demo-shaped relationship path further (see "Deferred: Instruments run" below for why and exactly how)
+- [ ] Narrow `relationship-fetch` to only the referenced related rows via a macro-generated multi-identity (`IN`) predicate; collect the union of referenced IDs per sync pass, cache per type as today, and fall back to a full fetch above a threshold (SQLite param limits). Measure on the `demo-shaped-project-session` benchmark before/after.
 
-## Deferred: Instruments run (why + how)
+## Next optimization target: narrow `relationship-fetch` (why + how)
 
-**Why we need it (and only then):** items 2-3 already prove that for the realistic demo-shaped workload the dominant cost is `apply-relationships` (~596 ms), inside which `relationship-fetch` (~509 ms) is the single largest sub-phase. The phase profiler tells us *which phase* is hot but not *what inside it* — whether `relationship-fetch` time is SwiftData relationship faulting, SQLite reads, or Swift-side model materialization. We do **not** need that breakdown yet: no relationship optimization is currently planned, and `relationship-fetch` is already the known target. Run Instruments only when someone commits to optimizing that path and needs to know which layer to attack.
+**The gap (confirmed by the fixture, not speculative):** both relationship-resolution paths fetch the entire related table to resolve however few IDs the payload references — `try context.fetch(FetchDescriptor<Model>())` with no predicate (`Core.swift` `SyncRelationshipLookupCache.rows(for:in:)` and `syncFetchRelatedRows(_:in:)`). The per-pass `SyncRelationshipLookupCache` only ensures this runs once per type per pass; it does not narrow *what* is fetched.
 
-**Exact steps to do it later:**
+In the demo-shaped benchmark (`FetchStrategyBenchmarkTests.testDemoShapedScenarioBenchmarks`), at the 10k tier the related tables hold 10,000 rows but the payload references only ~20 IDs total (`tag_ids: Array(1...10)`, `watcher_ids`: 10, `assignee_id`: 1). So the ~547 ms `relationship-fetch` materializes 10,000 rows to use ~20 — the same fetch-all-then-filter-in-memory pattern already beaten on the `fetch-existing-by-identity` path.
+
+**Why this, not Instruments:** the layer question (SwiftData faulting vs SQLite reads vs model materialization) is moot while the fetch is unbounded — over-fetching 10k rows to use 20 is wasteful at every layer, and the fix does not depend on the answer. The macro already emits `Model.syncIdentityPredicate(matching:)` for the single-identity fast path (`API.swift`); the natural move is an `IN`-predicate variant for related-row resolution.
+
+**Caveat — the win is reference-density dependent:** narrowing helps only when referenced IDs are a small subset of the related table (K ≪ N), which the demo fixture is and detail/list screens generally are. If a pass references most of the table, an `IN` over thousands of IDs won't help and risks SQLite's parameter limit — hence narrow to the per-pass union of referenced IDs and keep a full-fetch fallback above a threshold.
+
+**Instruments is now the fallback, not the gate:** run it only if the `IN`-predicate narrowing fails to move `relationship-fetch` on the demo benchmark. That outcome would prove the residual cost is materializing rows we genuinely need — and only then does layer attribution decide the next move.
+
+**Exact Instruments steps if it comes to that:**
 
 1. The signposts already exist — `SyncPerformanceProfiler` emits `OSSignposter` intervals named `SwiftSyncPhase` (subsystem `SwiftSync`, category `Performance`), with the phase name as the interval message, so `relationship-fetch` shows up as a labelled interval.
 2. Record headlessly with the bundled toolchain:

--- a/docs/planning/performance-attribution-follow-ups.md
+++ b/docs/planning/performance-attribution-follow-ups.md
@@ -2,19 +2,27 @@
 
 ## Open items
 
-- [ ] Narrow `relationship-fetch` to only the referenced related rows via a macro-generated multi-identity (`IN`) predicate; collect the union of referenced IDs per sync pass, cache per type as today, and fall back to a full fetch above a threshold (SQLite param limits). Measure on the `demo-shaped-project-session` benchmark before/after.
+- [ ] Narrow the nested-object relationship paths (`syncApplyToOneNestedObject` / `syncApplyToManyNestedObjects`) — they still `context.fetch(FetchDescriptor<Model>())` the whole related table (`relationship-fetch`). Only worth doing if a nested-object-heavy workload shows the full fetch dominating; the demo workload uses foreign-key relationships, which are now narrowed.
 
-## Next optimization target: narrow `relationship-fetch` (why + how)
+## Done: foreign-key `relationship-fetch` narrowing (measured 2026-06-13, Xcode 26.5 / Swift 6.3.2)
 
-**The gap (confirmed by the fixture, not speculative):** both relationship-resolution paths fetch the entire related table to resolve however few IDs the payload references — `try context.fetch(FetchDescriptor<Model>())` with no predicate (`Core.swift` `SyncRelationshipLookupCache.rows(for:in:)` and `syncFetchRelatedRows(_:in:)`). The per-pass `SyncRelationshipLookupCache` only ensures this runs once per type per pass; it does not narrow *what* is fetched.
+The foreign-key relationship paths now resolve referenced rows through a macro-generated multi-identity (`IN`) predicate (`syncIdentityPredicate(matchingAny:)`) instead of fetching the whole related table. New phase `relationship-fetch-by-identity`; the per-pass cache keeps a separate partial identity map so a narrowed result is never mistaken for a complete table. Manual conformers without the generated predicate fall back to the full-table path (locked by `testForeignKeyResolutionFallsBackToTableFetchForManualConformerWithoutPredicate`).
 
-In the demo-shaped benchmark (`FetchStrategyBenchmarkTests.testDemoShapedScenarioBenchmarks`), at the 10k tier the related tables hold 10,000 rows but the payload references only ~20 IDs total (`tag_ids: Array(1...10)`, `watcher_ids`: 10, `assignee_id`: 1). So the ~547 ms `relationship-fetch` materializes 10,000 rows to use ~20 — the same fetch-all-then-filter-in-memory pattern already beaten on the `fetch-existing-by-identity` path.
+Verified before/after on `FetchStrategyBenchmarkTests.testDemoShapedScenarioBenchmarks`, `sqlite + 10k`, 3 samples:
 
-**Why this, not Instruments:** the layer question (SwiftData faulting vs SQLite reads vs model materialization) is moot while the fetch is unbounded — over-fetching 10k rows to use 20 is wasteful at every layer, and the fix does not depend on the answer. The macro already emits `Model.syncIdentityPredicate(matching:)` for the single-identity fast path (`API.swift`); the natural move is an `IN`-predicate variant for related-row resolution.
+| phase | before | after |
+| --- | --- | --- |
+| total | `784.97 ms` | `112.34 ms` |
+| `apply-relationships` | `614.34 ms` | `40.51 ms` |
+| `relationship-fetch` (full table) | `527.09 ms` | — (gone) |
+| `relationship-fetch-by-identity` | — | `18.31 ms` |
+| `relationship-apply-to-many-foreign-keys` | `309.47 ms` | `16.85 ms` |
+| `relationship-apply-to-one-foreign-key` | `303.90 ms` | `19.45 ms` |
+| `relationship-index-by-id` | `67.96 ms` | `0.54 ms` |
 
-**Caveat — the win is reference-density dependent:** narrowing helps only when referenced IDs are a small subset of the related table (K ≪ N), which the demo fixture is and detail/list screens generally are. If a pass references most of the table, an `IN` over thousands of IDs won't help and risks SQLite's parameter limit — hence narrow to the per-pass union of referenced IDs and keep a full-fetch fallback above a threshold.
+About 7× faster on the demo-shaped workload. The apply-phase totals shrank because they wrap the fetch (nested signposts); indexing dropped because it now indexes ~20 rows instead of 10k.
 
-**Instruments is now the fallback, not the gate:** run it only if the `IN`-predicate narrowing fails to move `relationship-fetch` on the demo benchmark. That outcome would prove the residual cost is materializing rows we genuinely need — and only then does layer attribution decide the next move.
+This makes the Instruments stack-attribution follow-up moot for the foreign-key paths: the cost was over-fetching, not a layer that needed attributing. Keep the Instruments steps below only as a fallback if the remaining nested-object full fetch ever becomes the dominant phase in a real workload.
 
 **Exact Instruments steps if it comes to that:**
 


### PR DESCRIPTION
## What

Foreign-key relationship resolution fetched the **entire** related table to resolve however few IDs a payload referenced. This narrows it to only the referenced rows via a new macro-generated multi-identity `IN` predicate, mirroring the existing `fetch-existing` → `fetch-existing-by-identity` fast path.

## Why

On the demo-shaped benchmark (`sqlite + 10k`), related tables hold 10,000 rows but a payload references ~20 IDs (`tag_ids`, `watcher_ids`, `assignee_id`). The full-table `relationship-fetch` materialized 10k rows to use ~20 — the dominant cost in the realistic workload, and the same fetch-all pattern already beaten elsewhere.

This supersedes the deferred "Instruments stack attribution of `relationship-fetch`" follow-up: the cost was over-fetching, not a layer needing attribution.

## How

- New protocol requirement + macro generation: `syncIdentityPredicate(matchingAny:)` (uses `PredicateExpressions.build_contains`).
- New phase `relationship-fetch-by-identity`; the per-pass cache keeps a **separate** partial identity map (`narrowedRowsByIdentityType`) so a narrowed result is never mistaken for a complete table by the full-table consumer.
- Wired the three foreign-key call sites (two to-one, one to-many) to pass referenced IDs.
- Manual conformers without the generated predicate fall back to the full-table path (no behavior change).

Nested-object relationship paths are intentionally left on the full-table path (they create rows and mutate the map locally; not exercised by the demo workload) — tracked as the remaining open item.

## Verification (TDD)

Red tests written first and confirmed failing for the right reason, then made green.

- `testToOneForeignKeyResolutionUsesIdentityTargetedFetchWhenPredicateExists`
- `testToManyForeignKeyResolutionUsesIdentityTargetedFetchWhenPredicateExists`
- `testForeignKeyResolutionFallsBackToTableFetchForManualConformerWithoutPredicate`

Full `swift test` suite green.

## Benchmark (`testDemoShapedScenarioBenchmarks`, sqlite + 10k, 3 samples)

| phase | before | after |
| --- | --- | --- |
| total | 784.97 ms | **112.34 ms** |
| apply-relationships | 614.34 ms | 40.51 ms |
| relationship-fetch (full table) | 527.09 ms | — gone |
| relationship-fetch-by-identity | — | 18.31 ms |
| relationship-apply-to-many-foreign-keys | 309.47 ms | 16.85 ms |
| relationship-apply-to-one-foreign-key | 303.90 ms | 19.45 ms |
| relationship-index-by-id | 67.96 ms | 0.54 ms |

~7× faster on the demo-shaped workload.

## Note

Touches `Core.swift` and the macro, so the iOS regression suite runs on merge.
