### PR TITLE
docs: Phase 7 production-sync design (plan-of-record)

### DIFF
--- a/docs/planning/production-sync-design.md
+++ b/docs/planning/production-sync-design.md
@@ -78,29 +78,39 @@ thread-safety: never pass a model across contexts).
 - **Realm / Atlas Device Sync:** client-generated id; an *operation-log* changeset (not a query);
   field-level OT merge (deletes win, per-field LWW); client-reset escape hatch.
 
-**Implications for our `localId` + `remoteId` + `updatedAt` model:**
+**Decisions and implications for our `localId` + `remoteId` + `updatedAt` model:**
 
-1. **The two-id model is the heavier, less-common choice — confirm it deliberately.** All three modern
-   systems use a single client-generated id that *is* the server id (no remap). Our `remoteId`-nil-until-
-   synced design re-introduces exactly the id-rewrite pain we remember (patching the id + every
-   foreign-key reference after first sync). We chose it for broad reach (non-greenfield backends); that
-   trade is real, but prior art weighs against it. **Re-confirm: accept the rewrite cost for reach, or
-   adopt single-client-id and accept greenfield-only?**
-2. **We are missing deletes — a real gap.** "Missing `remoteId` or newer `updatedAt`" *cannot represent
-   a deletion* (the row is gone, the query finds nothing). Every system keeps **tombstones**. Add a
-   soft-delete state that survives until the server acks, then hard-delete.
+1. **Decided: keep `localId` + `remoteId`.** The modern single-client-id systems (WatermelonDB / Couch /
+   Realm) all *control both ends* — a different category. SwiftSync syncs **conventional JSON APIs**:
+   backends it doesn't control, that mint their own ids on create. Single-client-id would require the
+   backend to accept client UUIDs as canonical, narrowing SwiftSync to greenfield / controlled-backend
+   apps. Two-id is the fit for our positioning (reach over existing backends *is* the point). The cost
+   we knowingly own: the id-rewrite when `remoteId` arrives — reconcile references, and manage the
+   thread-safety/mutability hazard (never pass a model across contexts). *(Only a deliberate
+   repositioning to greenfield would flip this.)*
+2. **Decided: `isDeleted` soft-delete.** A query for "missing `remoteId` / newer `updatedAt`" can't
+   represent a deletion, so a deleted row keeps an `isDeleted` flag and stays in the store until the
+   delete is pushed and the server acks; only then is it hard-deleted. (This is what "tombstone" means.)
 3. **Make retried pushes idempotent.** Server upserts keyed by the client id; advance `lastSyncedAt` /
    clear the dirty condition only *after* the server acks; a client mutation-id lets the server dedupe.
 4. **Whole-record `updatedAt` LWW loses concurrent different-field edits.** WatermelonDB (`_changed`)
    and Realm (OT) merge per-field. If a record can have concurrent writers, track `changedKeys` and
-   merge per-field; if single-writer, whole-record LWW is fine — decide deliberately.
-5. **`updatedAt` wall-clock is clock-skew-fragile.** Prefer a server-authoritative timestamp, and use a
-   monotonic server cursor (CouchDB-style) for "what changed since last sync" rather than a raw
-   timestamp (records written in the same second as a sync can be missed).
+   merge per-field; if single-writer, whole-record LWW is fine — decide when we hit it.
+5. **`updatedAt` wall-clock is clock-skew-fragile.** Prefer a server-authoritative timestamp, and a
+   monotonic server cursor for "what changed since last sync" rather than a raw timestamp (records
+   written in the same second as a sync can be missed).
 
-## Next step — design the public seam
+## Next step — build the seam, slice by slice (each with its first real use)
 
-With prior art in hand, design *our* outbound seam (syncable-model contract, pending queue + tombstones,
-push hook, failures table) for *our* constraints, and build it with its first real use — not plumbing
-now and a use case later. Blocked on resolving implication #1 (two-id vs single-id) and #2 (add
-tombstones).
+Decisions are settled; implement the outbound seam in thin slices, each shipped with the thing that
+exercises it (no plumbing-then-use-later):
+
+1. **Offline-model contract + outbound detection.** A model declares `localId` (always), `remoteId`
+   (nil until synced), `updatedAt`, `isDeleted`. First use: a query that partitions a store into
+   pending **creates** (`remoteId == nil`), **updates** (`remoteId != nil`, `updatedAt` newer than last
+   sync), and **deletes** (`isDeleted`). TDD it.
+2. Pending-changes queue + push hook (app owns the network call); advance the sync cursor only on ack.
+3. Failures table with discard / edit / retry.
+4. Migration safety (the offline queue survives a nuclear reset).
+
+Open: per-field vs whole-record LWW (#4 above) and the History-API optimisation — revisit on evidence.

--- a/docs/planning/production-sync-design.md
+++ b/docs/planning/production-sync-design.md
@@ -63,10 +63,44 @@ thread-safety: never pass a model across contexts).
       id + `updatedAt` query above. History could help *later* for efficient deltas and **delete
       tombstones** at scale; evaluate it then, on evidence — not now.
 
-## Next step — design the public seam (study prior art first)
+## Prior art (surveyed) — and what it changes
 
-The outbound API — the syncable-model contract (`localId`/`remoteId`/`updatedAt`), the pending queue,
-the push hook, the failures table — is a **public seam**, so study prior art before designing it: how
-the old `Sync` did `localId`/`remoteId` (and where it hurt), plus WatermelonDB / PouchDB–CouchDB
-replication / Realm sync. Then design *our* seam for *our* constraints and build it together with its
-first real use — not plumbing now and a use case later.
+- **Legacy `Sync` (`DataFilter`):** inbound set-diff keyed by `localPrimaryKey` / `remotePrimaryKey`
+  (local-not-in-remote ⇒ delete; remote-not-in-local ⇒ insert; intersection ⇒ update). Inbound only —
+  the id mapping is the identity concept; its pain was rewriting references when a local id became a
+  remote id (the Core Data "ids changed" breakage).
+- **WatermelonDB:** client-generated stable ids (no remap); reserved `_status` + `_changed` columns;
+  outbound is a *query* for `_status != synced`; soft-delete tombstones until the server acks;
+  per-column "client wins" merge; all-or-nothing batch push with retry-once.
+- **PouchDB ⇄ CouchDB:** client-chosen stable `_id`; `_rev` tree; changes-feed + resumable checkpoint;
+  `_deleted` tombstone revisions; deterministic (clock-free) conflict winner, app resolves; pushes are
+  idempotent/resumable.
+- **Realm / Atlas Device Sync:** client-generated id; an *operation-log* changeset (not a query);
+  field-level OT merge (deletes win, per-field LWW); client-reset escape hatch.
+
+**Implications for our `localId` + `remoteId` + `updatedAt` model:**
+
+1. **The two-id model is the heavier, less-common choice — confirm it deliberately.** All three modern
+   systems use a single client-generated id that *is* the server id (no remap). Our `remoteId`-nil-until-
+   synced design re-introduces exactly the id-rewrite pain we remember (patching the id + every
+   foreign-key reference after first sync). We chose it for broad reach (non-greenfield backends); that
+   trade is real, but prior art weighs against it. **Re-confirm: accept the rewrite cost for reach, or
+   adopt single-client-id and accept greenfield-only?**
+2. **We are missing deletes — a real gap.** "Missing `remoteId` or newer `updatedAt`" *cannot represent
+   a deletion* (the row is gone, the query finds nothing). Every system keeps **tombstones**. Add a
+   soft-delete state that survives until the server acks, then hard-delete.
+3. **Make retried pushes idempotent.** Server upserts keyed by the client id; advance `lastSyncedAt` /
+   clear the dirty condition only *after* the server acks; a client mutation-id lets the server dedupe.
+4. **Whole-record `updatedAt` LWW loses concurrent different-field edits.** WatermelonDB (`_changed`)
+   and Realm (OT) merge per-field. If a record can have concurrent writers, track `changedKeys` and
+   merge per-field; if single-writer, whole-record LWW is fine — decide deliberately.
+5. **`updatedAt` wall-clock is clock-skew-fragile.** Prefer a server-authoritative timestamp, and use a
+   monotonic server cursor (CouchDB-style) for "what changed since last sync" rather than a raw
+   timestamp (records written in the same second as a sync can be missed).
+
+## Next step — design the public seam
+
+With prior art in hand, design *our* outbound seam (syncable-model contract, pending queue + tombstones,
+push hook, failures table) for *our* constraints, and build it with its first real use — not plumbing
+now and a use case later. Blocked on resolving implication #1 (two-id vs single-id) and #2 (add
+tombstones).

--- a/docs/planning/production-sync-design.md
+++ b/docs/planning/production-sync-design.md
@@ -38,29 +38,35 @@ change detection, and failure surface; the app owns the network calls.
 - **API stability: break freely.** No pre-1.0 stability constraint; breaking changes ship as a SemVer
   major bump. Don't over-engineer for source stability.
 
-## Open forks (resolve before/while implementing)
+## Identity & change detection (decided)
 
-- [~] **Identity strategy — leaning `localId` + `remoteId`.** Client-UUID-becomes-the-server-id is
-      simpler (one id, minimal bookkeeping, a clean dictated contract) but is a *hard* requirement that
-      effectively limits adoption to greenfield apps. A `localId` + `remoteId` mapping is battle-tested
-      and works for existing apps / any backend; the historical pain was Core Data breaking when an id
-      changed — thread-safety + mutability red zones (never pass a model across contexts) — but that was
-      solved before with a lot of effort. **Leaning localId + remoteId for the broader reach; manage the
-      identity-mutation/threading hazard deliberately. Confirm before building on it.**
+**Model: `localId` + `remoteId` + `updatedAt`.** Every syncable row carries a client-generated
+`localId` (always) and a `remoteId` (nil until the server has it). The data model itself classifies
+and drives sync — no save-interception:
 
-- [ ] **Change detection — build our own plumbing first, then evaluate History.** To avoid biasing
-      toward a new and possibly-fragile API: implement our *own* outbound change-tracking first and get
-      it working, then see where the SwiftData History API can connect to / reduce its complexity.
-      Own-first; History as an optional optimization, decided on evidence, not a guess.
+- **Missing `remoteId`** ⇒ local-only row ⇒ a pending *create* to push (it gets a `remoteId` on success).
+- **Both ids, `updatedAt` newer than the last sync** ⇒ a pending *local update* to push.
+- **Conflict** (a local row with both ids vs an incoming server row) ⇒ **latest `updatedAt` wins** (last-writer-wins).
 
-## Proposed first step — own-plumbing change detection (spike)
+So outbound detection is a **query over the store**, not interception of saves. (A spike confirmed you
+*can* distinguish local-vs-sync writes via `didSave` + an "is-syncing" window — but the id model makes
+that machinery unnecessary; detection is data-driven, which is simpler and more robust.)
 
-Build our own outbound change-tracking: capture **app-originated** local edits into a pending-changes
-queue, keyed by `localId` / `remoteId`. Time-boxed and exploratory.
+Chosen over *client-UUID-becomes-the-server-id*: that's simpler (one id, a clean dictated contract)
+but a hard requirement that limits adoption to greenfield apps. `localId`/`remoteId` is battle-tested
+and works with any backend — with the known Core Data hazard to manage deliberately (id mutation +
+thread-safety: never pass a model across contexts).
 
-The central question it must answer: **how to tell an app-originated (local, queue-it) mutation from a
-sync-originated (server) one**, so only real local edits go outbound. Candidate to validate: a
-`ModelContext` save that happens *outside* a `SwiftSync.sync()` operation is a local edit.
+## Open question
 
-Once it works, evaluate where the History API could simplify it. Then break the accepted areas
-(queue, failures table, migration safety) into their own implementation PRs.
+- [ ] **SwiftData History API — optional optimisation, not the foundation.** Basic detection is the
+      id + `updatedAt` query above. History could help *later* for efficient deltas and **delete
+      tombstones** at scale; evaluate it then, on evidence — not now.
+
+## Next step — design the public seam (study prior art first)
+
+The outbound API — the syncable-model contract (`localId`/`remoteId`/`updatedAt`), the pending queue,
+the push hook, the failures table — is a **public seam**, so study prior art before designing it: how
+the old `Sync` did `localId`/`remoteId` (and where it hurt), plus WatermelonDB / PouchDB–CouchDB
+replication / Realm sync. Then design *our* seam for *our* constraints and build it together with its
+first real use — not plumbing now and a use case later.

--- a/docs/planning/production-sync-design.md
+++ b/docs/planning/production-sync-design.md
@@ -1,0 +1,60 @@
+# Production Sync — Design (Phase 7)
+
+Framing for the gap from today's **inbound sync-assist** (server → local SwiftData, read-reactive)
+to **production sync** (local edits flow back out, offline-first). Design-first: this records the
+decisions made so far and the open forks; implementation follows in dedicated PRs once the open
+forks are resolved.
+
+**Guiding principle:** the consumer should have to think as little as possible. Be opinionated —
+dictate the contract rather than support every backend shape. SwiftSync provides the local queue,
+change detection, and failure surface; the app owns the network calls.
+
+## Decisions
+
+- **Offline edits live in the database.** Pending local mutations persist in the local SwiftData
+  store (a queue), so they survive app restarts. SwiftSync owns the queue; the **client app uploads
+  them to the server** (SwiftSync detects/export changes and exposes the queue — it does not own the
+  network transport).
+
+- **Conflict resolution: last-writer-wins.** No per-field merge in the core.
+
+- **Failure handling: a visible, actionable failures table.** Failed uploads are stored (not
+  silently retried forever); the app/user can act per item — **discard, edit, retry** — like Google
+  Photos' offline-sync failure list. SwiftSync surfaces the table and the actions; the app decides
+  policy.
+
+- **Observability: net-new structured hooks.** SwiftSync has *no* `print`/logging in its library
+  source today (earlier "remove print" note was a mix-up with the Networking repo). Add structured
+  hooks for the sync lifecycle — started / progress / succeeded / failed, with errors — so apps can
+  log/surface sync state. Additive, not a rework.
+
+- **Schema migration: optimistic, with offline-safe nuclear option.** Prefer lightweight migrations;
+  when a destructive ("nuclear") reset is unavoidable, the **pending offline queue must be preserved**
+  — never wipe un-synced local edits.
+
+- **CloudKit: explicitly out of scope.** Not supported; if you need it, you're on your own. (Also
+  incompatible with the uniqueness model — see `docs/project/property-mapping-contract.md`.)
+
+- **API stability: break freely.** No pre-1.0 stability constraint; breaking changes ship as a SemVer
+  major bump. Don't over-engineer for source stability.
+
+## Open forks (resolve before/while implementing)
+
+- [ ] **Identity strategy for offline-created rows.** Preferred: **client-generated UUIDs that become
+      the server id** — the app and backend both use UUID ids; SwiftSync pushes the offline UUID and it
+      *is* the remote id (one id, minimal bookkeeping; a dictated contract). Alternative (debatable):
+      keep a separate **localId + remoteId** mapping (as the very old offline implementation did) —
+      more bookkeeping, but doesn't require backend UUIDs. **Decide.**
+
+- [ ] **Change detection: SwiftData History API vs. our own plumbing.** Spike the History API first;
+      adopt it if it's ergonomic and reliable (low consumer ceremony). It's new, so if it's cumbersome
+      or breaks easily, fall back to our own change-tracking plumbing. **It depends — resolve by spike,
+      not by guess.**
+
+## Proposed first step
+
+A **time-boxed spike**: implement outbound change detection two ways — (a) via the SwiftData History
+API, (b) via a minimal own-plumbing approach — on a representative model, and compare on consumer
+ceremony and reliability. The result picks the foundation. Throwaway code; the finding is the
+deliverable. Then break the accepted areas (queue, failures table, observability hooks, migration
+safety) into their own implementation PRs.

--- a/docs/planning/production-sync-design.md
+++ b/docs/planning/production-sync-design.md
@@ -23,10 +23,10 @@ change detection, and failure surface; the app owns the network calls.
   Photos' offline-sync failure list. SwiftSync surfaces the table and the actions; the app decides
   policy.
 
-- **Observability: net-new structured hooks.** SwiftSync has *no* `print`/logging in its library
-  source today (earlier "remove print" note was a mix-up with the Networking repo). Add structured
-  hooks for the sync lifecycle — started / progress / succeeded / failed, with errors — so apps can
-  log/surface sync state. Additive, not a rework.
+- **Observability: TBD — maybe not needed.** SwiftSync has *no* `print`/logging in its library
+  source today (the earlier "remove print" note was a mix-up with the Networking repo). Whether to
+  add structured sync-lifecycle hooks is undecided — revisit once outbound sync exists and we can see
+  what's actually worth surfacing.
 
 - **Schema migration: optimistic, with offline-safe nuclear option.** Prefer lightweight migrations;
   when a destructive ("nuclear") reset is unavoidable, the **pending offline queue must be preserved**
@@ -40,21 +40,27 @@ change detection, and failure surface; the app owns the network calls.
 
 ## Open forks (resolve before/while implementing)
 
-- [ ] **Identity strategy for offline-created rows.** Preferred: **client-generated UUIDs that become
-      the server id** — the app and backend both use UUID ids; SwiftSync pushes the offline UUID and it
-      *is* the remote id (one id, minimal bookkeeping; a dictated contract). Alternative (debatable):
-      keep a separate **localId + remoteId** mapping (as the very old offline implementation did) —
-      more bookkeeping, but doesn't require backend UUIDs. **Decide.**
+- [~] **Identity strategy — leaning `localId` + `remoteId`.** Client-UUID-becomes-the-server-id is
+      simpler (one id, minimal bookkeeping, a clean dictated contract) but is a *hard* requirement that
+      effectively limits adoption to greenfield apps. A `localId` + `remoteId` mapping is battle-tested
+      and works for existing apps / any backend; the historical pain was Core Data breaking when an id
+      changed — thread-safety + mutability red zones (never pass a model across contexts) — but that was
+      solved before with a lot of effort. **Leaning localId + remoteId for the broader reach; manage the
+      identity-mutation/threading hazard deliberately. Confirm before building on it.**
 
-- [ ] **Change detection: SwiftData History API vs. our own plumbing.** Spike the History API first;
-      adopt it if it's ergonomic and reliable (low consumer ceremony). It's new, so if it's cumbersome
-      or breaks easily, fall back to our own change-tracking plumbing. **It depends — resolve by spike,
-      not by guess.**
+- [ ] **Change detection — build our own plumbing first, then evaluate History.** To avoid biasing
+      toward a new and possibly-fragile API: implement our *own* outbound change-tracking first and get
+      it working, then see where the SwiftData History API can connect to / reduce its complexity.
+      Own-first; History as an optional optimization, decided on evidence, not a guess.
 
-## Proposed first step
+## Proposed first step — own-plumbing change detection (spike)
 
-A **time-boxed spike**: implement outbound change detection two ways — (a) via the SwiftData History
-API, (b) via a minimal own-plumbing approach — on a representative model, and compare on consumer
-ceremony and reliability. The result picks the foundation. Throwaway code; the finding is the
-deliverable. Then break the accepted areas (queue, failures table, observability hooks, migration
-safety) into their own implementation PRs.
+Build our own outbound change-tracking: capture **app-originated** local edits into a pending-changes
+queue, keyed by `localId` / `remoteId`. Time-boxed and exploratory.
+
+The central question it must answer: **how to tell an app-originated (local, queue-it) mutation from a
+sync-originated (server) one**, so only real local edits go outbound. Candidate to validate: a
+`ModelContext` save that happens *outside* a `SwiftSync.sync()` operation is a local edit.
+
+Once it works, evaluate where the History API could simplify it. Then break the accepted areas
+(queue, failures table, migration safety) into their own implementation PRs.

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -66,8 +66,10 @@ token (with delete tombstones) is how outbound/offline change export works. High
 design-first, substantial effort — not a quick bolt-on. Evaluated and deferred here from Phase 4
 for that reason; SwiftSync has no outbound/change-tracking path today.
 
-- [ ] Write a design doc framing the gap from "sync-assist" to "production sync":
-      conflict resolution, offline mutation queue, retry/backoff, observability hooks,
-      schema-migration policy, history-based local change export (via the History API),
-      CloudKit coexistence, and versioned API stability.
-- [ ] Break each accepted area into its own dedicated implementation item once designed.
+Design recorded in [`production-sync-design.md`](production-sync-design.md): offline queue in the
+DB, last-writer-wins, a visible/actionable failures table, net-new structured observability,
+offline-safe migrations, CloudKit out, break-freely versioning. Two forks remain open.
+
+- [ ] Spike outbound change detection — SwiftData History API vs. our own plumbing — and decide the foundation.
+- [ ] Resolve the identity-strategy fork (client UUID becomes the server id, vs. a localId + remoteId mapping).
+- [ ] Break each accepted area (queue, failures table, observability hooks, migration safety) into its own implementation PR once the forks land.

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -61,15 +61,18 @@ branch. Work through them systematically; mark complete by deleting the line (pe
 
 ### Phase 7 — Define the production-sync story (design-first)
 
-The **SwiftData History API** is the foundation here: querying what changed locally since a
-token (with delete tombstones) is how outbound/offline change export works. High-value, but a
-design-first, substantial effort — not a quick bolt-on. Evaluated and deferred here from Phase 4
-for that reason; SwiftSync has no outbound/change-tracking path today.
+The gap: SwiftSync is inbound-only (server → local, read-reactive); production sync adds the
+outbound/offline side (local edits flow back). Design-first and substantial — deferred here from
+Phase 4. Full design in [`production-sync-design.md`](production-sync-design.md): offline queue in
+the DB, last-writer-wins, a visible/actionable failures table, offline-safe migrations, CloudKit out,
+break-freely versioning; observability TBD.
 
-Design recorded in [`production-sync-design.md`](production-sync-design.md): offline queue in the
-DB, last-writer-wins, a visible/actionable failures table, net-new structured observability,
-offline-safe migrations, CloudKit out, break-freely versioning. Two forks remain open.
+Decided: **identity + change detection** use a `localId` + `remoteId` + `updatedAt` model — detection
+is a query over the store (no save-interception; a `didSave`-interception spike was explored and
+discarded as unnecessary), and conflicts resolve by latest `updatedAt`. The History API is an optional
+later optimisation (efficient deltas / delete tombstones), not the foundation.
 
-- [ ] Spike outbound change detection — SwiftData History API vs. our own plumbing — and decide the foundation.
-- [ ] Resolve the identity-strategy fork (client UUID becomes the server id, vs. a localId + remoteId mapping).
-- [ ] Break each accepted area (queue, failures table, observability hooks, migration safety) into its own implementation PR once the forks land.
+- [ ] Study prior art (the old `Sync`, WatermelonDB, PouchDB–CouchDB replication, Realm sync), then
+      design the public outbound seam — syncable-model contract, pending queue, push hook, failures
+      table — and build it with its first real use.
+- [ ] Break each accepted area into its own implementation PR.


### PR DESCRIPTION
Planning deliverable for Phase 7 — the design-of-record for moving from inbound sync-assist to production (outbound/offline) sync. New `docs/planning/production-sync-design.md`, with the roadmap's Phase 7 pointing at it.

**Guiding principle:** the consumer thinks as little as possible; be opinionated — dictate the contract, don't accommodate every backend. SwiftSync owns the local queue / change detection / failure surface; the app owns the network calls.

**Decisions captured (from review):**
- Offline edits persist in the local DB queue; the app uploads them.
- Last-writer-wins conflicts.
- A visible, actionable failures table (discard / edit / retry — Google-Photos style), not silent retry.
- Net-new structured observability hooks (corrected: SwiftSync has no `print` today — that was a Networking-repo mix-up).
- Optimistic migrations with an offline-safe nuclear option (never wipe un-synced edits).
- CloudKit explicitly out of scope.
- Break freely; SemVer major bumps.

**Open forks (to decide):**
1. Identity strategy — client-generated UUID *becomes* the server id (preferred, dictated contract) vs a `localId` + `remoteId` mapping (the old approach).
2. Change detection — SwiftData History API vs our own plumbing; decided by a **spike**, not a guess.

**Proposed first step:** a time-boxed spike of History-API vs own-plumbing change detection to pick the foundation, then break the accepted areas into implementation PRs.

Docs-only; link-check clean.