### PR TITLE
Demo: offline editing + push (first consumer of the public push API)

### DIFF
--- a/Demo/Demo/App/ContentView.swift
+++ b/Demo/Demo/App/ContentView.swift
@@ -44,7 +44,7 @@ struct ContentView: View {
                         Spacer()
 
                         Button("Sync now", action: pushPendingChanges)
-                            .disabled(engine.pendingChangeCount == 0 || engine.isSyncing)
+                            .disabled(engine.isOffline || engine.pendingChangeCount == 0 || engine.isSyncing)
                     }
                 }
             }

--- a/Demo/Demo/App/ContentView.swift
+++ b/Demo/Demo/App/ContentView.swift
@@ -1,24 +1,89 @@
-import SwiftUI
 import DemoCore
 import Observation
 import SwiftSync
+import SwiftUI
 
 struct ContentView: View {
     @Bindable var runtime: DemoRuntime
+    @State private var syncResult: SyncResultAlert?
+
+    private var engine: DemoSyncEngine { runtime.syncEngine }
 
     var body: some View {
         ProjectsView(syncContainer: runtime.syncContainer, syncEngine: runtime.syncEngine)
-        .toolbar {
-            if !runtime.isUITesting {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Picker("Scenario", selection: $runtime.scenario) {
-                        ForEach(DemoNetworkScenario.allCases) { scenario in
-                            Text(scenario.title).tag(scenario)
+            .toolbar {
+                if !runtime.isUITesting {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Picker("Scenario", selection: $runtime.scenario) {
+                            ForEach(DemoNetworkScenario.allCases) { scenario in
+                                Text(scenario.title).tag(scenario)
+                            }
                         }
+                        .pickerStyle(.menu)
                     }
-                    .pickerStyle(.menu)
+
+                    ToolbarItemGroup(placement: .bottomBar) {
+                        Button {
+                            engine.isOffline.toggle()
+                        } label: {
+                            Label(
+                                engine.isOffline ? "Offline" : "Online",
+                                systemImage: engine.isOffline ? "wifi.slash" : "wifi"
+                            )
+                        }
+                        .tint(engine.isOffline ? .orange : .accentColor)
+
+                        Spacer()
+
+                        if engine.pendingChangeCount > 0 {
+                            Text("\(engine.pendingChangeCount) pending")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        Button("Sync now", action: pushPendingChanges)
+                            .disabled(engine.pendingChangeCount == 0 || engine.isSyncing)
+                    }
                 }
             }
+            .alert(item: $syncResult) { result in
+                Alert(title: Text(result.title), message: Text(result.message), dismissButton: .default(Text("OK")))
+            }
+    }
+
+    private func pushPendingChanges() {
+        _Concurrency.Task {
+            do {
+                guard let summary = try await engine.pushPendingChanges() else { return }
+                syncResult = SyncResultAlert(summary: summary)
+            } catch {
+                syncResult = SyncResultAlert(title: "Sync failed", message: error.localizedDescription)
+            }
+        }
+    }
+}
+
+private struct SyncResultAlert: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+
+    init(title: String, message: String) {
+        self.title = title
+        self.message = message
+    }
+
+    init(summary: SyncPushSummary) {
+        let applied = summary.insertedCount + summary.updatedCount + summary.deletedCount
+        if summary.failures.isEmpty {
+            title = "Synced"
+            message = "Pushed \(applied) change\(applied == 1 ? "" : "s") to the server."
+        } else {
+            title = "Synced with \(summary.failures.count) failure\(summary.failures.count == 1 ? "" : "s")"
+            let lines = summary.failures.map { "• \($0.operation.rawValue): \($0.message)" }
+            message = (["Pushed \(applied) change\(applied == 1 ? "" : "s")."] + lines).joined(separator: "\n")
         }
     }
 }

--- a/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
+++ b/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
@@ -118,7 +118,7 @@ public final class ProjectViewMachine {
         projectPublisher.rows.first(where: { $0.id == projectID })
     }
     public var tasks: [Task] {
-        taskPublisher.rows
+        taskPublisher.rows.filter { $0.isLocallyDeleted != true }
     }
     public var contentState: ProjectDetailContentState {
         resolveProjectDetailContentState(

--- a/DemoCore/Sources/DemoCore/Models/DemoModels.swift
+++ b/DemoCore/Sources/DemoCore/Models/DemoModels.swift
@@ -86,6 +86,14 @@ public final class Task {
     public var updatedAt: Date
 
     @NotExport
+    public var syncRemoteID: String?
+
+    // Not `isDeleted`: that name collides with PersistentModel's built-in context-deletion flag,
+    // which silently shadows a stored property of the same name.
+    @NotExport
+    public var isLocallyDeleted: Bool?
+
+    @NotExport
     public var project: Project?
 
     @NotExport
@@ -115,6 +123,8 @@ public final class Task {
         stateLabel: String = "",
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
+        syncRemoteID: String? = nil,
+        isLocallyDeleted: Bool? = nil,
         project: Project? = nil,
         author: User? = nil,
         assignee: User? = nil,
@@ -132,6 +142,8 @@ public final class Task {
         self.stateLabel = stateLabel
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+        self.syncRemoteID = syncRemoteID
+        self.isLocallyDeleted = isLocallyDeleted
         self.project = project
         self.author = author
         self.assignee = assignee
@@ -139,6 +151,12 @@ public final class Task {
         self.watchers = watchers
         self.items = items
     }
+}
+
+extension Task: SyncOfflineModel {
+    public var syncLocalID: String { id }
+    public var syncUpdatedAt: Date { updatedAt }
+    public var syncIsDeleted: Bool { isLocallyDeleted ?? false }
 }
 
 @Syncable

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -22,6 +22,17 @@ public final class DemoSyncEngine {
 
     public private(set) var isSyncing = false
 
+    /// When on, task create/edit/delete mutate the local store only — no network — and accumulate as
+    /// pending changes until `pushPendingChanges()` reconciles them with the server.
+    public var isOffline = false
+
+    public private(set) var pendingChangeCount = 0
+
+    /// Last point local state was reconciled with the server. Edits after this are pending updates;
+    /// advanced after every inbound pull (so freshly-pulled rows aren't mistaken for local edits) and
+    /// after a successful push.
+    private var syncCursor = Date()
+
     private var inFlightOperations: Set<String> = []
 
     private let syncContainer: SyncContainer
@@ -58,6 +69,14 @@ public final class DemoSyncEngine {
     }
 
     public func createTask(body: DemoSyncPayload, projectID: String) async throws {
+        if isOffline {
+            guard try project(withID: projectID) != nil else {
+                throw SyncTaskDetailError.missingProject(projectID)
+            }
+            try await syncContainer.sync(item: body, as: Task.self)
+            refreshPendingCount()
+            return
+        }
         try await runOperation("createTask-\(projectID)") {
             let created = try await apiClient.createTask(body: body)
             try await syncProjectTasksData(projectID: projectID)
@@ -68,6 +87,15 @@ public final class DemoSyncEngine {
     }
 
     public func updateTask(taskID: String, projectID: String?, body: DemoSyncPayload) async throws {
+        if isOffline {
+            try await syncContainer.sync(item: body, as: Task.self)
+            if let task = try task(withID: taskID) {
+                task.updatedAt = Date()
+                try syncContainer.mainContext.save()
+            }
+            refreshPendingCount()
+            return
+        }
         try await runOperation("updateTask-\(taskID)") {
             _ = try await apiClient.updateTask(taskID: taskID, body: body)
             try await syncTaskAfterMutation(taskID: taskID, projectID: projectID)
@@ -75,6 +103,15 @@ public final class DemoSyncEngine {
     }
 
     public func deleteTask(taskID: String, projectID: String) async throws {
+        if isOffline {
+            if let task = try task(withID: taskID) {
+                task.isLocallyDeleted = true
+                task.updatedAt = Date()
+                try syncContainer.mainContext.save()
+            }
+            refreshPendingCount()
+            return
+        }
         try await runOperation("deleteTask-\(taskID)") {
             try await apiClient.deleteTask(taskID: taskID)
             try await syncProjectTasksData(projectID: projectID)
@@ -93,6 +130,97 @@ public final class DemoSyncEngine {
             _ = try await self.apiClient.replaceTaskWatchers(taskID: taskID, watcherIDs: watcherIDs)
             try await self.syncTaskAfterMutation(taskID: taskID, projectID: projectID)
         }
+    }
+
+    /// Push every locally-pending task change to the server and apply the result. Returns `nil` if a
+    /// push is already in flight.
+    @discardableResult
+    public func pushPendingChanges() async throws -> SyncPushSummary? {
+        let key = "push"
+        guard !inFlightOperations.contains(key) else { return nil }
+
+        inFlightOperations.insert(key)
+        isSyncing = true
+        defer {
+            inFlightOperations.remove(key)
+            isSyncing = !inFlightOperations.isEmpty
+        }
+
+        let summary = try await SwiftSync.push(
+            for: Task.self,
+            in: syncContainer.mainContext,
+            changedSince: syncCursor,
+            upload: { batch in try await self.upload(batch) }
+        )
+        syncCursor = summary.cursor
+        refreshPendingCount()
+        return summary
+    }
+
+    private func upload(_ batch: SyncPushBatch) async throws -> SyncPushResponse {
+        var response = SyncPushResponse()
+        for localID in batch.inserts {
+            guard let body = try taskBody(localID: localID) else { continue }
+            do {
+                let created = try await apiClient.createTask(body: body)
+                response.assignedRemoteIDs[localID] = created.string("id") ?? localID
+            } catch {
+                response.failures.append(
+                    SyncPushFailure(localID: localID, operation: .insert, message: errorMessage(error)))
+            }
+        }
+        for localID in batch.updates {
+            guard let body = try taskBody(localID: localID) else { continue }
+            do {
+                _ = try await apiClient.updateTask(taskID: localID, body: body)
+                response.confirmedUpdateLocalIDs.insert(localID)
+            } catch {
+                response.failures.append(
+                    SyncPushFailure(localID: localID, operation: .update, message: errorMessage(error)))
+            }
+        }
+        for localID in batch.deletes {
+            do {
+                try await apiClient.deleteTask(taskID: localID)
+                response.confirmedDeleteLocalIDs.insert(localID)
+            } catch {
+                response.failures.append(
+                    SyncPushFailure(localID: localID, operation: .delete, message: errorMessage(error)))
+            }
+        }
+        return response
+    }
+
+    private func taskBody(localID: String) throws -> DemoSyncPayload? {
+        guard let task = try task(withID: localID) else { return nil }
+        return try DemoSyncPayload(dictionary: syncContainer.export(task))
+    }
+
+    private func refreshPendingCount() {
+        let pending = try? SwiftSync.pendingChanges(
+            for: Task.self, in: syncContainer.mainContext, changedSince: syncCursor)
+        pendingChangeCount = pending.map { $0.inserts.count + $0.updates.count + $0.deletes.count } ?? 0
+    }
+
+    /// Mark every task the server just reported as synced (`syncRemoteID = id`) and advance the cursor,
+    /// so freshly-pulled rows are not later mistaken for local inserts or edits.
+    private func markServerTasksSynced(payloadIDs: [String]) throws {
+        let idSet = Set(payloadIDs.filter { !$0.isEmpty })
+        if !idSet.isEmpty {
+            let tasks = try syncContainer.mainContext.fetch(FetchDescriptor<Task>())
+            var changed = false
+            for task in tasks where task.syncRemoteID == nil && idSet.contains(task.id) {
+                task.syncRemoteID = task.id
+                changed = true
+            }
+            if changed { try syncContainer.mainContext.save() }
+        }
+        syncCursor = Date()
+        refreshPendingCount()
+    }
+
+    private func errorMessage(_ error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
     }
 
     private func syncProjectsData() async throws {
@@ -130,6 +258,7 @@ public final class DemoSyncEngine {
             parent: project,
             relationship: \Task.project
         )
+        try markServerTasksSynced(payloadIDs: payload.compactMap { $0.string("id") })
         try await syncProjectsData()
     }
 
@@ -153,6 +282,9 @@ public final class DemoSyncEngine {
             throw SyncTaskDetailError.missingProject(projectID)
         }
         try await syncContainer.sync(item: payload, as: Task.self)
+        if let taskID = payload.string("id") {
+            try markServerTasksSynced(payloadIDs: [taskID])
+        }
     }
 
     private func syncTaskAfterMutation(taskID: String, projectID: String?) async throws {

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -132,10 +132,11 @@ public final class DemoSyncEngine {
         }
     }
 
-    /// Push every locally-pending task change to the server and apply the result. Returns `nil` if a
-    /// push is already in flight.
+    /// Push every locally-pending task change to the server and apply the result. Returns `nil` while
+    /// offline (no network) or if a push is already in flight.
     @discardableResult
     public func pushPendingChanges() async throws -> SyncPushSummary? {
+        guard !isOffline else { return nil }
         let key = "push"
         guard !inFlightOperations.contains(key) else { return nil }
 

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -1,0 +1,106 @@
+import SwiftData
+import SwiftSync
+import XCTest
+
+@testable import DemoCore
+
+final class OfflinePushTests: XCTestCase {
+
+    @MainActor
+    func testOfflineCreateThenPushStampsRemoteIDAndReachesBackend() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        try await engine.syncProjectTasks(projectID: projectID)
+        XCTAssertEqual(engine.pendingChangeCount, 0)
+
+        let body = try createBody(
+            from: DemoSeedData.SeedIDs.Tasks.sessionTimeout,
+            newID: "OFFLINE-CREATE-1",
+            in: syncContainer
+        )
+
+        engine.isOffline = true
+        try await engine.createTask(body: body, projectID: projectID)
+
+        let local = try XCTUnwrap(fetchTask(id: "OFFLINE-CREATE-1", in: syncContainer.mainContext))
+        XCTAssertNil(local.syncRemoteID, "an offline-created row is pending until pushed")
+        XCTAssertEqual(engine.pendingChangeCount, 1)
+
+        engine.isOffline = false
+        let pushResult = try await engine.pushPendingChanges()
+        let summary = try XCTUnwrap(pushResult)
+
+        XCTAssertEqual(summary.insertedCount, 1)
+        XCTAssertTrue(summary.failures.isEmpty)
+        XCTAssertEqual(engine.pendingChangeCount, 0)
+
+        let synced = try XCTUnwrap(fetchTask(id: "OFFLINE-CREATE-1", in: syncContainer.mainContext))
+        XCTAssertEqual(synced.syncRemoteID, "OFFLINE-CREATE-1", "push stamps the server-assigned id")
+        let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-CREATE-1")
+        XCTAssertNotNil(backendDetail)
+    }
+
+    @MainActor
+    func testOfflineDeleteThenPushHardDeletesLocallyAndOnBackend() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        engine.isOffline = true
+        try await engine.deleteTask(taskID: taskID, projectID: projectID)
+
+        let tombstone = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertEqual(tombstone.isLocallyDeleted, true, "offline delete is a soft delete until pushed")
+        XCTAssertEqual(engine.pendingChangeCount, 1)
+
+        engine.isOffline = false
+        let pushResult = try await engine.pushPendingChanges()
+        let summary = try XCTUnwrap(pushResult)
+
+        XCTAssertEqual(summary.deletedCount, 1)
+        XCTAssertTrue(summary.failures.isEmpty)
+        let remaining = try fetchTask(id: taskID, in: syncContainer.mainContext)
+        XCTAssertNil(remaining, "confirmed delete is hard-deleted")
+        let detail = try await apiClient.getTaskDetail(taskID: taskID)
+        XCTAssertNil(detail)
+    }
+
+    @MainActor
+    private func createBody(from templateID: String, newID: String, in syncContainer: SyncContainer) throws
+        -> DemoSyncPayload
+    {
+        let template = try XCTUnwrap(fetchTask(id: templateID, in: syncContainer.mainContext))
+        var dictionary = syncContainer.export(template)
+        dictionary["id"] = newID
+        dictionary["title"] = "Offline task"
+        dictionary.removeValue(forKey: "items")
+        return try DemoSyncPayload(dictionary: dictionary)
+    }
+
+    @MainActor
+    private func makeSyncContainer() throws -> SyncContainer {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try SyncContainer(
+            for: Project.self,
+            User.self,
+            Task.self,
+            Item.self,
+            TaskStateOption.self,
+            configurations: configuration
+        )
+    }
+
+    @MainActor
+    private func fetchTask(id: String, in context: ModelContext) throws -> Task? {
+        try context.fetch(FetchDescriptor<Task>(predicate: #Predicate { $0.id == id })).first
+    }
+}

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -75,6 +75,34 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testPushWhileOfflineIsANoOp() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        let body = try createBody(
+            from: DemoSeedData.SeedIDs.Tasks.sessionTimeout,
+            newID: "OFFLINE-NOOP-1",
+            in: syncContainer
+        )
+
+        engine.isOffline = true
+        try await engine.createTask(body: body, projectID: projectID)
+        XCTAssertEqual(engine.pendingChangeCount, 1)
+
+        // Still offline: a push must not reach the server.
+        let result = try await engine.pushPendingChanges()
+        XCTAssertNil(result, "push is unavailable while offline")
+        XCTAssertEqual(engine.pendingChangeCount, 1, "the pending change survives")
+        let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-NOOP-1")
+        XCTAssertNil(backendDetail, "nothing was uploaded while offline")
+    }
+
+    @MainActor
     private func createBody(from templateID: String, newID: String, in syncContainer: SyncContainer) throws
         -> DemoSyncPayload
     {

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Define your models once, read from local SwiftData, and let SwiftSync handle the
 - Deterministic diffing for inserts, updates, and deletes
 - Automatic relationship syncing for nested objects and foreign keys
 - Export back into API-ready JSON
+- Offline push (local → server) with two-id identity and last-writer-wins
 - Reactive local reads for SwiftUI and UIKit
 
 ## Quick Start
@@ -610,6 +611,45 @@ Best practices:
 - Use `@RemoteKey`, `@NotExport`, and container formatting options to keep transport concerns out of your UI code
 
 See [FAQ](docs/project/faq.md) and [Property Mapping Contract](docs/project/property-mapping-contract.md) for more on export.
+
+## Offline Push (local → server)
+
+`sync` and `export` cover the pull side: pull server state into SwiftData, and turn a draft into a request body. **Push** is the outbound counterpart for offline-first apps — edit locally while disconnected, then reconcile with the server when you reconnect.
+
+Identity is a two-id mapping: `syncLocalID` is the client-generated id that is stable forever; `syncRemoteID` is the server's id, `nil` until the row has been pushed and acknowledged. `syncUpdatedAt` drives last-writer-wins, and `syncIsDeleted` is a soft-delete tombstone that survives until the deletion reaches the server. Conform your model to `SyncOfflineModel`:
+
+```swift
+extension Task: SyncOfflineModel {
+  var syncLocalID: String { id }
+  var syncUpdatedAt: Date { updatedAt }
+  var syncIsDeleted: Bool { isDeleted }
+  // syncRemoteID is a stored property the push driver assigns on acknowledgement
+}
+```
+
+`pendingChanges` partitions the store into inserts, updates, and deletes relative to your last-synced cursor — by querying the store, with no save-interception:
+
+- **insert** — never synced (`syncRemoteID == nil`) and not deleted
+- **update** — synced, not deleted, and edited since the cursor
+- **delete** — soft-deleted *and* known to the server (a row inserted-then-deleted locally never reached the server, so it is dropped, not pushed)
+
+`push` drives one pass. It hands the pending ids to your `upload` closure as a `Sendable` `SyncPushBatch` (so SwiftData objects never cross into a network call — you own the request), then applies the server's `SyncPushResponse` locally: stamping server-assigned `syncRemoteID`s onto inserts, hard-deleting confirmed deletes, and returning per-item failures for you to surface (discard / edit / retry).
+
+```swift
+let summary = try await SwiftSync.push(
+  for: Task.self,
+  in: syncContainer.mainContext,
+  changedSince: lastSyncedAt,
+  upload: { batch in
+    // map batch.inserts / batch.updates / batch.deletes (syncLocalIDs) to requests,
+    // call your API, and report back what the server assigned/accepted/rejected
+    try await api.push(batch)
+  }
+)
+lastSyncedAt = summary.cursor
+```
+
+Advance your cursor to `summary.cursor` on every pass: it only moves forward when *every* pending update was acknowledged, so an unacknowledged update is safely re-detected on the next push rather than lost.
 
 ## Date Handling
 

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -9,10 +9,7 @@ import SwiftData
 /// `syncRemoteID` is the server's id — `nil` until the row has been pushed and acknowledged (the
 /// push driver assigns it). `syncUpdatedAt` drives last-writer-wins; `syncIsDeleted` is a
 /// soft-delete that survives until the deletion is pushed (then the row is hard-deleted).
-///
-/// `package` while the push feature is built out; promoted to `public` (with README docs) once it
-/// is consumer-usable.
-package protocol SyncOfflineModel: PersistentModel {
+public protocol SyncOfflineModel: PersistentModel {
     var syncLocalID: String { get }
     var syncRemoteID: String? { get set }
     var syncUpdatedAt: Date { get }
@@ -20,34 +17,34 @@ package protocol SyncOfflineModel: PersistentModel {
 }
 
 /// The local rows pending a push, partitioned by operation (live models, for applying results).
-package struct SyncPendingChanges<Model: SyncOfflineModel> {
-    package let inserts: [Model]
-    package let updates: [Model]
-    package let deletes: [Model]
+public struct SyncPendingChanges<Model: SyncOfflineModel> {
+    public let inserts: [Model]
+    public let updates: [Model]
+    public let deletes: [Model]
 
-    package var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
+    public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
 /// The `syncLocalID`s to push, partitioned by operation. This — not the live models — is what the
 /// async uploader receives, so SwiftData objects never cross into a network call (the
 /// "never pass a model across contexts" rule). It's `Sendable`; the app maps each id to its payload.
-package struct SyncPushBatch: Sendable {
-    package let inserts: [String]
-    package let updates: [String]
-    package let deletes: [String]
+public struct SyncPushBatch: Sendable {
+    public let inserts: [String]
+    public let updates: [String]
+    public let deletes: [String]
 
-    package var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
+    public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
 /// One pushed item the server rejected. SwiftSync surfaces these so the app can let the user act on
 /// them (discard / edit / retry) rather than silently retrying forever.
-package struct SyncPushFailure: Equatable, Sendable {
-    package enum Operation: String, Equatable, Sendable { case insert, update, delete }
-    package let localID: String
-    package let operation: Operation
-    package let message: String
+public struct SyncPushFailure: Equatable, Sendable {
+    public enum Operation: String, Equatable, Sendable { case insert, update, delete }
+    public let localID: String
+    public let operation: Operation
+    public let message: String
 
-    package init(localID: String, operation: Operation, message: String) {
+    public init(localID: String, operation: Operation, message: String) {
         self.localID = localID
         self.operation = operation
         self.message = message
@@ -56,14 +53,14 @@ package struct SyncPushFailure: Equatable, Sendable {
 
 /// What the app's uploader reports back after talking to the server: the server-assigned ids for
 /// inserted rows, which updates/deletes were accepted, and any per-item failures.
-package struct SyncPushResponse: Sendable {
+public struct SyncPushResponse: Sendable {
     /// insert's `syncLocalID` → server-assigned `syncRemoteID`.
-    package var assignedRemoteIDs: [String: String]
-    package var confirmedUpdateLocalIDs: Set<String>
-    package var confirmedDeleteLocalIDs: Set<String>
-    package var failures: [SyncPushFailure]
+    public var assignedRemoteIDs: [String: String]
+    public var confirmedUpdateLocalIDs: Set<String>
+    public var confirmedDeleteLocalIDs: Set<String>
+    public var failures: [SyncPushFailure]
 
-    package init(
+    public init(
         assignedRemoteIDs: [String: String] = [:],
         confirmedUpdateLocalIDs: Set<String> = [],
         confirmedDeleteLocalIDs: Set<String> = [],
@@ -77,12 +74,12 @@ package struct SyncPushResponse: Sendable {
 }
 
 /// Result of a push pass. Advance the caller's stored "last synced" cursor to `cursor` on success.
-package struct SyncPushSummary {
-    package let insertedCount: Int
-    package let updatedCount: Int
-    package let deletedCount: Int
-    package let failures: [SyncPushFailure]
-    package let cursor: Date
+public struct SyncPushSummary {
+    public let insertedCount: Int
+    public let updatedCount: Int
+    public let deletedCount: Int
+    public let failures: [SyncPushFailure]
+    public let cursor: Date
 }
 
 extension SwiftSync {
@@ -93,7 +90,7 @@ extension SwiftSync {
     /// - **update**: synced (`syncRemoteID != nil`), not deleted, edited since the last sync.
     /// - **delete**: soft-deleted *and* known to the server (a row inserted-then-deleted locally
     ///   never reached the server, so it's dropped, not pushed).
-    package static func pendingChanges<Model: SyncOfflineModel>(
+    public static func pendingChanges<Model: SyncOfflineModel>(
         for _: Model.Type,
         in context: ModelContext,
         changedSince: Date
@@ -123,7 +120,7 @@ extension SwiftSync {
     /// cursor to `summary.cursor`: it only moves forward when *every* pending update was
     /// acknowledged, so an unacknowledged update is safely re-detected on the next push.
     @discardableResult
-    package static func push<Model: SyncOfflineModel>(
+    public static func push<Model: SyncOfflineModel>(
         for _: Model.Type,
         in context: ModelContext,
         changedSince: Date,


### PR DESCRIPTION
Demo enhancement #1 of the plan: show offline-first editing end to end, and promote the push API to public — the demo is its first real consumer.

## What changed
A global **Online/Offline** toggle in the bottom bar:
- **Offline** → task create / edit / delete mutate the local store only and accumulate as pending changes (`syncRemoteID == nil` inserts, soft-delete tombstones, bumped-timestamp updates). A "N pending" badge + enabled "Sync now" appear.
- **Sync now** → drives `SwiftSync.push` against the `DemoServerSimulator`: stamps the server-assigned id back onto inserts, hard-deletes confirmed deletes, and alerts with applied counts + per-item failures.

## Layers
| Layer | Change |
|---|---|
| `SwiftSync/Push.swift` | push API `package` → `public` (+ README "Offline Push" section, feature bullet) |
| `DemoModels.swift` | `Task: SyncOfflineModel` — `syncRemoteID` + `isLocallyDeleted` (`@NotExport`, optional so inbound sync ignores absent keys) |
| `DemoSyncEngine.swift` | `isOffline`, offline C/U/D branches, `pendingChangeCount`, `pushPendingChanges()`, remote-id stamping after inbound pulls |
| `ScreenMachines.swift` | hide tombstones from the task list (1 line) |
| `ContentView.swift` | offline bar + push action + result alert |

This is the **first real consumer of the push API**, which is what justified making it public (no abstraction without a consumer).

## Verification
- SwiftSync: 48 tests pass; `Push.swift` diff is keyword-only (CI format-gate safe).
- DemoCore: 23 tests pass, incl. 2 new `OfflinePushTests` (offline-create→push stamps remoteID + reaches backend; offline-delete→push hard-deletes locally + on backend).
- Demo app builds, launches, and the bar renders correctly.

## Notes / deferred
- **Gotcha:** a `@Model` property named `isDeleted` is silently shadowed by `PersistentModel`'s built-in — renamed `isLocallyDeleted`.
- Offline reviewers/watchers stay online-only this slice; the flow assumes push-before-pull (deeper inbound last-writer-wins is a later slice). The failures-inbox UI (discard/edit/retry) is demo enhancement #3.