### PR TITLE
feat: reject uniqueness on non-identity fields (Phase 4: #Index/#Unique interop)

### DIFF
--- a/SwiftSync/Sources/MacrosImplementation/SyncableMacro.swift
+++ b/SwiftSync/Sources/MacrosImplementation/SyncableMacro.swift
@@ -103,6 +103,7 @@ public struct SyncableMacro: ExtensionMacro {
                     \(raw: memberAccessModifier)typealias SyncID = \(raw: identityProperty.typeSource)
 
                     \(raw: memberAccessModifier)static var syncIdentity: KeyPath<\(raw: typeName), \(raw: identityProperty.typeSource)> { \\.\(raw: identityProperty.name) }
+                    \(raw: memberAccessModifier)static var syncIdentityPropertyName: String { "\(raw: identityProperty.name)" }
                     \(raw: memberAccessModifier)static func syncIdentityPredicate(matching identity: \(raw: identityProperty.typeSource)) -> Predicate<\(raw: typeName)>? {
                         Predicate<\(raw: typeName)> { row in
                             PredicateExpressions.build_Equal(

--- a/SwiftSync/Sources/SwiftSync/Core.swift
+++ b/SwiftSync/Sources/SwiftSync/Core.swift
@@ -50,6 +50,9 @@ public enum SwiftSync {}
 public protocol SyncModelable: PersistentModel {
     associatedtype SyncID: Hashable & Codable & Sendable
     static var syncIdentity: KeyPath<Self, SyncID> { get }
+    /// Swift property name of the identity (synthesised by `@Syncable`). Empty for hand-written
+    /// conformances; used by `SyncContainer` to reject uniqueness constraints on non-identity fields.
+    static var syncIdentityPropertyName: String { get }
     static func syncIdentityPredicate(matching identity: SyncID) -> Predicate<Self>?
     static func syncIdentityPredicate(matchingAny identities: [SyncID]) -> Predicate<Self>?
     static func syncParentPredicate(
@@ -63,6 +66,7 @@ public protocol SyncModelable: PersistentModel {
 }
 
 extension SyncModelable {
+    public static var syncIdentityPropertyName: String { "" }
     public static var syncIdentityRemoteKeys: [String] { ["id", "remote_id", "remoteID"] }
     public static func syncIdentityPredicate(matching _: SyncID) -> Predicate<Self>? { nil }
     public static func syncIdentityPredicate(matchingAny _: [SyncID]) -> Predicate<Self>? { nil }

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -316,6 +316,39 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
                     """
             )
         }
+
+        try _validateUniquenessConstraints(modelTypes: modelTypes)
+    }
+
+    /// Uniqueness must live only on the sync identity. A unique constraint (`@Attribute(.unique)`
+    /// or `#Unique`, single or compound) on any other property lets SwiftData's constraint-based
+    /// upsert silently destroy identity-distinct rows during sync — breaking SwiftSync's one-row-
+    /// per-`syncIdentity` invariant. Enforced for `@Syncable` models (which synthesise
+    /// `syncIdentityPropertyName`); hand-written conformances opt out by leaving it empty.
+    static func _validateUniquenessConstraints(
+        modelTypes: [any PersistentModel.Type]
+    ) throws {
+        let entitiesByName = Dictionary(
+            Schema(modelTypes).entities.map { ($0.name, $0) }, uniquingKeysWith: { lhs, _ in lhs })
+
+        for modelType in modelTypes {
+            guard let syncType = modelType as? any SyncModelable.Type else { continue }
+            let identityName = syncType.syncIdentityPropertyName
+            guard !identityName.isEmpty else { continue }
+            guard let entity = entitiesByName[String(describing: modelType)] else { continue }
+
+            for constraint in entity.uniquenessConstraints where constraint != [identityName] {
+                throw SchemaValidationError(
+                    message: """
+                        \(String(reflecting: modelType)) declares a uniqueness constraint on \(constraint), \
+                        which is not the sync identity ("\(identityName)"). A unique constraint on a \
+                        non-identity property causes silent data loss during sync: SwiftData's \
+                        constraint-based upsert overwrites identity-distinct rows that collide on it. \
+                        Declare uniqueness only on the sync identity.
+                        """
+                )
+            }
+        }
     }
 
     static func _schemaRelationships(from modelTypes: [any PersistentModel.Type]) -> [_SchemaRelationship] {

--- a/SwiftSync/Sources/SwiftSync/SyncableMacro.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncableMacro.swift
@@ -1,5 +1,6 @@
 @attached(
     extension, conformances: SyncUpdatableModel, names: named(SyncID), named(syncIdentity),
+    named(syncIdentityPropertyName),
     named(syncIdentityPredicate), named(syncParentPredicate), named(syncIdentityRemoteKeys),
     named(syncDefaultRefreshModelTypes), named(syncRelatedModelType), named(syncRelationshipSchemaDescriptors),
     named(make), named(apply), named(applyRelationships), named(syncApplyGeneratedRelationships), named(export),

--- a/SwiftSync/Tests/SwiftSyncMacrosTests/SyncableMacroDiagnosticsTests.swift
+++ b/SwiftSync/Tests/SwiftSyncMacrosTests/SyncableMacroDiagnosticsTests.swift
@@ -57,6 +57,9 @@ final class SyncableMacroDiagnosticsTests: XCTestCase {
                     public static var syncIdentity: KeyPath<Ticket, String> {
                         \\.id
                     }
+                    public static var syncIdentityPropertyName: String {
+                        "id"
+                    }
                     public static func syncIdentityPredicate(matching identity: String) -> Predicate<Ticket>? {
                         Predicate<Ticket> { row in
                             PredicateExpressions.build_Equal(
@@ -198,6 +201,9 @@ final class SyncableMacroDiagnosticsTests: XCTestCase {
 
                     static var syncIdentity: KeyPath<Note, Int> {
                         \\.id
+                    }
+                    static var syncIdentityPropertyName: String {
+                        "id"
                     }
                     static func syncIdentityPredicate(matching identity: Int) -> Predicate<Note>? {
                         Predicate<Note> { row in

--- a/SwiftSync/Tests/SwiftSyncTests/SyncFeatureInteropTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncFeatureInteropTests.swift
@@ -1,0 +1,176 @@
+import SwiftData
+import XCTest
+
+@testable import SwiftSync
+
+// Models that bolt modern SwiftData features onto an otherwise-correct @Syncable model,
+// to characterise how those features interact with SwiftSync's identity/upsert patterns.
+
+// `#Index` on a non-identity field.
+@Syncable
+@Model
+final class InteropIndexedNote {
+    #Index<InteropIndexedNote>([\.category])
+    @Attribute(.unique) var id: Int
+    var title: String
+    var category: String
+    init(id: Int, title: String, category: String) {
+        self.id = id
+        self.title = title
+        self.category = category
+    }
+}
+
+// `@Attribute(.unique)` on a non-identity field.
+@Syncable
+@Model
+final class InteropUniqueEmailUser {
+    @Attribute(.unique) var id: Int
+    @Attribute(.unique) var email: String
+    var name: String
+    init(id: Int, email: String, name: String) {
+        self.id = id
+        self.email = email
+        self.name = name
+    }
+}
+
+// Compound `#Unique` across non-identity fields.
+@Syncable
+@Model
+final class InteropCompoundUniqueEvent {
+    #Unique<InteropCompoundUniqueEvent>([\.name, \.day])
+    @Attribute(.unique) var id: Int
+    var name: String
+    var day: String
+    init(id: Int, name: String, day: String) {
+        self.id = id
+        self.name = name
+        self.day = day
+    }
+}
+
+final class SyncFeatureInteropTests: XCTestCase {
+
+    /// `#Index` on a non-identity property is transparent to SwiftSync: it only affects query
+    /// planning, so identity-based upsert is unaffected. This is the "safe to use freely" case.
+    @MainActor
+    func testIndexOnNonIdentityFieldIsTransparentToSync() async throws {
+        let context = ModelContext(
+            try ModelContainer(
+                for: InteropIndexedNote.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
+
+        try await SwiftSync.sync(
+            payload: [
+                ["id": 1, "title": "A", "category": "x"],
+                ["id": 2, "title": "B", "category": "x"],
+            ], as: InteropIndexedNote.self, in: context)
+
+        // Re-sync id 1 with changed fields — must update the same row, not create a new one.
+        try await SwiftSync.sync(
+            item: ["id": 1, "title": "A2", "category": "y"], as: InteropIndexedNote.self,
+            in: context)
+
+        let notes = try context.fetch(FetchDescriptor<InteropIndexedNote>())
+        XCTAssertEqual(notes.count, 2, "#Index must not change row identity or count")
+        XCTAssertEqual(
+            notes.first { $0.id == 1 }?.title, "A2", "upsert-by-id must still update in place")
+    }
+
+    /// A unique constraint on a *non-identity* property breaks SwiftSync's core invariant
+    /// (one row per `syncIdentity`). When sync inserts an identity-distinct row whose unique
+    /// field collides with an existing row, SwiftData performs a constraint-based upsert and
+    /// silently overwrites/destroys the other row — local data ends up disagreeing with the
+    /// backend, with no error. Put uniqueness only on the sync identity.
+    @MainActor
+    func testUniqueOnNonIdentityFieldCausesSilentSyncDataLoss() async throws {
+        XCTExpectFailure(
+            "Known incompatibility: a unique constraint on a non-identity property lets SwiftData's constraint-based upsert destroy identity-distinct rows during sync. Declare uniqueness only on the sync identity."
+        )
+
+        let context = ModelContext(
+            try ModelContainer(
+                for: InteropUniqueEmailUser.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
+
+        try await SwiftSync.sync(
+            item: ["id": 1, "email": "a@x.com", "name": "Alice"], as: InteropUniqueEmailUser.self,
+            in: context)
+        // id 2 is a distinct record per SwiftSync identity, but collides on the unique email.
+        try await SwiftSync.sync(
+            item: ["id": 2, "email": "a@x.com", "name": "Bob"], as: InteropUniqueEmailUser.self,
+            in: context)
+
+        let users = try context.fetch(FetchDescriptor<InteropUniqueEmailUser>())
+        XCTAssertEqual(users.count, 2, "both identity-distinct rows should survive")
+        XCTAssertTrue(users.contains { $0.id == 1 }, "the original row must not be destroyed")
+    }
+
+    /// Compound `#Unique` across non-identity fields has the same hazard as a single-field
+    /// unique constraint: an identity-distinct row that collides on the compound key destroys
+    /// the existing row during sync.
+    @MainActor
+    func testCompoundUniqueOnSyncedFieldsCausesSilentSyncDataLoss() async throws {
+        XCTExpectFailure(
+            "Known incompatibility: compound #Unique on synced fields lets SwiftData destroy identity-distinct rows during sync. Declare uniqueness only on the sync identity."
+        )
+
+        let context = ModelContext(
+            try ModelContainer(
+                for: InteropCompoundUniqueEvent.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
+
+        try await SwiftSync.sync(
+            item: ["id": 1, "name": "Launch", "day": "Mon"], as: InteropCompoundUniqueEvent.self,
+            in: context)
+        try await SwiftSync.sync(
+            item: ["id": 2, "name": "Launch", "day": "Mon"], as: InteropCompoundUniqueEvent.self,
+            in: context)
+
+        let events = try context.fetch(FetchDescriptor<InteropCompoundUniqueEvent>())
+        XCTAssertEqual(events.count, 2, "both identity-distinct rows should survive")
+        XCTAssertTrue(events.contains { $0.id == 1 }, "the original row must not be destroyed")
+    }
+
+    // MARK: - Guardrail: SyncContainer refuses the data-loss footgun at init
+
+    /// `#Index` on a non-identity field is safe, so a `SyncContainer` built from such a model
+    /// initialises normally.
+    @MainActor
+    func testSyncContainerAcceptsIndexAndIdentityUniqueModel() throws {
+        XCTAssertNoThrow(
+            try SyncContainer(
+                for: InteropIndexedNote.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
+    }
+
+    /// A `@Syncable` model with `@Attribute(.unique)` on a non-identity field must be rejected at
+    /// `SyncContainer` init — same guardrail style as the many-to-many inverse check.
+    @MainActor
+    func testSyncContainerRejectsUniqueOnNonIdentityField() throws {
+        XCTAssertThrowsError(
+            try SyncContainer(
+                for: InteropUniqueEmailUser.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        ) { error in
+            XCTAssertTrue(
+                error is SyncContainer.SchemaValidationError,
+                "expected SchemaValidationError, got \(error)")
+        }
+    }
+
+    /// Compound `#Unique` across non-identity fields is rejected at `SyncContainer` init.
+    @MainActor
+    func testSyncContainerRejectsCompoundUniqueOnNonIdentityFields() throws {
+        XCTAssertThrowsError(
+            try SyncContainer(
+                for: InteropCompoundUniqueEvent.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        ) { error in
+            XCTAssertTrue(
+                error is SyncContainer.SchemaValidationError,
+                "expected SchemaValidationError, got \(error)")
+        }
+    }
+}

--- a/docs/project/property-mapping-contract.md
+++ b/docs/project/property-mapping-contract.md
@@ -131,3 +131,23 @@ Supported scalar coercions on inbound attribute reads include:
 - string/number -> `Date` via parser and unix timestamp handling
 
 Strict reads (`strictValue`, relationship FK linking) remain non-coercive by design.
+
+## Uniqueness Constraints (identity only)
+
+Declare uniqueness **only on the sync identity** (the `id` / `@PrimaryKey` property). Do **not**
+put `@Attribute(.unique)` or `#Unique` (single or compound) on any other property of a synced model.
+
+SwiftSync identifies rows by `syncIdentity` and upserts by fetching the existing row, then
+updating or inserting — one row per identity is the core invariant. SwiftData enforces unique
+constraints with its own *constraint-based* upsert: inserting a row that collides on a unique
+property silently overwrites the existing row. When those two disagree — e.g. two
+identity-distinct records that happen to share a `email` you marked unique — sync **silently
+destroys** one of them, and the local store ends up with fewer rows than the backend sent, with
+no error.
+
+Guardrail: `SyncContainer` validates this at init and throws `SchemaValidationError` if a
+`@Syncable` model declares a uniqueness constraint on a non-identity property (alongside the
+existing many-to-many inverse check). `#Index` on any property is unaffected — it only changes
+query planning and is safe to use freely. Hand-written `SyncUpdatableModel` conformances are not
+checked (they leave `syncIdentityPropertyName` empty); the same rule applies to them by
+convention.


### PR DESCRIPTION
Closes the Phase 4 `#Index`/`#Unique` evaluation by testing how these features interact with SwiftSync's patterns when a consumer bolts them onto an otherwise-correct `@Syncable` model — and adds a guardrail for the dangerous case.

## Findings (characterization tests)
- **`#Index` anywhere → transparent.** Only affects query planning; identity-based upsert is unaffected. Asserted safe.
- **A unique constraint on a non-identity field → silent data loss.** `@Attribute(.unique)` or `#Unique` (single or compound) on a non-identity property breaks SwiftSync's one-row-per-`syncIdentity` invariant: SwiftData's constraint-based upsert overwrites identity-distinct rows during sync (verified — an identity-distinct insert that collides on a unique field *destroys* the existing row, no error). Documented with `XCTExpectFailure` tests on the raw-sync path, mirroring the existing many-to-many footgun.

## Guardrail
`SyncContainer` init now throws `SchemaValidationError` when a `@Syncable` model declares a uniqueness constraint on a non-identity property — alongside the existing many-to-many inverse check. Implemented via a new macro-synthesised `syncIdentityPropertyName` + SwiftData's `Schema.uniquenessConstraints`. Makes the footgun *unrepresentable* rather than just documented. Hand-written `SyncUpdatableModel` conformances opt out (empty identity name); same rule applies by convention.

## Verification
- 159 macOS tests + 48 swift-testing green; no existing model trips the guardrail.
- DemoCore (real `@Syncable` consumer) green.
- Doc caveat added to `property-mapping-contract.md`.

Touches `Core.swift` + the macro → `ios-regression.yml` runs on merge.