### PR TITLE
docs: DocC catalog + CI doc-build gate (Phase 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,26 @@ jobs:
       - name: Test package
         working-directory: ${{ matrix.package.path }}
         run: swift test -v
+
+  docc-build:
+    name: DocC build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Cache SPM
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-docc-${{ hashFiles('Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-docc-
+
+      - name: Build documentation
+        run: |
+          set -o pipefail
+          swift package --allow-writing-to-directory ./.docc-out \
+            generate-documentation --target SwiftSync --output-path ./.docc-out 2>&1 | tee docc.log
+          if grep -q "warning:" docc.log; then
+            echo "::error::DocC emitted warnings (e.g. unresolved symbol links). Fix them and rebuild."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ DemoBackend/.build/
 DemoBackend/.swiftpm/
 DemoBackend/Package.resolved
 
+# DocC build output
+/.docc-out/
+
 # Xcode user data
 xcuserdata/
 *.xcuserdatad/

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,9 @@ let package = Package(
         .library(name: "SwiftSync", targets: ["SwiftSync"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0-latest")
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0-latest"),
+        // Doc generation only (`swift package generate-documentation`); not linked into the library.
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [
         .macro(

--- a/SwiftSync/Sources/SwiftSync/SwiftSync.docc/SwiftSync.md
+++ b/SwiftSync/Sources/SwiftSync/SwiftSync.docc/SwiftSync.md
@@ -1,0 +1,71 @@
+# ``SwiftSync``
+
+Keep SwiftData as the local source of truth while syncing conventional JSON APIs in and out, with explicit, predictable semantics.
+
+## Overview
+
+SwiftSync maps JSON payloads onto your SwiftData `@Model` types and back. Payload semantics are strict — an absent key is ignored (no mutation), while an explicit `null` clears the value — and key mapping is convention-based (snake_case ⇄ camelCase) with explicit overrides where you need them. Reads are reactive, so SwiftUI and UIKit update as the local store changes.
+
+A typical integration is three steps:
+
+1. **Define models once.** Annotate a SwiftData model with ``Syncable()`` (plus ``PrimaryKey(remote:)``, ``RemoteKey(_:)``, and ``NotExport()`` as needed) to synthesize its sync conformance.
+2. **Sync in and out.** Wrap your `ModelContainer` in a ``SyncContainer`` and call its sync and export methods.
+3. **Read reactively.** Use ``SyncQuery`` / ``SyncModel`` in SwiftUI, or ``SyncModelPublisher`` / ``SyncQueryPublisher`` in UIKit, to observe the local store.
+
+```swift
+@Syncable
+@Model
+final class Task {
+    @PrimaryKey var id: String
+    @RemoteKey("state.id") var stateID: String
+    var title: String
+    init(id: String, stateID: String, title: String) { … }
+}
+
+let container = SyncContainer(modelContainer)
+try await container.sync(payload, as: Task.self)
+```
+
+## Topics
+
+### Essentials
+
+- ``SyncContainer``
+
+### Defining Syncable Models
+
+- ``Syncable()``
+- ``PrimaryKey(remote:)``
+- ``RemoteKey(_:)``
+- ``NotExport()``
+- ``SyncModelable``
+- ``SyncUpdatableModel``
+- ``ParentScopedModel``
+
+### Payloads & Key Mapping
+
+- ``SyncPayload``
+- ``SyncPayloadConvertible``
+- ``KeyStyle``
+
+### Reactive Reads
+
+- ``SyncQuery``
+- ``SyncModel``
+- ``SyncModelPublisher``
+- ``SyncQueryPublisher``
+
+### Relationships
+
+- ``SyncRelationshipOperations``
+
+### Data Freshness & Loading
+
+- ``DataFreshnessPolicy``
+- ``ScopeSyncStatus``
+
+### Errors & Diagnostics
+
+- ``SyncError``
+- ``SyncContainer/SchemaValidationError``
+- ``SyncContainer/ObjectiveCInitializationExceptionError``

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -39,9 +39,9 @@ branch. Work through them systematically; mark complete by deleting the line (pe
 
 ### Phase 3 — DocC + publishable API documentation
 
-- [ ] Add a DocC catalog to the SwiftSync target with a landing page and curated topics.
-- [ ] Document every public symbol surviving the API-surface tightening (Phase 5).
-- [ ] Add a CI job that builds DocC (and optionally publishes to GitHub Pages).
+- [ ] Document every public symbol with doc comments, once the API surface is tightened
+      in Phase 5 (do it after, so we don't write docs for symbols that get demoted).
+- [ ] Optionally publish the built DocC archive to GitHub Pages.
 
 ### Phase 4 — Explicit SwiftData-modern stance
 


### PR DESCRIPTION
Phase 3 of the world-class roadmap — DocC **infrastructure** (per-symbol doc comments come after Phase 5 so we don't document soon-to-be-internal symbols).

## Changes
- **DocC catalog** at `SwiftSync/Sources/SwiftSync/SwiftSync.docc/SwiftSync.md` — a module landing page with an overview, a quick-start snippet, and curated `## Topics` groups: Essentials, Defining Syncable Models, Payloads & Key Mapping, Reactive Reads, Relationships, Data Freshness & Loading, Errors & Diagnostics.
- **`swift-docc-plugin`** added as a dependency (doc generation only — it's a command plugin, not linked into the library) so docs build with `swift package generate-documentation`.
- **`DocC build` CI job** in `ci.yml` that builds the docs and **fails on any DocC warning** (e.g. unresolved symbol links).
- Gitignore the DocC output dir.

## Verification
- `swift package generate-documentation --target SwiftSync` → builds with **zero warnings** locally (fixed the macro links to use signatures, e.g. ``Syncable()``, and the nested error links, e.g. ``SyncContainer/SchemaValidationError``).

## Notes
- The curated topics foreground the real entry points (`SyncContainer`, the `@Syncable` family, reactive types) and intentionally omit the lower-level symbols that Phase 5 will likely demote (`ExportState`, `ScreenLoadPlanner`, `FiniteAsyncRunner`, …). They still appear in DocC's auto-generated groups until then.
- `swift-docc-plugin` does enter the dependency graph for consumers — standard for DocC-enabled SPM libraries, flagged here for visibility.