### PR TITLE
refactor: tighten the public API surface (Phase 5)

### DIFF
--- a/SwiftSync/Sources/SwiftSync/DataFreshnessPolicy.swift
+++ b/SwiftSync/Sources/SwiftSync/DataFreshnessPolicy.swift
@@ -1,31 +1,31 @@
 import Foundation
 
-public struct DataKey: Hashable, Sendable {
-    public let namespace: String
-    public let id: String?
+struct DataKey: Hashable, Sendable {
+    let namespace: String
+    let id: String?
 
-    public init(namespace: String, id: String? = nil) {
+    init(namespace: String, id: String? = nil) {
         self.namespace = namespace
         self.id = id
     }
 }
 
-public enum LoadDecision: Sendable, Equatable {
+enum LoadDecision: Sendable, Equatable {
     case empty
     case fresh
     case stale
 }
 
-public struct DataFreshnessPolicy: Sendable {
-    public let defaultTTL: TimeInterval
-    public let ttlByNamespace: [String: TimeInterval]
+struct DataFreshnessPolicy: Sendable {
+    let defaultTTL: TimeInterval
+    let ttlByNamespace: [String: TimeInterval]
 
-    public init(defaultTTL: TimeInterval, ttlByNamespace: [String: TimeInterval]) {
+    init(defaultTTL: TimeInterval, ttlByNamespace: [String: TimeInterval]) {
         self.defaultTTL = defaultTTL
         self.ttlByNamespace = ttlByNamespace
     }
 
-    public func decision(
+    func decision(
         for key: DataKey,
         hasLocalData: Bool,
         lastSuccessfulSync: Date?,

--- a/SwiftSync/Sources/SwiftSync/FiniteAsyncRunner.swift
+++ b/SwiftSync/Sources/SwiftSync/FiniteAsyncRunner.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 @MainActor
-public final class FiniteAsyncRunner {
+final class FiniteAsyncRunner {
     private let sleep: @Sendable (UInt64) async throws -> Void
     private let operation: @Sendable (Int) async -> Void
     private let onStop: @MainActor () async -> Void
     private var workerTask: _Concurrency.Task<Void, Never>?
 
-    public private(set) var isRunning = false
+    private(set) var isRunning = false
 
-    public init(
+    init(
         sleep: @escaping @Sendable (UInt64) async throws -> Void,
         operation: @escaping @Sendable (Int) async -> Void,
         onStop: @escaping @MainActor () async -> Void
@@ -19,7 +19,7 @@ public final class FiniteAsyncRunner {
         self.onStop = onStop
     }
 
-    public func start(maxIterations: Int, intervalNanoseconds: UInt64) {
+    func start(maxIterations: Int, intervalNanoseconds: UInt64) {
         guard !isRunning, maxIterations > 0 else { return }
         isRunning = true
 
@@ -44,7 +44,7 @@ public final class FiniteAsyncRunner {
         }
     }
 
-    public func stop() {
+    func stop() {
         workerTask?.cancel()
         workerTask = nil
         isRunning = false

--- a/SwiftSync/Sources/SwiftSync/ScopeSyncStatus.swift
+++ b/SwiftSync/Sources/SwiftSync/ScopeSyncStatus.swift
@@ -1,24 +1,24 @@
 import Foundation
 
-public enum ScopeLoadPath: Sendable, Equatable, CaseIterable {
+enum ScopeLoadPath: Sendable, Equatable, CaseIterable {
     case localFirstRefresh
     case networkFirst
 }
 
-public enum ScopeSyncPhase: Sendable, Equatable {
+enum ScopeSyncPhase: Sendable, Equatable {
     case idle
     case loading
     case refreshing
     case failed
 }
 
-public struct ScopeSyncStatus: Sendable, Equatable {
-    public let phase: ScopeSyncPhase
-    public let path: ScopeLoadPath
-    public let errorMessage: String?
-    public let updatedAt: Date
+struct ScopeSyncStatus: Sendable, Equatable {
+    let phase: ScopeSyncPhase
+    let path: ScopeLoadPath
+    let errorMessage: String?
+    let updatedAt: Date
 
-    public init(phase: ScopeSyncPhase, path: ScopeLoadPath, errorMessage: String?, updatedAt: Date) {
+    init(phase: ScopeSyncPhase, path: ScopeLoadPath, errorMessage: String?, updatedAt: Date) {
         self.phase = phase
         self.path = path
         self.errorMessage = errorMessage
@@ -26,8 +26,8 @@ public struct ScopeSyncStatus: Sendable, Equatable {
     }
 }
 
-public enum ScopeSyncStatusReducer {
-    public static func start(path: ScopeLoadPath, now: Date = Date()) -> ScopeSyncStatus {
+enum ScopeSyncStatusReducer {
+    static func start(path: ScopeLoadPath, now: Date = Date()) -> ScopeSyncStatus {
         ScopeSyncStatus(
             phase: path == .localFirstRefresh ? .refreshing : .loading,
             path: path,
@@ -36,7 +36,7 @@ public enum ScopeSyncStatusReducer {
         )
     }
 
-    public static func succeed(previous: ScopeSyncStatus, now: Date = Date()) -> ScopeSyncStatus {
+    static func succeed(previous: ScopeSyncStatus, now: Date = Date()) -> ScopeSyncStatus {
         ScopeSyncStatus(
             phase: .idle,
             path: previous.path,
@@ -45,7 +45,7 @@ public enum ScopeSyncStatusReducer {
         )
     }
 
-    public static func fail(previous: ScopeSyncStatus, errorMessage: String, now: Date = Date()) -> ScopeSyncStatus {
+    static func fail(previous: ScopeSyncStatus, errorMessage: String, now: Date = Date()) -> ScopeSyncStatus {
         ScopeSyncStatus(
             phase: .failed,
             path: previous.path,

--- a/SwiftSync/Sources/SwiftSync/ScreenLoadPlanner.swift
+++ b/SwiftSync/Sources/SwiftSync/ScreenLoadPlanner.swift
@@ -1,5 +1,5 @@
-public enum ScreenLoadPlanner {
-    public static func path(decisions: [LoadDecision]) -> ScopeLoadPath {
+enum ScreenLoadPlanner {
+    static func path(decisions: [LoadDecision]) -> ScopeLoadPath {
         if !decisions.isEmpty, decisions.allSatisfy({ $0 == .fresh }) {
             return .localFirstRefresh
         }

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -26,12 +26,14 @@ branch. Work through them systematically; mark complete by deleting the line (pe
   version + iOS 18 floor; covers all tested surface.
 - `migrating-from-sync.md`: **remove the two dangling links** (docs/README.md); defer any
   migration guide.
+- Public extension points: the low-level helpers (`syncApplyTo*`, `exportSetValue`,
+  `exportEncodeValue`, `ExportState`, `SyncRelationshipSchemaDescriptor`,
+  `SyncRelationshipOperations`) **stay public by contract** — the `@Syncable` expansion emits
+  calls to them in the *consumer's* module, so demoting them breaks every consumer. The
+  accidental publics were the load-planning/freshness internals, now demoted to `internal`.
 
 ## Open decisions (resolve before/while doing the items they block)
 
-- [ ] Decide intended public extension points: which low-level sync helpers
-      (`syncApplyToOneForeignKey`, `exportSetValue`, `ExportState`, …) are deliberate
-      seams vs. accidentally-public implementation detail.
 - [ ] Decide SwiftData-modern stance per feature (`#Unique`, `#Index`, history API,
       custom `DataStore`, `#Expression`): adopt, interop-and-document, or out-of-scope.
 
@@ -52,9 +54,8 @@ branch. Work through them systematically; mark complete by deleting the line (pe
 
 ### Phase 5 — Tighten the public API surface
 
-- [ ] Audit all `public` symbols; demote low-level sync helpers to `internal`/`package`
-      unless the decision marks them as intended extension points.
-- [ ] Document the intended public surface and supported extension points in DocC.
+- [ ] Document the intended public surface and the macro-support extension points (the
+      helpers that must stay public) so they aren't mistakenly demoted later.
 
 ### Phase 6 — CI gates for world-class hygiene
 


### PR DESCRIPTION
Phase 5 of the world-class roadmap — remove accidental publics before a serious release.

## The key finding
The external review flagged `syncApplyToOneForeignKey`, `exportSetValue`, `ExportState`, etc. as "too internal to be public." They're actually **load-bearing public API**: the `@Syncable` macro expands *in the consumer's module* and emits calls to them, so demoting them would break every consumer. They stay public by contract.

Method for finding the *real* accidental publics: cross-reference every public symbol against (a) what the macro emits, (b) what the demo consumers use, (c) docs. The ones with **zero** macro/consumer/doc references were the internal load-planning & freshness mechanism.

## Demoted `public` → `internal`
`DataKey`, `LoadDecision`, `DataFreshnessPolicy`, `FiniteAsyncRunner`, `ScopeLoadPath`, `ScopeSyncPhase`, `ScopeSyncStatus`, `ScopeSyncStatusReducer`, `ScreenLoadPlanner` (4 files). None are referenced by the macro, the demo apps, or the docs; tests reach them via `@testable`.

## Verification
- Root: `swift build` clean (no "public X exposes internal type Y"), **153 + 48 tests pass**.
- **DemoCore** (real `@Syncable` consumer): build complete.
- **Demo app** (iOS Simulator): BUILD SUCCEEDED.

So the macro-support surface is intact and only genuine internals were hidden. Recorded the "these helpers stay public by contract" decision in the roadmap so they're not mistakenly demoted later.