### PR TITLE
ci: pick an available iPhone simulator dynamically (fix iOS regression)

### DIFF
--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -27,10 +27,32 @@ jobs:
       - name: Xcode Version
         run: xcodebuild -version && swift --version
 
+      # Pick whatever iPhone simulator the runner image ships — don't pin a device name,
+      # which breaks whenever GitHub rolls the macos image (e.g. iPhone 16 Pro -> 17 Pro).
+      - name: Select an available iPhone simulator
+        id: sim
+        run: |
+          UDID=$(xcrun simctl list devices available --json | python3 -c '
+          import json, sys
+          devices = json.load(sys.stdin)["devices"]
+          candidates = [
+              d for runtime, ds in devices.items() if "iOS" in runtime
+              for d in ds if d.get("isAvailable") and "iPhone" in d.get("name", "")
+          ]
+          print(candidates[0]["udid"] if candidates else "")
+          ')
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator found on the runner."
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using iPhone simulator $UDID"
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
       - name: Test — DirtyTrackingGapTests (iOS Simulator)
         working-directory: DemoCore
         run: |
           xcodebuild test \
             -scheme DemoCore \
-            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest' \
+            -destination "id=${{ steps.sim.outputs.udid }}" \
             -only-testing:DemoCoreTests/DirtyTrackingGapTests


### PR DESCRIPTION
The iOS regression gate started failing on **every** PR with exit 70 (unresolved destination): it pinned `-destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=latest'`, and GitHub rolled the `macos-15` runner image overnight — `iPhone 16 Pro` is gone (it's `iPhone 17 Pro` now). Tell-tale: #613's first run passed the iOS gate, the second (after the image refresh) failed with only macOS destinations + placeholders listed.

## Fix
Stop hardcoding the device. A step queries `xcrun simctl list devices available`, picks the first available iPhone simulator, and the test targets it by `id=<udid>`. A future image bump can't break it.

Verified locally end-to-end: dynamic select picks `iPhone 17 Pro`, then `xcodebuild test -scheme DemoCore -destination "id=<udid>" -only-testing:DemoCoreTests/DirtyTrackingGapTests` → `** TEST SUCCEEDED **`.

Unblocks all PRs (including #613, whose own gates are green). This PR's own iOS-regression run validates the fix.