### PR TITLE
Prototype: per-item-closure push overload

### DIFF
--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -9,6 +9,7 @@ public final class DemoSyncEngine {
     private enum SyncTaskDetailError: LocalizedError {
         case missingProjectID
         case missingProject(String)
+        case missingLocalTask(String)
 
         var errorDescription: String? {
             switch self {
@@ -16,6 +17,8 @@ public final class DemoSyncEngine {
                 return "Task detail payload is missing project_id."
             case let .missingProject(projectID):
                 return "Task detail sync requires project \(projectID) to exist locally."
+            case let .missingLocalTask(taskID):
+                return "Task \(taskID) is no longer in the local store."
             }
         }
     }
@@ -151,49 +154,26 @@ public final class DemoSyncEngine {
             for: Task.self,
             in: syncContainer.mainContext,
             changedSince: syncCursor,
-            upload: { batch in try await self.upload(batch) }
+            insert: { localID in
+                let created = try await self.apiClient.createTask(body: try self.taskBody(localID: localID))
+                return created.string("id") ?? localID
+            },
+            update: { localID in
+                _ = try await self.apiClient.updateTask(taskID: localID, body: try self.taskBody(localID: localID))
+            },
+            delete: { localID in
+                try await self.apiClient.deleteTask(taskID: localID)
+            }
         )
         syncCursor = summary.cursor
         refreshPendingCount()
         return summary
     }
 
-    private func upload(_ batch: SyncPushBatch) async throws -> SyncPushResponse {
-        var response = SyncPushResponse()
-        for localID in batch.inserts {
-            guard let body = try taskBody(localID: localID) else { continue }
-            do {
-                let created = try await apiClient.createTask(body: body)
-                response.assignedRemoteIDs[localID] = created.string("id") ?? localID
-            } catch {
-                response.failures.append(
-                    SyncPushFailure(localID: localID, operation: .insert, message: errorMessage(error)))
-            }
+    private func taskBody(localID: String) throws -> DemoSyncPayload {
+        guard let task = try task(withID: localID) else {
+            throw SyncTaskDetailError.missingLocalTask(localID)
         }
-        for localID in batch.updates {
-            guard let body = try taskBody(localID: localID) else { continue }
-            do {
-                _ = try await apiClient.updateTask(taskID: localID, body: body)
-                response.confirmedUpdateLocalIDs.insert(localID)
-            } catch {
-                response.failures.append(
-                    SyncPushFailure(localID: localID, operation: .update, message: errorMessage(error)))
-            }
-        }
-        for localID in batch.deletes {
-            do {
-                try await apiClient.deleteTask(taskID: localID)
-                response.confirmedDeleteLocalIDs.insert(localID)
-            } catch {
-                response.failures.append(
-                    SyncPushFailure(localID: localID, operation: .delete, message: errorMessage(error)))
-            }
-        }
-        return response
-    }
-
-    private func taskBody(localID: String) throws -> DemoSyncPayload? {
-        guard let task = try task(withID: localID) else { return nil }
         return try DemoSyncPayload(dictionary: syncContainer.export(task))
     }
 
@@ -218,10 +198,6 @@ public final class DemoSyncEngine {
         }
         syncCursor = Date()
         refreshPendingCount()
-    }
-
-    private func errorMessage(_ error: Error) -> String {
-        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
     }
 
     private func syncProjectsData() async throws {

--- a/README.md
+++ b/README.md
@@ -651,6 +651,19 @@ lastSyncedAt = summary.cursor
 
 Advance your cursor to `summary.cursor` on every pass: it only moves forward when *every* pending update was acknowledged, so an unacknowledged update is safely re-detected on the next push rather than lost.
 
+If your backend works one item at a time, use the per-item overload — supply a closure per operation and SwiftSync builds the `SyncPushResponse` for you (`insert` returns the server-assigned id; `update`/`delete` confirm by returning; a closure that throws becomes a `SyncPushFailure` for that item, leaving the row pending):
+
+```swift
+let summary = try await SwiftSync.push(
+  for: Task.self,
+  in: syncContainer.mainContext,
+  changedSince: lastSyncedAt,
+  insert: { localID in try await api.create(localID) },  // returns the server id
+  update: { localID in try await api.update(localID) },
+  delete: { localID in try await api.delete(localID) }
+)
+```
+
 ## Date Handling
 
 SwiftSync handles common API date formats out of the box, so most apps do not need any date setup to get started.

--- a/README.md
+++ b/README.md
@@ -633,25 +633,7 @@ extension Task: SyncOfflineModel {
 - **update** — synced, not deleted, and edited since the cursor
 - **delete** — soft-deleted *and* known to the server (a row inserted-then-deleted locally never reached the server, so it is dropped, not pushed)
 
-`push` drives one pass. It hands the pending ids to your `upload` closure as a `Sendable` `SyncPushBatch` (so SwiftData objects never cross into a network call — you own the request), then applies the server's `SyncPushResponse` locally: stamping server-assigned `syncRemoteID`s onto inserts, hard-deleting confirmed deletes, and returning per-item failures for you to surface (discard / edit / retry).
-
-```swift
-let summary = try await SwiftSync.push(
-  for: Task.self,
-  in: syncContainer.mainContext,
-  changedSince: lastSyncedAt,
-  upload: { batch in
-    // map batch.inserts / batch.updates / batch.deletes (syncLocalIDs) to requests,
-    // call your API, and report back what the server assigned/accepted/rejected
-    try await api.push(batch)
-  }
-)
-lastSyncedAt = summary.cursor
-```
-
-Advance your cursor to `summary.cursor` on every pass: it only moves forward when *every* pending update was acknowledged, so an unacknowledged update is safely re-detected on the next push rather than lost.
-
-If your backend works one item at a time, use the per-item overload — supply a closure per operation and SwiftSync builds the `SyncPushResponse` for you (`insert` returns the server-assigned id; `update`/`delete` confirm by returning; a closure that throws becomes a `SyncPushFailure` for that item, leaving the row pending):
+`push` drives one pass. You supply a closure per operation; SwiftSync detects the pending changes, calls your closures (SwiftData objects never cross into the network call — your closures get `syncLocalID`s, not models), then applies the result locally: stamping server-assigned `syncRemoteID`s onto inserts, hard-deleting confirmed deletes, and returning per-item failures for you to surface (discard / edit / retry). `insert` returns the server-assigned id; `update`/`delete` confirm by returning; a closure that throws becomes a `SyncPushFailure` for that item and leaves the row pending, while the rest of the batch still runs.
 
 ```swift
 let summary = try await SwiftSync.push(
@@ -662,7 +644,10 @@ let summary = try await SwiftSync.push(
   update: { localID in try await api.update(localID) },
   delete: { localID in try await api.delete(localID) }
 )
+lastSyncedAt = summary.cursor
 ```
+
+Advance your cursor to `summary.cursor` on every pass: it only moves forward when *every* pending update was acknowledged, so an unacknowledged update is safely re-detected on the next push rather than lost.
 
 ## Date Handling
 

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -26,14 +26,14 @@ public struct SyncPendingChanges<Model: SyncOfflineModel> {
 }
 
 /// The `syncLocalID`s to push, partitioned by operation. This — not the live models — is what the
-/// async uploader receives, so SwiftData objects never cross into a network call (the
-/// "never pass a model across contexts" rule). It's `Sendable`; the app maps each id to its payload.
-public struct SyncPushBatch: Sendable {
-    public let inserts: [String]
-    public let updates: [String]
-    public let deletes: [String]
+/// internal uploader works from, so SwiftData objects never cross into a network call (the
+/// "never pass a model across contexts" rule). It's `Sendable`.
+struct SyncPushBatch: Sendable {
+    let inserts: [String]
+    let updates: [String]
+    let deletes: [String]
 
-    public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
+    var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
 /// One pushed item the server rejected. SwiftSync surfaces these so the app can let the user act on
@@ -51,16 +51,16 @@ public struct SyncPushFailure: Equatable, Sendable {
     }
 }
 
-/// What the app's uploader reports back after talking to the server: the server-assigned ids for
+/// What the internal uploader reports back after talking to the server: the server-assigned ids for
 /// inserted rows, which updates/deletes were accepted, and any per-item failures.
-public struct SyncPushResponse: Sendable {
+struct SyncPushResponse: Sendable {
     /// insert's `syncLocalID` → server-assigned `syncRemoteID`.
-    public var assignedRemoteIDs: [String: String]
-    public var confirmedUpdateLocalIDs: Set<String>
-    public var confirmedDeleteLocalIDs: Set<String>
-    public var failures: [SyncPushFailure]
+    var assignedRemoteIDs: [String: String]
+    var confirmedUpdateLocalIDs: Set<String>
+    var confirmedDeleteLocalIDs: Set<String>
+    var failures: [SyncPushFailure]
 
-    public init(
+    init(
         assignedRemoteIDs: [String: String] = [:],
         confirmedUpdateLocalIDs: Set<String> = [],
         confirmedDeleteLocalIDs: Set<String> = [],
@@ -113,14 +113,13 @@ extension SwiftSync {
         return SyncPendingChanges(inserts: inserts, updates: updates, deletes: deletes)
     }
 
-    /// Drive one push: detect pending changes, hand their ids (a Sendable `SyncPushBatch`) to the
-    /// app's `upload` closure (the app owns the network call), then apply the server's response
-    /// locally — stamp server-assigned `syncRemoteID`s onto inserted rows, hard-delete confirmed
-    /// deletes — and report failures for the app to surface. Always advance your "last synced"
-    /// cursor to `summary.cursor`: it only moves forward when *every* pending update was
-    /// acknowledged, so an unacknowledged update is safely re-detected on the next push.
+    /// The push core: detect pending changes, hand their ids (a Sendable `SyncPushBatch`) to `upload`,
+    /// then apply the server's response locally — stamp server-assigned `syncRemoteID`s onto inserted
+    /// rows, hard-delete confirmed deletes — and report failures. Internal: the public `push` is the
+    /// per-item form below, which builds the `SyncPushResponse` for you. This bulk seam (one call for
+    /// the whole batch) stays internal until a backend with a bulk endpoint needs it.
     @discardableResult
-    public static func push<Model: SyncOfflineModel>(
+    static func push<Model: SyncOfflineModel>(
         for _: Model.Type,
         in context: ModelContext,
         changedSince: Date,
@@ -173,12 +172,14 @@ extension SwiftSync {
             cursor: allUpdatesAcknowledged ? now : changedSince)
     }
 
-    /// Convenience over `push(…, upload:)` for the common case where the app talks to the server one
-    /// item at a time. Supply a per-operation closure and SwiftSync runs the batch, building the
-    /// `SyncPushResponse` for you: `insert` returns the server-assigned `syncRemoteID`; `update` and
-    /// `delete` are confirmed by returning normally. A closure that throws records a `SyncPushFailure`
-    /// for that item (its message taken from the error) and leaves the row pending — the other items
-    /// in the batch still run.
+    /// Drive one push. Supply a closure per operation — `insert` returns the server-assigned
+    /// `syncRemoteID`; `update` and `delete` are confirmed by returning normally — and SwiftSync runs
+    /// the batch: detect pending changes, call your closures, then apply the result locally (stamp
+    /// remote ids, hard-delete confirmed deletes). A closure that throws records a `SyncPushFailure`
+    /// for that item (its message taken from the error) and leaves the row pending; the other items in
+    /// the batch still run. Always advance your "last synced" cursor to `summary.cursor`: it only moves
+    /// forward when *every* pending update was acknowledged, so an unacknowledged update is safely
+    /// re-detected on the next push.
     @discardableResult
     public static func push<Model: SyncOfflineModel>(
         for _: Model.Type,

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -172,4 +172,57 @@ extension SwiftSync {
             failures: response.failures,
             cursor: allUpdatesAcknowledged ? now : changedSince)
     }
+
+    /// Convenience over `push(…, upload:)` for the common case where the app talks to the server one
+    /// item at a time. Supply a per-operation closure and SwiftSync runs the batch, building the
+    /// `SyncPushResponse` for you: `insert` returns the server-assigned `syncRemoteID`; `update` and
+    /// `delete` are confirmed by returning normally. A closure that throws records a `SyncPushFailure`
+    /// for that item (its message taken from the error) and leaves the row pending — the other items
+    /// in the batch still run.
+    @discardableResult
+    public static func push<Model: SyncOfflineModel>(
+        for _: Model.Type,
+        in context: ModelContext,
+        changedSince: Date,
+        now: Date = Date(),
+        isolation: isolated (any Actor)? = #isolation,
+        insert: (String) async throws -> String,
+        update: (String) async throws -> Void,
+        delete: (String) async throws -> Void
+    ) async throws -> SyncPushSummary {
+        try await push(for: Model.self, in: context, changedSince: changedSince, now: now) { batch in
+            var response = SyncPushResponse()
+            for localID in batch.inserts {
+                do {
+                    response.assignedRemoteIDs[localID] = try await insert(localID)
+                } catch {
+                    response.failures.append(
+                        SyncPushFailure(localID: localID, operation: .insert, message: failureMessage(error)))
+                }
+            }
+            for localID in batch.updates {
+                do {
+                    try await update(localID)
+                    response.confirmedUpdateLocalIDs.insert(localID)
+                } catch {
+                    response.failures.append(
+                        SyncPushFailure(localID: localID, operation: .update, message: failureMessage(error)))
+                }
+            }
+            for localID in batch.deletes {
+                do {
+                    try await delete(localID)
+                    response.confirmedDeleteLocalIDs.insert(localID)
+                } catch {
+                    response.failures.append(
+                        SyncPushFailure(localID: localID, operation: .delete, message: failureMessage(error)))
+                }
+            }
+            return response
+        }
+    }
+
+    private static func failureMessage(_ error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+    }
 }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncPushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncPushTests.swift
@@ -200,4 +200,85 @@ final class SyncPushTests: XCTestCase {
 
         XCTAssertEqual(summary.updatedCount, 1, "only the in-batch update counts, not server echoes")
     }
+
+    @MainActor
+    func testPushWithPerItemClosuresAppliesResults() async throws {
+        let context = ModelContext(
+            try ModelContainer(
+                for: OfflineNote.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
+        let lastSync = Date(timeIntervalSince1970: 1_000)
+        let now = Date(timeIntervalSince1970: 2_000)
+        let edited = Date(timeIntervalSince1970: 1_500)
+
+        context.insert(
+            OfflineNote(
+                syncLocalID: "c1", syncRemoteID: nil, syncUpdatedAt: edited, syncIsDeleted: false,
+                title: "insert"))
+        context.insert(
+            OfflineNote(
+                syncLocalID: "u1", syncRemoteID: "r-u1", syncUpdatedAt: edited, syncIsDeleted: false,
+                title: "update"))
+        context.insert(
+            OfflineNote(
+                syncLocalID: "d1", syncRemoteID: "r-d1", syncUpdatedAt: edited, syncIsDeleted: true,
+                title: "delete"))
+        try context.save()
+
+        var inserted: [String] = []
+        var updated: [String] = []
+        var deleted: [String] = []
+        let summary = try await SwiftSync.push(
+            for: OfflineNote.self, in: context, changedSince: lastSync, now: now,
+            insert: { localID in
+                inserted.append(localID)
+                return "server-\(localID)"
+            },
+            update: { localID in updated.append(localID) },
+            delete: { localID in deleted.append(localID) }
+        )
+
+        XCTAssertEqual(inserted, ["c1"])
+        XCTAssertEqual(updated, ["u1"])
+        XCTAssertEqual(deleted, ["d1"])
+
+        let rows = try context.fetch(FetchDescriptor<OfflineNote>())
+        let byLocalID = Dictionary(uniqueKeysWithValues: rows.map { ($0.syncLocalID, $0) })
+        XCTAssertEqual(byLocalID["c1"]?.syncRemoteID, "server-c1", "insert closure's return becomes the remote id")
+        XCTAssertNil(byLocalID["d1"], "confirmed delete is hard-deleted")
+        XCTAssertEqual(summary.insertedCount, 1)
+        XCTAssertEqual(summary.updatedCount, 1)
+        XCTAssertEqual(summary.deletedCount, 1)
+        XCTAssertTrue(summary.failures.isEmpty)
+        XCTAssertEqual(summary.cursor, now)
+    }
+
+    @MainActor
+    func testPushWithPerItemClosuresRecordsThrownFailures() async throws {
+        struct RejectedError: LocalizedError {
+            var errorDescription: String? { "422 invalid" }
+        }
+        let context = ModelContext(
+            try ModelContainer(
+                for: OfflineNote.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
+        context.insert(
+            OfflineNote(
+                syncLocalID: "c1", syncRemoteID: nil, syncUpdatedAt: Date(timeIntervalSince1970: 1_500),
+                syncIsDeleted: false, title: "rejected insert"))
+        try context.save()
+
+        let summary = try await SwiftSync.push(
+            for: OfflineNote.self, in: context, changedSince: Date(timeIntervalSince1970: 1_000),
+            insert: { _ in throw RejectedError() },
+            update: { _ in },
+            delete: { _ in }
+        )
+
+        XCTAssertEqual(
+            summary.failures,
+            [SyncPushFailure(localID: "c1", operation: .insert, message: "422 invalid")])
+        let rows = try context.fetch(FetchDescriptor<OfflineNote>())
+        XCTAssertNil(rows.first?.syncRemoteID, "a thrown insert keeps no remote id and stays local")
+    }
 }


### PR DESCRIPTION
Stacked on #618. Prototypes the convenience overload we discussed — moving the per-item batch loop out of the consumer and into SwiftSync.

## API
`push(for:in:changedSince:now:insert:update:delete:)` — a convenience over `push(…, upload:)` for backends that talk one item at a time:
- `insert: (localID) async throws -> String` — returns the server-assigned `syncRemoteID`
- `update: (localID) async throws -> Void` / `delete: (localID) async throws -> Void` — confirmed by returning normally
- a closure that **throws** becomes a `SyncPushFailure` for that item (message from the error), leaving the row pending; the other items in the batch still run.

SwiftSync builds the `SyncPushResponse` (the loop + try/catch) internally; the lower-level `upload:` form stays for backends with a bulk endpoint.

## Does it earn its place?
This is the point of the prototype. With the demo adopting it as the first consumer:
- **Consumer glue: ~22 fewer net lines** — `DemoSyncEngine`'s manual batch loop and `errorMessage` helper are deleted; the three closures are just the network calls.
- **Library: +53 lines** paid once, reusable.

## TDD
Red-first: stubbed the overload (ignores the closures) → 2 new tests failed for the right reason (closures never called, nothing applied) → implemented → green. SwiftSync push tests now 7 (5 + 2).

## Verification
- SwiftSync: push tests 7/7; format gate clean (additions only, no pre-existing reformatting).
- DemoCore: 24 tests pass (incl. the 3 offline tests, now exercising the overload).
- Demo app builds.

## Open question for review
Is the ergonomics win worth a second public push entry point, or keep the single `upload:` seam? Easy to drop if not.