### PR TITLE
chore: drop redundant -strict-concurrency unsafeFlags (make package consumable)

### DIFF
--- a/DemoBackend/Package.swift
+++ b/DemoBackend/Package.swift
@@ -13,18 +13,12 @@ let package = Package(
     targets: [
         .target(
             name: "DemoBackend",
-            path: "Sources/DemoBackend",
-            swiftSettings: [
-                .unsafeFlags(["-strict-concurrency=complete"])
-            ]
+            path: "Sources/DemoBackend"
         ),
         .testTarget(
             name: "DemoBackendTests",
             dependencies: ["DemoBackend"],
-            path: "Tests/DemoBackendTests",
-            swiftSettings: [
-                .unsafeFlags(["-strict-concurrency=complete"])
-            ]
+            path: "Tests/DemoBackendTests"
         ),
     ],
     swiftLanguageModes: [.v6]

--- a/DemoCore/Package.swift
+++ b/DemoCore/Package.swift
@@ -22,10 +22,7 @@ let package = Package(
                 .product(name: "SwiftSync", package: "SwiftSync"),
                 .product(name: "DemoBackend", package: "DemoBackend"),
             ],
-            path: "Sources/DemoCore",
-            swiftSettings: [
-                .unsafeFlags(["-strict-concurrency=complete"])
-            ]
+            path: "Sources/DemoCore"
         ),
         .testTarget(
             name: "DemoCoreTests",

--- a/Package.swift
+++ b/Package.swift
@@ -29,10 +29,7 @@ let package = Package(
         .target(
             name: "SwiftSync",
             dependencies: ["MacrosImplementation", "ObjCExceptionCatcher"],
-            path: "SwiftSync/Sources/SwiftSync",
-            swiftSettings: [
-                .unsafeFlags(["-strict-concurrency=complete"])
-            ]
+            path: "SwiftSync/Sources/SwiftSync"
         ),
         .target(
             name: "ObjCExceptionCatcher",
@@ -42,10 +39,7 @@ let package = Package(
         .testTarget(
             name: "SwiftSyncTests",
             dependencies: ["SwiftSync"],
-            path: "SwiftSync/Tests/SwiftSyncTests",
-            swiftSettings: [
-                .unsafeFlags(["-strict-concurrency=complete"])
-            ]
+            path: "SwiftSync/Tests/SwiftSyncTests"
         ),
         .testTarget(
             name: "SwiftSyncMacrosTests",
@@ -54,10 +48,7 @@ let package = Package(
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ],
-            path: "SwiftSync/Tests/SwiftSyncMacrosTests",
-            swiftSettings: [
-                .unsafeFlags(["-strict-concurrency=complete"])
-            ]
+            path: "SwiftSync/Tests/SwiftSyncMacrosTests"
         ),
     ],
     swiftLanguageModes: [.v6]


### PR DESCRIPTION
SwiftSync couldn't be used as a **versioned** SPM dependency: every target carried `.unsafeFlags(["-strict-concurrency=complete"])`, and SPM forbids `unsafeFlags` in any package consumed by URL+version. So the README's `.package(url: "https://github.com/3lvis/SwiftSync.git", from: "1.0.0")` instruction was actually unusable.

The flag is **redundant**: all packages are `swiftLanguageModes: [.v6]`, and Swift 6 language mode already enforces complete data-race checking as *errors* by default. The `unsafeFlags` only added (no-op) Swift-5-style opt-in checking on top.

## Change
Remove `.unsafeFlags(["-strict-concurrency=complete"])` from every target in `Package.swift`, `DemoCore`, and `DemoBackend`. No other `unsafeFlags` remain.

## Verified
- Root: 159 macOS + 48 swift-testing tests green, **no new concurrency errors or warnings** — confirming Swift 6 mode still enforces complete checking, so removal is behavior-neutral.
- DemoCore and DemoBackend build clean.
- README install instruction now actually works; no stale caveat to fix.