### PR TITLE
docs: SwiftData feature evaluation plan + #Index result (Phase 4)

### DIFF
--- a/docs/planning/swiftdata-modern-features.md
+++ b/docs/planning/swiftdata-modern-features.md
@@ -1,0 +1,42 @@
+# SwiftData-Modern Features — Evaluation Plan
+
+Roadmap Phase 4. We evaluate each modern SwiftData feature (WWDC24+) **one at a time, hands-on**:
+
+1. **Implement / adopt** it into SwiftSync (or the demo).
+2. **Measure before/after** — a perf benchmark for performance features (the `FetchStrategyBenchmarkTests` harness), or a before/after **developer-experience** comparison for ergonomics features.
+3. **Decide** — keep it only if it genuinely improves things and *feels natural*; otherwise record why not.
+4. **Document** the outcome here.
+
+One feature = one workstream = one PR. Record the baseline on the same benchmark before changing anything (per AGENTS.md).
+
+## Status
+
+| Feature | Status | Outcome |
+|---|---|---|
+| `#Index` | ✅ evaluated | **Not adopted in the library** (see below) |
+| `#Unique` | ⬜ todo | — |
+| `#Expression` / richer predicates | ⬜ todo | — |
+| History API | ⬜ todo | — |
+| Custom `DataStore` | ⬜ todo | — |
+
+## Findings
+
+### `#Index` — evaluated, not adopted (library level)
+
+Measured parent-scoped sync on a SQLite store, 20 000 total rows, 100 in-scope, 3 samples each (`FetchStrategyBenchmarkTests`):
+
+| Scenario | Baseline (no index) | `#Index([\.project])` |
+|---|---|---|
+| parent-scoped single-item sync | 28.2 ms | 27.4 ms |
+| parent-scoped batch sync | 40.1 ms | 40.2 ms |
+
+Both within noise. Reason: SwiftSync identifies rows by `syncIdentity`, which is conventionally `@Attribute(.unique)` — and SwiftData already indexes unique attributes. That index dominates the fetch; the residual cost is row materialization/save, which an extra index can't help (it only adds write-time maintenance).
+
+**Stance:** `#Index` is **consumer-optional** — apps can add it to their *own* non-unique query/sort columns if profiling shows a need. SwiftSync does not auto-generate it in `@Syncable` (no read benefit on its access patterns, and it would slow writes).
+
+## Open items
+
+- [ ] `#Unique`: try compound uniqueness on a model and compare DX vs the current `@Attribute(.unique)` + `syncIdentity` convention; does it simplify identity modeling or conflict with sync upserts?
+- [ ] `#Expression` / richer predicates: use in a `@SyncQuery`/`SyncQueryPublisher` predicate; does it improve query ergonomics for consumers?
+- [ ] History API: evaluate whether `HistoryDescriptor`/transaction history can replace or strengthen the `didSave` + `syncMarkChanged` dirty-tracking workaround, and feed change-export (links to the Phase 7 production-sync story).
+- [ ] Custom `DataStore`: confirm SwiftSync works against a custom store; document the contract it relies on (fetch, save, relationship faulting, `didSave` notifications) and any caveats.

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -47,10 +47,10 @@ branch. Work through them systematically; mark complete by deleting the line (pe
 
 ### Phase 4 — Explicit SwiftData-modern stance
 
-- [ ] Write a doc stating SwiftSync's position on `#Unique`, `#Index`, the history API,
-      custom `DataStore`, and `#Expression`/richer predicates — interop rules + rationale.
-- [ ] Adopt the features that genuinely improve the library (e.g. `#Index` on sync keys),
-      with red-first tests; document the rest as interop-only.
+Tracked feature-by-feature in `docs/planning/swiftdata-modern-features.md` (implement →
+measure before/after → decide → document; one feature per PR). `#Index` is evaluated
+(not adopted — identity is already unique-indexed). Remaining: `#Unique`, `#Expression`,
+History API, custom `DataStore`.
 
 ### Phase 5 — Tighten the public API surface
 


### PR DESCRIPTION
Sets up the missing structure for Phase 4: a **per-feature evaluation plan** worked one item at a time, plus the first item's result.

## Plan doc — `docs/planning/swiftdata-modern-features.md`
Each modern SwiftData feature is its own workstream: **implement → measure before/after (perf benchmark or DX) → decide (keep only if it earns its place) → document**. One feature = one PR. Roadmap Phase 4 now points here. Status table tracks: `#Index` (done), `#Unique`, `#Expression`, History API, custom `DataStore` (todo).

## First item — `#Index`: evaluated, not adopted
Measured parent-scoped sync, SQLite, 20k rows, 3 samples (`FetchStrategyBenchmarkTests`):

| Scenario | Baseline | `#Index([\.project])` |
|---|---|---|
| single-item | 28.2 ms | 27.4 ms |
| batch | 40.1 ms | 40.2 ms |

Both within noise. SwiftSync identifies rows by `syncIdentity` = `@Attribute(.unique)`, which SwiftData already indexes; that dominates the fetch, so an extra `#Index` adds write-time maintenance for no read gain. **Stance:** consumer-optional (apps can index their own non-unique query columns); not auto-generated by `@Syncable`.

Doc-only PR (the benchmark `#Index` was added only to measure, then reverted). Next: `#Unique`, in its own worktree/PR.