### PR TITLE
docs: fix architecture drift and dead links (Phase 2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,35 +2,29 @@
 
 ## Package Structure
 
-5 library targets, 1 compiler plugin, 1 ObjC helper:
+One library product (`SwiftSync`), backed by a single library target plus a compiler
+plugin and an ObjC helper (see `Package.swift`):
 
 ```
-Core                    (no dependencies)
-  ↑
-  ├─ MacrosImplementation  (compiler plugin, + swift-syntax)
-  │     ↑
-  │     └─ Macros          (public macro declarations)
-  │
-  ├─ SwiftDataBridge       (sync engine)
-  │
-  └─ TestingKit            (test helpers)
-
-SwiftSync                 (container + reactive queries)
-  depends on: Core, SwiftDataBridge, Macros, ObjCExceptionCatcher
-
-ObjCExceptionCatcher      (mixed Swift/ObjC, catches NSException from ModelContainer)
+SwiftSync                 (library — public API, sync engine, reactive queries)
+  ├─ MacrosImplementation (compiler plugin, + swift-syntax)
+  └─ ObjCExceptionCatcher (ObjC, catches NSException from ModelContainer init)
 ```
+
+There is no separate `Core` / `SwiftDataBridge` / `Macros` / `TestingKit` target —
+everything public lives in the one `SwiftSync` target. The `@Syncable` family of macro
+*declarations* lives in `SwiftSync` (`SyncableMacro.swift`); the macro *implementation*
+lives in `MacrosImplementation` (`SyncableMacro.swift`).
 
 ### What lives where
 
-| Target | Key types |
-|---|---|
-| Core | `SyncPayload`, `SyncDateParser`, all protocols, `KeyStyle`, `SyncError` |
-| SwiftDataBridge | `SwiftSync.sync()`, `SyncLeaseRegistry` |
-| MacrosImplementation | `SyncableMacro` + three no-op peer macros |
-| Macros | `@Syncable`, `@PrimaryKey`, `@RemoteKey`, `@NotExport` declarations |
-| SwiftSync | `SyncContainer`, `SyncQuery`, `SyncModel` |
-| ObjCExceptionCatcher | `SwiftSyncObjCExceptionCatcher` |
+| Target | Role | Key contents |
+|---|---|---|
+| `SwiftSync` | the library (public API) | `SyncPayload`, `SyncDateParser`, the protocols (`SyncModelable`, `SyncUpdatableModel`, `ParentScopedModel`), `KeyStyle`, `SyncError`, `SwiftSync.sync()`, the relationship-apply globals (`Core.swift`), `SyncContainer`, the reactive query system (`@SyncQuery`/`@SyncModel`, `SyncModelPublisher`, `SyncQueryPublisher`), and the `@Syncable`/`@PrimaryKey`/`@RemoteKey`/`@NotExport` macro declarations |
+| `MacrosImplementation` | compiler plugin (`.macro`, + swift-syntax) | `SyncableMacro` plus the `PrimaryKeyMacro` / `NotExportMacro` / `RemoteKeyMacro` no-op peer macros |
+| `ObjCExceptionCatcher` | ObjC helper | bridges `NSException` from `ModelContainer(for:)` into a Swift error |
+
+Test targets: `SwiftSyncTests`, `SwiftSyncMacrosTests`.
 
 ---
 
@@ -151,7 +145,7 @@ The macro emits an `extension Task: SyncUpdatableModel, ...` containing:
 - For `tags`: if `payload.contains("tags_ids") || payload.contains("tag_ids")` → `syncApplyToManyForeignKeys`
   - else if `payload.contains("tags")` → `syncApplyToManyNestedObjects`
 
-**`func exportObject(keyStyle:dateFormatter:) -> [String: Any]`**
+**`func export(keyStyle:dateFormatter:) -> [String: Any]`**
 - `internalFlag` skipped (`@NotExport`)
 - `stateID` exported under key `"state.id"` (nested dict)
 - `assignee` exported as object or NSNull
@@ -312,13 +306,13 @@ syncContainer.export(as: Task.self)
 ```
 
 1. Fetch all rows, sort by identity key string
-2. For each row: `row.exportObject(keyStyle: syncContainer.keyStyle, dateFormatter: syncContainer.dateFormatter)`
-3. Each call to `exportObject`:
+2. For each row: `row.export(keyStyle: syncContainer.keyStyle, dateFormatter: syncContainer.dateFormatter)`
+3. Each call to `export`:
    - `state.enter(self)` — guard against cycles
    - For each non-`@NotExport` property:
       - Scalar: `exportEncodeValue(value, dateFormatter: dateFormatter)` → encode
      - Optional scalar: encode or NSNull if nil
-     - Relationship: recurse via `exportObject` on children
+     - Relationship: recurse via `export` on children
     - Key from `@RemoteKey` or `keyStyle.transform(propertyName)`
    - `exportSetValue(value, for: keyPath, into: &result)` — supports nested dot-path keys
    - `state.leave(self)`

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,6 @@ If you want the shortest description of the project:
 - Need parent-scoped sync/query rules: [parent-scope.md](project/parent-scope.md)
 - Need mapping/import/export rules: [property-mapping-contract.md](project/property-mapping-contract.md)
 - Need relationship edge-case guidance: [relationship-integrity.md](project/relationship-integrity.md)
-- Migrating from legacy `Sync`: [migrating-from-sync.md](project/migrating-from-sync.md)
 - Need short answers first: [faq.md](project/faq.md)
 
 ## Recommended Reading Order
@@ -33,7 +32,6 @@ If you want the shortest description of the project:
 - [backend-contract.md](project/backend-contract.md): recommended API shape for low-boilerplate sync
 - [faq.md](project/faq.md): short answers and cross-links
 - [manual-syncupdatablemodel.md](project/manual-syncupdatablemodel.md): manual conformance path
-- [migrating-from-sync.md](project/migrating-from-sync.md): how to approach the old Core Data `Sync` -> SwiftSync transition
 - [parent-scope.md](project/parent-scope.md): parent-scoped identity and query rules
 - [property-mapping-contract.md](project/property-mapping-contract.md): key mapping, `null`, export, and coercion rules
 - [reactive-reads.md](project/reactive-reads.md): `@SyncQuery`, `@SyncModel`, publishers, and app architecture guidance

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -37,13 +37,6 @@ branch. Work through them systematically; mark complete by deleting the line (pe
 
 ## Open items
 
-### Phase 2 — Fix doc drift
-
-- [ ] Rewrite `ARCHITECTURE.md` to match the real Package.swift module layout
-      (SwiftSync + ObjCExceptionCatcher libraries, MacrosImplementation macro, test targets).
-- [ ] Remove the two `migrating-from-sync.md` dangling links in `docs/README.md`.
-- [ ] Sweep all docs for dead cross-links and stale claims; add a link-check to CI (Phase 6).
-
 ### Phase 3 — DocC + publishable API documentation
 
 - [ ] Add a DocC catalog to the SwiftSync target with a landing page and curated topics.


### PR DESCRIPTION
Phase 2 of the world-class roadmap — fix doc drift.

## Changes
- **`ARCHITECTURE.md` Package Structure** — it described a fictional 7-module layout (`Core` / `SwiftDataBridge` / `Macros` / `TestingKit` / …) that never matched `Package.swift`. Rewrote it to the real structure: one `SwiftSync` library target + the `MacrosImplementation` compiler plugin + the `ObjCExceptionCatcher` ObjC helper, with an accurate "what lives where" table. Noted that the `@Syncable` macro *declarations* live in `SwiftSync` while the *implementation* lives in `MacrosImplementation`.
- **Stale `exportObject` references** — the generated/protocol method is `export(keyStyle:dateFormatter:)`. Fixed all 4 occurrences.
- **`docs/README.md`** — removed the two dangling `migrating-from-sync.md` links (the file doesn't exist; migration guide deferred).

## Verification
- Link-check across all 18 markdown files: **zero dead relative links**.
- Stale-symbol sweep: no remaining references to the fictional targets or `exportObject` (other than the sentence explaining they don't exist).
- The detailed sections (sync pipeline, concurrency lease, reactive query system, export, schema validation, ObjC bridge) were spot-checked against source and left intact — they're accurate.

Docs-only; no code changes.