### PR TITLE
ci: make the iOS dirty-tracking regression a pre-merge gate

### DIFF
--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -1,11 +1,17 @@
-name: iOS Regression (post-merge)
+name: iOS Regression
 
-# Runs only when a PR is actually merged into master — not on draft closes,
-# not on manual dispatch, not on direct pushes.
+# Pre-merge gate: the dirty-tracking gap is iOS-specific, so the macOS `swift test`
+# in ci.yml can pass while iOS behaves differently. Run the iOS-Simulator regression
+# on every PR (and on master pushes) so it can actually block a regression — a
+# post-merge-only check only reports the breakage after it has already landed.
 on:
   pull_request:
-    types: [closed]
+  push:
     branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
@@ -13,7 +19,6 @@ env:
 jobs:
   ios-dirty-tracking:
     name: iOS Dirty-Tracking Regression
-    if: github.event.pull_request.merged == true
     runs-on: macos-15
 
     steps:


### PR DESCRIPTION
Follow-up to #605. That PR fixed the broken iOS regression command; this one fixes the **design**: it was a *post-merge* gate (`pull_request: [closed]` + `if merged`), which can't block anything — it only reports a regression after it's already on master. That's precisely how the broken gate stayed invisible through several merges.

## Change
- Trigger on `pull_request` (every PR) + `push` to `master`, instead of post-merge only.
- Drop the `types: [closed]` / `if: github.event.pull_request.merged` guard.
- Add `concurrency` cancellation to match `ci.yml`.
- Rename `iOS Regression (post-merge)` → `iOS Regression`.

## Why this is the gate that matters
The dirty-tracking gap is **iOS-specific** — the macOS `swift test` in `ci.yml` can pass while iOS behaves differently (we hit exactly that with the iOS 18 observation change). Running `DemoCoreTests/DirtyTrackingGapTests` on the iOS Simulator pre-merge is what actually protects the behavior the library exists to provide.

Unlike the post-merge version, this workflow runs on **this PR**, so you can see it pass before merge. (Making it a *required* check is a branch-protection setting you control.)