### PR TITLE
ci: warnings + doc-link + perf-regression gates (Phase 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,54 @@ jobs:
       - name: Test package
         working-directory: ${{ matrix.package.path }}
         run: swift test -v
+
+  warnings:
+    name: Warnings gate
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+      # No SPM cache on purpose: a fresh build recompiles everything so warnings are
+      # actually re-emitted (an incremental build would skip unchanged files).
+      - name: Build and fail on first-party warnings
+        run: |
+          set -o pipefail
+          swift build --build-tests 2>&1 | tee build.log
+          if grep -E "warning:" build.log | grep -vE "\.build/(checkouts|artifacts)"; then
+            echo "::error::Build emitted warnings in first-party code. Fix them (the lines above)."
+            exit 1
+          fi
+
+  doc-links:
+    name: Doc link check
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check relative markdown links resolve
+        run: python3 scripts/check-doc-links.py
+
+  perf-regression:
+    name: Perf regression gate
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Cache SPM
+        uses: actions/cache@v5
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-perf-${{ hashFiles('Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-perf-
+
+      # Runs a small, fast benchmark subset (memory store, 1000 rows) and fails if a median
+      # exceeds the ceiling. Generous on purpose — a catastrophic/algorithmic-regression guard,
+      # not precise perf tracking (CI hardware is shared and noisy). Local median is ~75ms.
+      - name: Run benchmark subset with regression ceiling
+        env:
+          SWIFTSYNC_RUN_BENCHMARKS: "1"
+          SWIFTSYNC_BENCHMARK_STORES: memory
+          SWIFTSYNC_BENCHMARK_TIERS: "1000"
+          SWIFTSYNC_BENCHMARK_MAX_MEDIAN_MS: "2000"
+        run: |
+          swift test \
+            --filter FetchStrategyBenchmarkTests/testGlobalBatchSyncBenchmarks \
+            --filter FetchStrategyBenchmarkTests/testSingleItemSyncBenchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,18 +57,29 @@ jobs:
         run: swift test -v
 
   warnings:
-    name: Warnings gate
+    name: Warnings gate (${{ matrix.package.name }})
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: SwiftSync
+            path: .
+          - name: DemoBackend
+            path: DemoBackend
+          - name: DemoCore
+            path: DemoCore
     steps:
       - uses: actions/checkout@v5
       # No SPM cache on purpose: a fresh build recompiles everything so warnings are
       # actually re-emitted (an incremental build would skip unchanged files).
       - name: Build and fail on first-party warnings
+        working-directory: ${{ matrix.package.path }}
         run: |
           set -o pipefail
           swift build --build-tests 2>&1 | tee build.log
           if grep -E "warning:" build.log | grep -vE "\.build/(checkouts|artifacts)"; then
-            echo "::error::Build emitted warnings in first-party code. Fix them (the lines above)."
+            echo "::error::Build emitted warnings in first-party code (${{ matrix.package.name }}). Fix them (the lines above)."
             exit 1
           fi
 

--- a/SwiftSync/Tests/SwiftSyncTests/FetchStrategyBenchmarkTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/FetchStrategyBenchmarkTests.swift
@@ -8,6 +8,8 @@ import XCTest
 // Full matrix example:
 // SWIFTSYNC_RUN_BENCHMARKS=1 SWIFTSYNC_BENCHMARK_STORES=memory,sqlite \
 // SWIFTSYNC_BENCHMARK_TIERS=1000,10000,50000 swift test --filter FetchStrategyBenchmarkTests
+// CI regression gate: set SWIFTSYNC_BENCHMARK_MAX_MEDIAN_MS=<ms> to fail when any run's median
+// exceeds that ceiling (set generously — a catastrophic-regression guard, not perf tracking).
 
 @Syncable
 @Model
@@ -873,6 +875,14 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
 
     private func emit(_ result: BenchmarkSummary) {
         print(result.rendered)
+        if let ceiling = environment.maxMedianMilliseconds {
+            let medianMs = result.median.millisecondsValue
+            XCTAssertLessThanOrEqual(
+                medianMs, ceiling,
+                "Perf regression: \(result.name) (store=\(result.storeKind.rawValue), totalRows=\(result.totalRows)) "
+                    + "median \(medianMs)ms exceeded ceiling \(ceiling)ms"
+            )
+        }
     }
 }
 
@@ -894,6 +904,10 @@ private struct BenchmarkEnvironment {
     let scopeSize: Int
     let sampleCount: Int
     let phaseProfilingEnabled: Bool
+    /// Optional CI regression ceiling: if set, a benchmark whose median exceeds this many
+    /// milliseconds fails the test. Set generously — this is a catastrophic/algorithmic
+    /// regression guard, not precise perf tracking (CI hardware varies and is noisy).
+    let maxMedianMilliseconds: Double?
 
     static var current: BenchmarkEnvironment {
         from(ProcessInfo.processInfo.environment)
@@ -907,7 +921,8 @@ private struct BenchmarkEnvironment {
             relationshipCounts: parseIntegers(environment["SWIFTSYNC_BENCHMARK_RELATIONSHIP_COUNTS"]) ?? [1, 10, 50],
             scopeSize: parseIntegers(environment["SWIFTSYNC_BENCHMARK_SCOPE_SIZE"])?.first ?? 100,
             sampleCount: max(1, parseIntegers(environment["SWIFTSYNC_BENCHMARK_SAMPLES"])?.first ?? 3),
-            phaseProfilingEnabled: environment["SWIFTSYNC_BENCHMARK_PROFILE_PHASES"] == "1"
+            phaseProfilingEnabled: environment["SWIFTSYNC_BENCHMARK_PROFILE_PHASES"] == "1",
+            maxMedianMilliseconds: environment["SWIFTSYNC_BENCHMARK_MAX_MEDIAN_MS"].flatMap(Double.init)
         )
     }
 
@@ -980,7 +995,7 @@ private struct BenchmarkSummary {
         durations.sorted { $0.millisecondsValue < $1.millisecondsValue }
     }
 
-    private var median: Duration {
+    var median: Duration {
         sortedDurations[sortedDurations.count / 2]
     }
 

--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Fail if any relative markdown link in the repo's docs points to a missing file.
+
+Checks internal `[text](relative/path)` links only; ignores http(s)/mailto/anchor links.
+Run from anywhere: `python3 scripts/check-doc-links.py`.
+"""
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(__file__).resolve().parent.parent
+markdown_files = [
+    p for p in root.rglob("*.md") if ".build" not in p.parts and ".git" not in p.parts
+]
+link_re = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+dead: list[str] = []
+for md in markdown_files:
+    for match in link_re.finditer(md.read_text(encoding="utf-8")):
+        target = match.group(1).strip()
+        if target.startswith(("http://", "https://", "#", "mailto:")):
+            continue
+        path = target.split("#", 1)[0]
+        if not path:
+            continue
+        if not (md.parent / path).resolve().exists():
+            dead.append(f"{md.relative_to(root)} -> {target}")
+
+if dead:
+    print("::error::Dead relative doc links found:")
+    print("\n".join(dead))
+    sys.exit(1)
+
+print(f"OK: no dead relative links across {len(markdown_files)} markdown files.")


### PR DESCRIPTION
Phase 6 — make the quality bar self-enforcing so it can't rot back. Three new CI jobs in `ci.yml` (all the gates you asked for, in one PR).

## 1. Warnings gate
Fresh `swift build --build-tests` and fail on any first-party `warning:` (dependency warnings under `.build/checkouts` are excluded). No SPM cache on this job on purpose — a fresh build re-emits warnings that an incremental build would skip. Locks in the warning-clean state from Phase 1.

## 2. Doc-link gate
`scripts/check-doc-links.py` (dependency-free) walks every `.md` and fails on a dead **relative** link — the `migrating-from-sync.md` class of bug from Phase 2. Internal links only; ignores `http(s)`/anchors. **Not** related to DocC and pulls in no dependency.

## 3. Perf-regression gate
Runs a small, fast benchmark subset (memory store, 1000 rows) and fails if a median exceeds `SWIFTSYNC_BENCHMARK_MAX_MEDIAN_MS` (new, harness-enforced). Set to **2000ms** — deliberately generous (local median ~75ms). This is a **catastrophic/algorithmic-regression guard**, not precise perf tracking: CI hardware is shared and noisy, so a tight threshold would flake; a generous one still catches an O(n²)/N+1 blow-up.

## Verified locally
- Doc-link script: clean across 19 markdown files.
- Warnings gate: fresh build emits no first-party warnings.
- Perf gate: passes at the 2000ms ceiling (~75ms actual); fails when the ceiling is tripped.
- Full suite: 159 macOS + 48 swift-testing green.

These add three checks to every PR; the perf job and warnings job each build from scratch (~a couple minutes).