### PR TITLE
docs: custom DataStore compatibility; close Phase 4; History -> Phase 7

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ If you want the shortest description of the project:
 - [relationship-integrity.md](project/relationship-integrity.md): many-to-many inverse anchor guidance
 - [fetch-strategy-under-load.md](project/fetch-strategy-under-load.md): performance framing for query strategy
 - [ios-dirty-tracking-gap.md](project/ios-dirty-tracking-gap.md): known SwiftData observation caveat
+- [custom-datastore-compat.md](project/custom-datastore-compat.md): what a custom SwiftData store must support
 
 ## Internal Project Workflow Docs
 

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -45,13 +45,6 @@ branch. Work through them systematically; mark complete by deleting the line (pe
 - [ ] Document every public symbol surviving the API-surface tightening (Phase 5).
 - [ ] Add a CI job that builds DocC (and optionally publishes to GitHub Pages).
 
-### Phase 4 — Explicit SwiftData-modern stance
-
-- [ ] Write a doc stating SwiftSync's position on `#Unique`, `#Index`, the history API,
-      custom `DataStore`, and `#Expression`/richer predicates — interop rules + rationale.
-- [ ] Adopt the features that genuinely improve the library (e.g. `#Index` on sync keys),
-      with red-first tests; document the rest as interop-only.
-
 ### Phase 5 — Tighten the public API surface
 
 - [ ] Document the intended public surface and the macro-support extension points (the
@@ -68,10 +61,13 @@ branch. Work through them systematically; mark complete by deleting the line (pe
 
 ### Phase 7 — Define the production-sync story (design-first)
 
+The **SwiftData History API** is the foundation here: querying what changed locally since a
+token (with delete tombstones) is how outbound/offline change export works. High-value, but a
+design-first, substantial effort — not a quick bolt-on. Evaluated and deferred here from Phase 4
+for that reason; SwiftSync has no outbound/change-tracking path today.
+
 - [ ] Write a design doc framing the gap from "sync-assist" to "production sync":
       conflict resolution, offline mutation queue, retry/backoff, observability hooks,
-      schema-migration policy, history-based local change export, CloudKit coexistence,
-      and versioned API stability.
+      schema-migration policy, history-based local change export (via the History API),
+      CloudKit coexistence, and versioned API stability.
 - [ ] Break each accepted area into its own dedicated implementation item once designed.
-</content>
-</invoke>

--- a/docs/project/custom-datastore-compat.md
+++ b/docs/project/custom-datastore-compat.md
@@ -3,32 +3,35 @@
 ## Short answer
 
 SwiftSync is **store-agnostic**. It works with any `ModelContainer` — the default SQLite store
-or a custom SwiftData `DataStore` — as long as the store honours standard SwiftData semantics
-(below). SwiftSync never touches `DataStoreConfiguration` or any store internals.
+or a custom SwiftData `DataStore` — provided the store honours the standard SwiftData semantics
+below. SwiftSync only uses public, store-neutral SwiftData APIs; it never configures or reaches
+into the store layer (no `DataStoreConfiguration` or store internals).
 
-## What SwiftSync actually depends on
+## The contract a backing store must satisfy
 
-Determined by auditing SwiftSync's SwiftData API surface (`ModelContext` ×40, `FetchDescriptor`
-×18, `PersistentIdentifier` ×17, `ModelContext.didSave` ×7, plus `Schema` / `ModelContainer` /
-`ModelConfiguration`). A backing store must support:
+SwiftSync drives sync entirely through standard `ModelContext` operations, so a custom store is
+compatible as long as it supports:
 
-1. **`ModelContext.fetch(_:)` with `FetchDescriptor`** — `#Predicate` filtering and `sortBy`.
-   Used for identity lookups, parent-scope queries, and `@SyncQuery` reads.
-2. **`insert` / `save` / `delete`** and **relationship persistence + faulting** (to-one and
-   to-many) — the upsert and relationship-resolution machinery.
-3. **`ModelContext.didSave` notifications** carrying inserted/updated/deleted
-   `PersistentIdentifier`s — the linchpin for reactive reads. **This is the one to watch:** if a
-   custom store does not post `didSave`, inbound sync still works, but `@SyncQuery` / `@SyncModel`
-   and the publishers won't auto-refresh (you'd have to refresh manually). See
-   [ios-dirty-tracking-gap.md](ios-dirty-tracking-gap.md) for a related `didSave` nuance.
-4. **`ModelContainer(for:configurations:)`** initialisation. NSExceptions thrown during init are
-   caught by SwiftSync's ObjC bridge regardless of store.
+1. **Fetching** — `ModelContext.fetch` with a `FetchDescriptor` (`#Predicate` filtering and
+   `sortBy`): identity lookups, parent-scope queries, and `@SyncQuery` reads.
+2. **Mutation & relationships** — `insert` / `save` / `delete`, plus persistence and faulting of
+   to-one and to-many relationships (the upsert and relationship-resolution machinery).
+3. **Save notifications** — `ModelContext.didSave` carrying the changed model identifiers.
+   **This is the one to watch:** it drives reactive reads. If a store doesn't post `didSave`,
+   inbound sync still works, but `@SyncQuery` / `@SyncModel` and the publishers won't auto-refresh
+   (you'd refresh manually). See [ios-dirty-tracking-gap.md](ios-dirty-tracking-gap.md) for a
+   related `didSave` nuance.
+4. **Container initialisation** — `ModelContainer(for:configurations:)`. NSExceptions thrown
+   during init are caught by SwiftSync's ObjC bridge on any store.
+
+To confirm compatibility for a specific store, exercise those four behaviours end-to-end. This
+list is the durable contract — SwiftSync's internal call sites will change across refactors, but
+what it *requires of a store* is the above.
 
 ## Caveats
 
-- Unique-constraint **upsert** behaviour is the store's, not SwiftSync's. The uniqueness rule in
+- Unique-constraint **upsert** behaviour belongs to the store, not SwiftSync. The rule in
   [property-mapping-contract.md](property-mapping-contract.md) (uniqueness only on the sync
   identity) applies on any store.
-- This compatibility is established by API-surface audit, not by a live run against a bespoke
-  `DataStore`. A smoke test against a real custom store is a reasonable future addition; the
-  contract above is what such a store must satisfy.
+- This contract is derived from the behaviours SwiftSync uses, not from a live run against a
+  bespoke `DataStore`. A smoke test against a real custom store is a reasonable future addition.

--- a/docs/project/custom-datastore-compat.md
+++ b/docs/project/custom-datastore-compat.md
@@ -1,0 +1,34 @@
+# Custom `DataStore` Compatibility
+
+## Short answer
+
+SwiftSync is **store-agnostic**. It works with any `ModelContainer` — the default SQLite store
+or a custom SwiftData `DataStore` — as long as the store honours standard SwiftData semantics
+(below). SwiftSync never touches `DataStoreConfiguration` or any store internals.
+
+## What SwiftSync actually depends on
+
+Determined by auditing SwiftSync's SwiftData API surface (`ModelContext` ×40, `FetchDescriptor`
+×18, `PersistentIdentifier` ×17, `ModelContext.didSave` ×7, plus `Schema` / `ModelContainer` /
+`ModelConfiguration`). A backing store must support:
+
+1. **`ModelContext.fetch(_:)` with `FetchDescriptor`** — `#Predicate` filtering and `sortBy`.
+   Used for identity lookups, parent-scope queries, and `@SyncQuery` reads.
+2. **`insert` / `save` / `delete`** and **relationship persistence + faulting** (to-one and
+   to-many) — the upsert and relationship-resolution machinery.
+3. **`ModelContext.didSave` notifications** carrying inserted/updated/deleted
+   `PersistentIdentifier`s — the linchpin for reactive reads. **This is the one to watch:** if a
+   custom store does not post `didSave`, inbound sync still works, but `@SyncQuery` / `@SyncModel`
+   and the publishers won't auto-refresh (you'd have to refresh manually). See
+   [ios-dirty-tracking-gap.md](ios-dirty-tracking-gap.md) for a related `didSave` nuance.
+4. **`ModelContainer(for:configurations:)`** initialisation. NSExceptions thrown during init are
+   caught by SwiftSync's ObjC bridge regardless of store.
+
+## Caveats
+
+- Unique-constraint **upsert** behaviour is the store's, not SwiftSync's. The uniqueness rule in
+  [property-mapping-contract.md](property-mapping-contract.md) (uniqueness only on the sync
+  identity) applies on any store.
+- This compatibility is established by API-surface audit, not by a live run against a bespoke
+  `DataStore`. A smoke test against a real custom store is a reasonable future addition; the
+  contract above is what such a store must satisfy.


### PR DESCRIPTION
Closes out Phase 4 with the custom-`DataStore` compatibility check and the plan updates.

## Custom `DataStore` compatibility (the check)
Audited SwiftSync's SwiftData API surface: `ModelContext` (fetch/insert/save/delete), `FetchDescriptor`, `ModelContext.didSave`, `Schema`/`ModelContainer`/`ModelConfiguration` — and **no** `DataStoreConfiguration` or store internals. So SwiftSync is **store-agnostic**: it works on the default SQLite store or any custom `DataStore` that honours standard SwiftData semantics. New `docs/project/custom-datastore-compat.md` documents the contract a custom store must satisfy, calling out `ModelContext.didSave` as the reactivity linchpin. (Established by API-surface audit, not a live bespoke-store run — that's a noted future smoke test; a full custom store is disproportionate to a compatibility *check*.)

## Plan updates
- **Phase 4 closed.** `#Index` (safe, no-op) and `#Unique` (footgun → guarded) shipped in #611; `#Expression` + custom `DataStore` are interop, now documented.
- **History API → Phase 7.** Recorded that it's the foundation for outbound/offline sync (change export) — high value but a design-first, substantial effort, deferred from Phase 4 (SwiftSync has no outbound path today).
- Removed stray `</content></invoke>` tags accidentally committed at the end of the roadmap.

Docs-only; link-check clean (0 dead links across 19 files).