### PR TITLE
fix(ci): repair the iOS dirty-tracking regression gate

### DIFF
--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -23,9 +23,9 @@ jobs:
         run: xcodebuild -version && swift --version
 
       - name: Test — DirtyTrackingGapTests (iOS Simulator)
+        working-directory: DemoCore
         run: |
           xcodebuild test \
-            -project Demo/Demo.xcodeproj \
-            -scheme Demo \
+            -scheme DemoCore \
             -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
-            -only-testing:DemoTests/DirtyTrackingGapTests
+            -only-testing:DemoCoreTests/DirtyTrackingGapTests


### PR DESCRIPTION
## The bug
The post-merge **iOS Regression** workflow (`ios-regression.yml`) has been failing on *every* merge — including #602 (before this roadmap work), #603, and #604. It's a config rot, not a code regression:

```
xcodebuild: error: ... Tests in the target "DemoTests" can't be run because
"DemoTests" isn't a member of the specified test plan or scheme.
```

It ran `-project Demo/Demo.xcodeproj -scheme Demo -only-testing:DemoTests/DirtyTrackingGapTests`, but:
- there is **no `DemoTests` target** (the `Demo` scheme's test plan only contains `DemoUITests`), and
- `DirtyTrackingGapTests` actually lives in the **DemoCore SPM package** (`DemoCoreTests`).

So it failed at the build step and never ran the test.

## The fix
Run the test via DemoCore's package scheme on the iOS Simulator:

```
working-directory: DemoCore
xcodebuild test -scheme DemoCore \
  -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
  -only-testing:DemoCoreTests/DirtyTrackingGapTests
```

Verified locally on iPhone 16 Pro (iOS Simulator): `Executed 2 tests, with 0 failures` / `** TEST SUCCEEDED **`. So the dirty-tracking behavior is correct on iOS — the gate was just pointed at a non-existent target.

## Note
This workflow triggers only on PR *merge* (post-merge gate, by design), so it won't run on this PR itself — it'll go green on the next merge into master. The trigger is unchanged.