### PR TITLE
Offline push via /sync/upload — backend + SwiftSync + demo

### DIFF
--- a/Demo/Demo/App/ContentView.swift
+++ b/Demo/Demo/App/ContentView.swift
@@ -11,7 +11,12 @@ struct ContentView: View {
 
     var body: some View {
         ProjectsView(syncContainer: runtime.syncContainer, syncEngine: runtime.syncEngine)
+            // A safe-area inset, not a `.bottomBar` toolbar: the toolbar would attach outside
+            // ProjectsView's own NavigationStack and drop out on re-render. This stays put.
+            .safeAreaInset(edge: .bottom) { offlineBar }
             .toolbar {
+                // The scenario picker is dev chrome with non-deterministic network behavior, so it
+                // stays hidden under UI testing. The offline bar above is a real feature (and tested).
                 if !runtime.isUITesting {
                     ToolbarItem(placement: .topBarTrailing) {
                         Picker("Scenario", selection: $runtime.scenario) {
@@ -21,36 +26,44 @@ struct ContentView: View {
                         }
                         .pickerStyle(.menu)
                     }
-
-                    ToolbarItemGroup(placement: .bottomBar) {
-                        Button {
-                            engine.isOffline.toggle()
-                        } label: {
-                            Label(
-                                engine.isOffline ? "Offline" : "Online",
-                                systemImage: engine.isOffline ? "wifi.slash" : "wifi"
-                            )
-                        }
-                        .tint(engine.isOffline ? .orange : .accentColor)
-
-                        Spacer()
-
-                        if engine.pendingChangeCount > 0 {
-                            Text("\(engine.pendingChangeCount) pending")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        Spacer()
-
-                        Button("Sync now", action: pushPendingChanges)
-                            .disabled(engine.isOffline || engine.pendingChangeCount == 0 || engine.isSyncing)
-                    }
                 }
             }
             .alert(item: $syncResult) { result in
                 Alert(title: Text(result.title), message: Text(result.message), dismissButton: .default(Text("OK")))
             }
+    }
+
+    private var offlineBar: some View {
+        HStack {
+            Button {
+                engine.isOffline.toggle()
+            } label: {
+                Label(
+                    engine.isOffline ? "Offline" : "Online",
+                    systemImage: engine.isOffline ? "wifi.slash" : "wifi"
+                )
+            }
+            .tint(engine.isOffline ? .orange : .accentColor)
+            .accessibilityIdentifier("offline-toggle")
+
+            Spacer()
+
+            if engine.pendingChangeCount > 0 {
+                Text("\(engine.pendingChangeCount) pending")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("pending-count")
+            }
+
+            Spacer()
+
+            Button("Sync now", action: pushPendingChanges)
+                .disabled(engine.isOffline || engine.pendingChangeCount == 0 || engine.isSyncing)
+                .accessibilityIdentifier("sync-now")
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.bar)
     }
 
     private func pushPendingChanges() {

--- a/Demo/Demo/App/ContentView.swift
+++ b/Demo/Demo/App/ContentView.swift
@@ -44,7 +44,7 @@ struct ContentView: View {
                         Spacer()
 
                         Button("Sync now", action: pushPendingChanges)
-                            .disabled(engine.pendingChangeCount == 0 || engine.isSyncing)
+                            .disabled(engine.isOffline || engine.pendingChangeCount == 0 || engine.isSyncing)
                     }
                 }
             }

--- a/Demo/Demo/App/ContentView.swift
+++ b/Demo/Demo/App/ContentView.swift
@@ -1,24 +1,89 @@
-import SwiftUI
 import DemoCore
 import Observation
 import SwiftSync
+import SwiftUI
 
 struct ContentView: View {
     @Bindable var runtime: DemoRuntime
+    @State private var syncResult: SyncResultAlert?
+
+    private var engine: DemoSyncEngine { runtime.syncEngine }
 
     var body: some View {
         ProjectsView(syncContainer: runtime.syncContainer, syncEngine: runtime.syncEngine)
-        .toolbar {
-            if !runtime.isUITesting {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Picker("Scenario", selection: $runtime.scenario) {
-                        ForEach(DemoNetworkScenario.allCases) { scenario in
-                            Text(scenario.title).tag(scenario)
+            .toolbar {
+                if !runtime.isUITesting {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Picker("Scenario", selection: $runtime.scenario) {
+                            ForEach(DemoNetworkScenario.allCases) { scenario in
+                                Text(scenario.title).tag(scenario)
+                            }
                         }
+                        .pickerStyle(.menu)
                     }
-                    .pickerStyle(.menu)
+
+                    ToolbarItemGroup(placement: .bottomBar) {
+                        Button {
+                            engine.isOffline.toggle()
+                        } label: {
+                            Label(
+                                engine.isOffline ? "Offline" : "Online",
+                                systemImage: engine.isOffline ? "wifi.slash" : "wifi"
+                            )
+                        }
+                        .tint(engine.isOffline ? .orange : .accentColor)
+
+                        Spacer()
+
+                        if engine.pendingChangeCount > 0 {
+                            Text("\(engine.pendingChangeCount) pending")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        Button("Sync now", action: pushPendingChanges)
+                            .disabled(engine.pendingChangeCount == 0 || engine.isSyncing)
+                    }
                 }
             }
+            .alert(item: $syncResult) { result in
+                Alert(title: Text(result.title), message: Text(result.message), dismissButton: .default(Text("OK")))
+            }
+    }
+
+    private func pushPendingChanges() {
+        _Concurrency.Task {
+            do {
+                guard let summary = try await engine.pushPendingChanges() else { return }
+                syncResult = SyncResultAlert(summary: summary)
+            } catch {
+                syncResult = SyncResultAlert(title: "Sync failed", message: error.localizedDescription)
+            }
+        }
+    }
+}
+
+private struct SyncResultAlert: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+
+    init(title: String, message: String) {
+        self.title = title
+        self.message = message
+    }
+
+    init(summary: SyncPushSummary) {
+        let applied = summary.insertedCount + summary.updatedCount + summary.deletedCount
+        if summary.failures.isEmpty {
+            title = "Synced"
+            message = "Pushed \(applied) change\(applied == 1 ? "" : "s") to the server."
+        } else {
+            title = "Synced with \(summary.failures.count) failure\(summary.failures.count == 1 ? "" : "s")"
+            let lines = summary.failures.map { "• \($0.operation.rawValue): \($0.message)" }
+            message = (["Pushed \(applied) change\(applied == 1 ? "" : "s")."] + lines).joined(separator: "\n")
         }
     }
 }

--- a/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
+++ b/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
@@ -256,8 +256,8 @@ extension TaskFormSheet {
 
                 VStack(alignment: .leading, spacing: 8) {
                     stateControl
-                    assigneeControl
                     authorControl
+                    assigneeControl
                 }
             }
             .padding(.vertical, 8)
@@ -273,7 +273,7 @@ extension TaskFormSheet {
             .foregroundStyle(.white)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(Color.gray, in: Capsule())
+            .background(Color(.systemGray3), in: Capsule())
             .accessibilityLabel("required")
     }
 

--- a/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
+++ b/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
@@ -246,12 +246,12 @@ extension TaskFormSheet {
     var overviewSection: some View {
         Section {
             VStack(alignment: .leading, spacing: 8) {
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    requiredMarker
+                HStack(alignment: .center, spacing: 8) {
                     TextField("Task title", text: $draft.title, axis: .vertical)
                         .lineLimit(2...4)
                         .font(.title3.weight(.semibold))
                         .accessibilityIdentifier("task-form.title")
+                    requiredPill
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
@@ -267,14 +267,21 @@ extension TaskFormSheet {
     // Required fields are marked; only Title, State, and Author gate Create (see isSaveDisabled).
     // Assignee, Description, Reviewers, Watchers, and Items are optional.
     @ViewBuilder
-    var requiredMarker: some View {
-        Text("*")
-            .foregroundStyle(.red)
+    var requiredPill: some View {
+        Text("Required")
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.gray, in: Capsule())
             .accessibilityLabel("required")
     }
 
-    func requiredFieldLabel(_ title: String) -> Text {
-        Text(title) + Text("  *").foregroundStyle(.red)
+    func requiredFieldLabel(_ title: String) -> some View {
+        HStack(spacing: 6) {
+            Text(title)
+            requiredPill
+        }
     }
 
     var descriptionSection: some View {

--- a/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
+++ b/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
@@ -258,6 +258,13 @@ extension TaskFormSheet {
                 }
             }
             .padding(.vertical, 8)
+        } footer: {
+            // Only these three gate Create (see isSaveDisabled); Assignee, Description, Reviewers,
+            // Watchers, and Items are optional.
+            if case .create = mode {
+                Text("Title, State, and Author are required.")
+                    .accessibilityIdentifier("task-form.required-note")
+            }
         }
     }
 

--- a/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
+++ b/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
@@ -246,10 +246,13 @@ extension TaskFormSheet {
     var overviewSection: some View {
         Section {
             VStack(alignment: .leading, spacing: 8) {
-                TextField("Task title", text: $draft.title, axis: .vertical)
-                    .lineLimit(2...4)
-                    .font(.title3.weight(.semibold))
-                    .accessibilityIdentifier("task-form.title")
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    requiredMarker
+                    TextField("Task title", text: $draft.title, axis: .vertical)
+                        .lineLimit(2...4)
+                        .font(.title3.weight(.semibold))
+                        .accessibilityIdentifier("task-form.title")
+                }
 
                 VStack(alignment: .leading, spacing: 8) {
                     stateControl
@@ -258,14 +261,20 @@ extension TaskFormSheet {
                 }
             }
             .padding(.vertical, 8)
-        } footer: {
-            // Only these three gate Create (see isSaveDisabled); Assignee, Description, Reviewers,
-            // Watchers, and Items are optional.
-            if case .create = mode {
-                Text("Title, State, and Author are required.")
-                    .accessibilityIdentifier("task-form.required-note")
-            }
         }
+    }
+
+    // Required fields are marked; only Title, State, and Author gate Create (see isSaveDisabled).
+    // Assignee, Description, Reviewers, Watchers, and Items are optional.
+    @ViewBuilder
+    var requiredMarker: some View {
+        Text("*")
+            .foregroundStyle(.red)
+            .accessibilityLabel("required")
+    }
+
+    func requiredFieldLabel(_ title: String) -> Text {
+        Text(title) + Text("  *").foregroundStyle(.red)
     }
 
     var descriptionSection: some View {
@@ -350,12 +359,14 @@ extension TaskFormSheet {
                 ProgressView("Loading states...")
             }
         case .available:
-            Picker("State", selection: $draft.state) {
+            Picker(selection: $draft.state) {
                 ForEach(machine.taskStateOptions, id: \.id) { option in
                     Text(option.label)
                         .tag(option.id)
                         .accessibilityIdentifier("task-form.state.\(option.id)")
                 }
+            } label: {
+                requiredFieldLabel("State")
             }
             .pickerStyle(.menu)
             .onChange(of: draft.state) { _, newValue in
@@ -409,12 +420,14 @@ extension TaskFormSheet {
                     ProgressView("Loading people...")
                 }
             case .available:
-                Picker("Author", selection: $draft.authorID) {
+                Picker(selection: $draft.authorID) {
                     ForEach(machine.users, id: \.id) { user in
                         Text(user.displayName)
                             .tag(user.id)
                             .accessibilityIdentifier("task-form.author.option.\(user.id)")
                     }
+                } label: {
+                    requiredFieldLabel("Author")
                 }
                 .pickerStyle(.menu)
                 .accessibilityIdentifier("task-form.summary.author")

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -311,6 +311,52 @@ final class DemoUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["task.watcher.\(DemoSeedUserID.ethanLee)"].exists)
     }
 
+    // User journey: create a task offline (reference data is cached), then sync on reconnect.
+    @MainActor
+    func testOfflineCreateQueuesThenSyncsOnReconnect() throws {
+        let app = configuredApp()
+        app.launch()
+
+        // Online: the home screen warms reference data (users + task states) into the cache.
+        openProject(app, id: DemoSeedProjectID.accountSecurity)
+        XCTAssertTrue(
+            app.staticTexts["Add session timeout controls to account settings"].waitForExistence(timeout: 2))
+        goBack(app)
+
+        let toggle = app.buttons["offline-toggle"]
+        XCTAssertTrue(toggle.waitForExistence(timeout: 2))
+        toggle.tap()
+        XCTAssertEqual(app.buttons["offline-toggle"].label, "Offline")
+
+        // Create a task offline. With reference data cached, the form fills its defaults and Create enables.
+        openProject(app, id: DemoSeedProjectID.accountSecurity)
+        openCreateTaskForm(app)
+        let title = uniqueTitle(prefix: "Offline Created")
+        replaceText(in: app.textFields["task-form.title"], with: title, app: app)
+        XCTAssertTrue(app.buttons["task-form.save"].isEnabled, "offline create works with cached reference data")
+        app.buttons["task-form.save"].tap()
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 1))
+
+        // It appears locally and is queued.
+        XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
+        goBack(app)
+        XCTAssertTrue(app.staticTexts["pending-count"].waitForExistence(timeout: 2), "the create is queued")
+
+        // Reconnect and sync.
+        app.buttons["offline-toggle"].tap()
+        let syncNow = app.buttons["sync-now"]
+        XCTAssertTrue(syncNow.isEnabled)
+        syncNow.tap()
+        let okButton = app.alerts.buttons["OK"]
+        XCTAssertTrue(okButton.waitForExistence(timeout: 5))
+        okButton.tap()
+        XCTAssertTrue(app.staticTexts["pending-count"].waitForNonExistence(timeout: 3))
+
+        // It survived the sync: reopening online (a real refresh) still shows it.
+        openProject(app, id: DemoSeedProjectID.accountSecurity)
+        XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
+    }
+
     // User journey: work offline, queue a change, then sync on reconnect.
     @MainActor
     func testOfflineDeleteQueuesThenSyncsOnReconnect() throws {

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -331,8 +331,6 @@ final class DemoUITests: XCTestCase {
         // Create a task offline. With reference data cached, the form fills its defaults and Create enables.
         openProject(app, id: DemoSeedProjectID.accountSecurity)
         openCreateTaskForm(app)
-        XCTAssertTrue(
-            app.staticTexts["task-form.required-note"].exists, "the form marks which fields are required")
         let title = uniqueTitle(prefix: "Offline Created")
         replaceText(in: app.textFields["task-form.title"], with: title, app: app)
         XCTAssertTrue(app.buttons["task-form.save"].isEnabled, "offline create works with cached reference data")

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -331,6 +331,8 @@ final class DemoUITests: XCTestCase {
         // Create a task offline. With reference data cached, the form fills its defaults and Create enables.
         openProject(app, id: DemoSeedProjectID.accountSecurity)
         openCreateTaskForm(app)
+        XCTAssertTrue(
+            app.staticTexts["task-form.required-note"].exists, "the form marks which fields are required")
         let title = uniqueTitle(prefix: "Offline Created")
         replaceText(in: app.textFields["task-form.title"], with: title, app: app)
         XCTAssertTrue(app.buttons["task-form.save"].isEnabled, "offline create works with cached reference data")

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -310,6 +310,57 @@ final class DemoUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["task.watcher.\(DemoSeedUserID.liamBrown)"].exists)
         XCTAssertFalse(app.staticTexts["task.watcher.\(DemoSeedUserID.ethanLee)"].exists)
     }
+
+    // User journey: work offline, queue a change, then sync on reconnect.
+    @MainActor
+    func testOfflineDeleteQueuesThenSyncsOnReconnect() throws {
+        let app = configuredApp()
+        app.launch()
+
+        let doomedTitle = "Add session timeout controls to account settings"
+
+        // Online: open the project so its tasks are cached locally.
+        openProject(app, id: DemoSeedProjectID.accountSecurity)
+        XCTAssertTrue(app.staticTexts[doomedTitle].waitForExistence(timeout: 2))
+        goBack(app)
+
+        // Go offline (the toggle lives on the projects list).
+        let toggle = app.buttons["offline-toggle"]
+        XCTAssertTrue(toggle.waitForExistence(timeout: 2))
+        XCTAssertEqual(toggle.label, "Online")
+        toggle.tap()
+        XCTAssertEqual(app.buttons["offline-toggle"].label, "Offline")
+
+        // Reopen the project offline: cached tasks still render (a dead network is not a blank screen).
+        openProject(app, id: DemoSeedProjectID.accountSecurity)
+        XCTAssertTrue(app.staticTexts[doomedTitle].exists, "cached tasks remain visible offline")
+
+        // Delete a task offline: it leaves the list and becomes a pending change.
+        deleteTaskFromProject(app, id: DemoSeedTaskID.sessionTimeout)
+        XCTAssertTrue(app.staticTexts[doomedTitle].waitForNonExistence(timeout: 2))
+        goBack(app)
+
+        XCTAssertTrue(app.staticTexts["pending-count"].waitForExistence(timeout: 2), "the delete is queued")
+        XCTAssertFalse(app.buttons["sync-now"].isEnabled, "cannot push while offline")
+
+        // Reconnect and sync.
+        app.buttons["offline-toggle"].tap()
+        XCTAssertEqual(app.buttons["offline-toggle"].label, "Online")
+        let syncNow = app.buttons["sync-now"]
+        XCTAssertTrue(syncNow.isEnabled)
+        syncNow.tap()
+
+        // The "Synced" confirmation appears; dismiss it and the pending indicator clears.
+        let okButton = app.alerts.buttons["OK"]
+        XCTAssertTrue(okButton.waitForExistence(timeout: 5))
+        okButton.tap()
+        XCTAssertTrue(app.staticTexts["pending-count"].waitForNonExistence(timeout: 3))
+
+        // The deletion held: reopening online (a real server refresh) does not bring it back.
+        openProject(app, id: DemoSeedProjectID.accountSecurity)
+        XCTAssertTrue(app.staticTexts["Write QA item list for forced re-auth scenarios"].waitForExistence(timeout: 2))
+        XCTAssertFalse(app.staticTexts[doomedTitle].exists)
+    }
 }
 
 private extension DemoUITests {

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -626,10 +626,17 @@ public final class DemoServerSimulator {
     private func uploadDelete(_ payload: [String: Any]) throws -> [String: Any] {
         try requireTasksType(payload)
         let remote = try requireRemoteID(payload)
-        _ = try requireUpdatedAt(payload)
+        let incoming = try requireUpdatedAt(payload)
         guard let localID = try localID(forRemoteID: remote) else {
             // Already absent ⇒ idempotent success.
             return ["operation": "delete", "remoteId": remote, "status": "applied"]
+        }
+        // Last-writer-wins applies to deletes too: an older delete must not erase a newer server edit.
+        if try isStale(localID: localID, incoming: incoming) {
+            return [
+                "operation": "delete", "remoteId": remote, "status": "stale",
+                "server": try getTaskDetailPayload(taskID: localID) ?? NSNull(),
+            ]
         }
         suspendAmbientMutationsAfterWrite()
         try self.sqlite.execute(
@@ -702,7 +709,8 @@ public final class DemoServerSimulator {
             bind: { stmt in self.sqlite.bind(text: localID, at: 1, in: stmt) }
         )
         guard let stored = rows.first?.double("updated_at") else { return false }
-        return incoming.timeIntervalSince1970 < stored
+        // Contract: an incoming write older *or equal* loses (server wins ties).
+        return incoming.timeIntervalSince1970 <= stored
     }
 
     private func rejected(_ payload: [String: Any], code: String, message: String) -> [String: Any] {

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -680,9 +680,18 @@ public final class DemoServerSimulator {
     }
 
     private func localID(forRemoteID remote: String) throws -> String? {
+        // Match the minted remote_id, or fall back to id for pre-upload rows whose remote_id the
+        // payload coalesced to their id.
         let rows = try self.sqlite.query(
-            "SELECT id FROM tasks WHERE remote_id = ? AND deleted_at IS NULL LIMIT 1",
-            bind: { stmt in self.sqlite.bind(text: remote, at: 1, in: stmt) }
+            """
+            SELECT id FROM tasks
+            WHERE (remote_id = ? OR (remote_id IS NULL AND id = ?)) AND deleted_at IS NULL
+            LIMIT 1
+            """,
+            bind: { stmt in
+                self.sqlite.bind(text: remote, at: 1, in: stmt)
+                self.sqlite.bind(text: remote, at: 2, in: stmt)
+            }
         )
         return rows.first.map { $0.string("id") }
     }
@@ -822,7 +831,9 @@ public final class DemoServerSimulator {
         let stateID = row.string("state")
         return [
             "id": taskID,
-            "remote_id": row.nullableString("remote_id") ?? NSNull(),
+            // Rows created before the upload path (seed / per-resource POST) have no minted
+            // remote_id; their own id is their canonical server id, so coalesce to it.
+            "remote_id": row.nullableString("remote_id") ?? taskID,
             "project_id": row.string("project_id"),
             "assignee_id": row.nullableString("assignee_id") ?? NSNull(),
             "reviewer_ids": try reviewerIDsFor(taskID: taskID),

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -146,9 +146,9 @@ public final class DemoServerSimulator {
     public func getTaskDetailPayload(taskID: String) throws -> [String: Any]? {
         let rows = try self.sqlite.query(
             """
-            SELECT id, project_id, assignee_id, author_id, title, description, state, created_at, updated_at
+            SELECT id, remote_id, project_id, assignee_id, author_id, title, description, state, created_at, updated_at
             FROM tasks
-            WHERE id = ?
+            WHERE id = ? AND deleted_at IS NULL
             LIMIT 1
             """,
             bind: { stmt in
@@ -556,6 +556,154 @@ public final class DemoServerSimulator {
         )
     }
 
+    // MARK: - POST /sync/upload (offline batch push)
+    // See docs/project/upload-endpoint-contract.md. A flat, op-tagged operation list; per-operation
+    // results (no all-or-nothing). The server mints an opaque `remote_id`; `localId` (the task's `id`)
+    // is the stable client key and the idempotency key.
+
+    public func upload(operations: [[String: Any]]) throws -> [String: Any] {
+        let results = operations.map(applyUploadOperation(_:))
+        return ["results": results, "cursor": iso8601(Date().timeIntervalSince1970)]
+    }
+
+    private func applyUploadOperation(_ payload: [String: Any]) -> [String: Any] {
+        do {
+            switch payload["operation"] as? String {
+            case "insert": return try uploadInsert(payload)
+            case "update": return try uploadUpdate(payload)
+            case "delete": return try uploadDelete(payload)
+            case .none:
+                return rejected(payload, code: "missing_operation", message: "operation is required")
+            case .some(let other):
+                return rejected(payload, code: "unknown_operation", message: "unknown operation '\(other)'")
+            }
+        } catch let error as DemoBackendError {
+            return rejected(payload, code: "rejected", message: error.errorDescription ?? "rejected")
+        } catch {
+            return rejected(payload, code: "error", message: "\(error)")
+        }
+    }
+
+    private func uploadInsert(_ payload: [String: Any]) throws -> [String: Any] {
+        try requireTasksType(payload)
+        guard let localID = payload["localId"] as? String, !localID.isEmpty else {
+            throw DemoBackendError.validation(message: "localId is required for insert")
+        }
+        // Idempotency: a row already keyed by this localId ⇒ return its remote_id (retry-safe).
+        if try !exists(in: "tasks", id: localID) {
+            guard let data = payload["data"] as? [String: Any] else {
+                throw DemoBackendError.validation(message: "data is required for insert")
+            }
+            var body = data
+            body["id"] = localID
+            _ = try createTask(body: body)
+        }
+        let remote = try ensureRemoteID(forLocalID: localID)
+        return ["operation": "insert", "localId": localID, "remoteId": remote, "status": "applied"]
+    }
+
+    private func uploadUpdate(_ payload: [String: Any]) throws -> [String: Any] {
+        try requireTasksType(payload)
+        let remote = try requireRemoteID(payload)
+        let incoming = try requireUpdatedAt(payload)
+        guard let localID = try localID(forRemoteID: remote) else {
+            throw DemoBackendError.notFound(entity: "task", id: remote)
+        }
+        if try isStale(localID: localID, incoming: incoming) {
+            return [
+                "operation": "update", "remoteId": remote, "status": "stale",
+                "server": try getTaskDetailPayload(taskID: localID) ?? NSNull(),
+            ]
+        }
+        guard var body = payload["data"] as? [String: Any] else {
+            throw DemoBackendError.validation(message: "data is required for update")
+        }
+        body["id"] = localID
+        _ = try updateTask(taskID: localID, body: body)
+        return ["operation": "update", "remoteId": remote, "status": "applied"]
+    }
+
+    private func uploadDelete(_ payload: [String: Any]) throws -> [String: Any] {
+        try requireTasksType(payload)
+        let remote = try requireRemoteID(payload)
+        _ = try requireUpdatedAt(payload)
+        guard let localID = try localID(forRemoteID: remote) else {
+            // Already absent ⇒ idempotent success.
+            return ["operation": "delete", "remoteId": remote, "status": "applied"]
+        }
+        suspendAmbientMutationsAfterWrite()
+        try self.sqlite.execute(
+            "UPDATE tasks SET deleted_at = ? WHERE id = ?",
+            bind: { stmt in
+                self.sqlite.bind(double: Date().timeIntervalSince1970, at: 1, in: stmt)
+                self.sqlite.bind(text: localID, at: 2, in: stmt)
+            }
+        )
+        return ["operation": "delete", "remoteId": remote, "status": "applied"]
+    }
+
+    private func requireTasksType(_ payload: [String: Any]) throws {
+        guard (payload["type"] as? String) == "tasks" else {
+            throw DemoBackendError.validation(message: "unsupported type (only 'tasks')")
+        }
+    }
+
+    private func requireRemoteID(_ payload: [String: Any]) throws -> String {
+        guard let remote = payload["remoteId"] as? String, !remote.isEmpty else {
+            throw DemoBackendError.validation(message: "remoteId is required")
+        }
+        return remote
+    }
+
+    private func requireUpdatedAt(_ payload: [String: Any]) throws -> Date {
+        guard let date = try parseISO8601(payload["updatedAt"]) else {
+            throw DemoBackendError.validation(message: "updatedAt is required (ISO 8601)")
+        }
+        return date
+    }
+
+    private func ensureRemoteID(forLocalID localID: String) throws -> String {
+        let rows = try self.sqlite.query(
+            "SELECT remote_id FROM tasks WHERE id = ? LIMIT 1",
+            bind: { stmt in self.sqlite.bind(text: localID, at: 1, in: stmt) }
+        )
+        if let existing = rows.first?.nullableString("remote_id") { return existing }
+        let remote = "srv-\(UUID().uuidString.lowercased())"
+        try self.sqlite.execute(
+            "UPDATE tasks SET remote_id = ? WHERE id = ?",
+            bind: { stmt in
+                self.sqlite.bind(text: remote, at: 1, in: stmt)
+                self.sqlite.bind(text: localID, at: 2, in: stmt)
+            }
+        )
+        return remote
+    }
+
+    private func localID(forRemoteID remote: String) throws -> String? {
+        let rows = try self.sqlite.query(
+            "SELECT id FROM tasks WHERE remote_id = ? AND deleted_at IS NULL LIMIT 1",
+            bind: { stmt in self.sqlite.bind(text: remote, at: 1, in: stmt) }
+        )
+        return rows.first.map { $0.string("id") }
+    }
+
+    private func isStale(localID: String, incoming: Date) throws -> Bool {
+        let rows = try self.sqlite.query(
+            "SELECT updated_at FROM tasks WHERE id = ? LIMIT 1",
+            bind: { stmt in self.sqlite.bind(text: localID, at: 1, in: stmt) }
+        )
+        guard let stored = rows.first?.double("updated_at") else { return false }
+        return incoming.timeIntervalSince1970 < stored
+    }
+
+    private func rejected(_ payload: [String: Any], code: String, message: String) -> [String: Any] {
+        var result: [String: Any] = ["status": "rejected", "code": code, "message": message]
+        if let operation = payload["operation"] as? String { result["operation"] = operation }
+        if let localID = payload["localId"] as? String { result["localId"] = localID }
+        if let remoteID = payload["remoteId"] as? String { result["remoteId"] = remoteID }
+        return result
+    }
+
     private func applyAmbientProjectMutation(projectID: String, step: Int) throws {
         guard try exists(in: "projects", id: projectID) else { return }
 
@@ -580,11 +728,14 @@ public final class DemoServerSimulator {
         whereClause: String,
         bind: ((OpaquePointer?) throws -> Void)?
     ) throws -> [[String: Any]] {
+        let scoped =
+            whereClause.isEmpty
+            ? "WHERE tasks.deleted_at IS NULL" : "\(whereClause) AND tasks.deleted_at IS NULL"
         let rows = try self.sqlite.query(
             """
-            SELECT tasks.id, tasks.project_id, tasks.assignee_id, tasks.author_id, tasks.title, tasks.description, tasks.state, tasks.created_at, tasks.updated_at
+            SELECT tasks.id, tasks.remote_id, tasks.project_id, tasks.assignee_id, tasks.author_id, tasks.title, tasks.description, tasks.state, tasks.created_at, tasks.updated_at
             FROM tasks
-            \(whereClause)
+            \(scoped)
             ORDER BY tasks.id ASC
             """,
             bind: bind
@@ -671,6 +822,7 @@ public final class DemoServerSimulator {
         let stateID = row.string("state")
         return [
             "id": taskID,
+            "remote_id": row.nullableString("remote_id") ?? NSNull(),
             "project_id": row.string("project_id"),
             "assignee_id": row.nullableString("assignee_id") ?? NSNull(),
             "reviewer_ids": try reviewerIDsFor(taskID: taskID),
@@ -937,6 +1089,8 @@ public final class DemoServerSimulator {
 
             CREATE TABLE IF NOT EXISTS tasks (
                 id TEXT PRIMARY KEY,
+                remote_id TEXT NULL,
+                deleted_at REAL NULL,
                 project_id TEXT NOT NULL,
                 assignee_id TEXT NULL,
                 author_id TEXT NOT NULL,

--- a/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
@@ -71,6 +71,31 @@ final class UploadEndpointTests: XCTestCase {
             "tombstoned row is hidden from the list")
     }
 
+    func testUploadDeleteIsLastWriterWins() throws {
+        let backend = try makeBackend()
+        let localID = "LOCAL-DELETE-LWW-1"
+        let inserted = try result(of: backend.upload(operations: [
+            insertOp(localID: localID, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
+        ]))
+        let remoteID = try XCTUnwrap(inserted["remoteId"] as? String)
+
+        // A delete older than the server's version must lose: stale + server state, not a tombstone.
+        let stale = try result(of: backend.upload(operations: [
+            deleteOp(remoteID: remoteID, updatedAt: "2020-01-01T00:00:00.000Z")
+        ]))
+        XCTAssertEqual(stale["status"] as? String, "stale")
+        XCTAssertNotNil(stale["server"] as? [String: Any])
+        XCTAssertNotNil(
+            try backend.getTaskDetailPayload(taskID: localID), "a stale delete must not tombstone the row")
+
+        // A newer delete wins.
+        let applied = try result(of: backend.upload(operations: [
+            deleteOp(remoteID: remoteID, updatedAt: "2040-01-01T00:00:00.000Z")
+        ]))
+        XCTAssertEqual(applied["status"] as? String, "applied")
+        XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID))
+    }
+
     func testUploadFailsClosedOnMissingOrUnknownOperation() throws {
         let backend = try makeBackend()
         let response = try backend.upload(operations: [

--- a/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import XCTest
+
+@testable import DemoBackend
+
+final class UploadEndpointTests: XCTestCase {
+    private let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+    private let authorID = DemoSeedData.SeedIDs.Users.avaMartinez
+
+    func testUploadInsertMintsDistinctRemoteIDAndIsIdempotent() throws {
+        let backend = try makeBackend()
+        let localID = "LOCAL-INSERT-1"
+        let before = try backend.getProjectTasksPayload(projectID: projectID).count
+
+        let first = try result(of: backend.upload(operations: [insertOp(localID: localID, title: "Offline task")]))
+        XCTAssertEqual(first["status"] as? String, "applied")
+        let remoteID = try XCTUnwrap(first["remoteId"] as? String)
+        XCTAssertNotEqual(remoteID, localID, "the server mints its own remote id, distinct from localId")
+        XCTAssertTrue(remoteID.hasPrefix("srv-"))
+
+        let tasks = try backend.getProjectTasksPayload(projectID: projectID)
+        XCTAssertEqual(tasks.count, before + 1)
+        let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == localID })
+        XCTAssertEqual(inserted["remote_id"] as? String, remoteID)
+
+        // Retry the same insert (lost-response scenario): same remote id, no duplicate row.
+        let retry = try result(of: backend.upload(operations: [insertOp(localID: localID, title: "Offline task")]))
+        XCTAssertEqual(retry["remoteId"] as? String, remoteID)
+        XCTAssertEqual(try backend.getProjectTasksPayload(projectID: projectID).count, before + 1)
+    }
+
+    func testUploadUpdateIsLastWriterWins() throws {
+        let backend = try makeBackend()
+        let localID = "LOCAL-UPDATE-1"
+        let inserted = try result(of: backend.upload(operations: [
+            insertOp(localID: localID, title: "Original", updatedAt: "2026-01-01T00:00:00.000Z")
+        ]))
+        let remoteID = try XCTUnwrap(inserted["remoteId"] as? String)
+
+        // Older write loses: kept server state returned, title unchanged.
+        let stale = try result(of: backend.upload(operations: [
+            updateOp(remoteID: remoteID, localID: localID, title: "Stale edit", updatedAt: "2020-01-01T00:00:00.000Z")
+        ]))
+        XCTAssertEqual(stale["status"] as? String, "stale")
+        let server = try XCTUnwrap(stale["server"] as? [String: Any])
+        XCTAssertEqual(server["title"] as? String, "Original")
+
+        // Newer write wins.
+        let applied = try result(of: backend.upload(operations: [
+            updateOp(remoteID: remoteID, localID: localID, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
+        ]))
+        XCTAssertEqual(applied["status"] as? String, "applied")
+        let detail = try XCTUnwrap(backend.getTaskDetailPayload(taskID: localID))
+        XCTAssertEqual(detail["title"] as? String, "Fresh edit")
+    }
+
+    func testUploadDeleteTombstonesAndHidesFromReads() throws {
+        let backend = try makeBackend()
+        let localID = "LOCAL-DELETE-1"
+        let inserted = try result(of: backend.upload(operations: [insertOp(localID: localID, title: "Doomed")]))
+        let remoteID = try XCTUnwrap(inserted["remoteId"] as? String)
+
+        let deleted = try result(of: backend.upload(operations: [
+            deleteOp(remoteID: remoteID, updatedAt: "2030-01-01T00:00:00.000Z")
+        ]))
+        XCTAssertEqual(deleted["status"] as? String, "applied")
+
+        XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID), "tombstoned row is hidden from detail")
+        XCTAssertFalse(
+            try backend.getProjectTasksPayload(projectID: projectID).contains { ($0["id"] as? String) == localID },
+            "tombstoned row is hidden from the list")
+    }
+
+    func testUploadFailsClosedOnMissingOrUnknownOperation() throws {
+        let backend = try makeBackend()
+        let response = try backend.upload(operations: [
+            ["type": "tasks", "localId": "x", "data": [:]],  // no operation
+            ["operation": "destroy", "type": "tasks", "remoteId": "y"],  // unknown
+        ])
+        let results = try XCTUnwrap(response["results"] as? [[String: Any]])
+        XCTAssertEqual(results.allSatisfy { ($0["status"] as? String) == "rejected" }, true)
+        XCTAssertEqual(results[0]["code"] as? String, "missing_operation")
+        XCTAssertEqual(results[1]["code"] as? String, "unknown_operation")
+    }
+
+    // MARK: - Helpers
+
+    private func makeBackend() throws -> DemoServerSimulator {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("upload-tests-\(UUID().uuidString).sqlite")
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
+    }
+
+    private func insertOp(localID: String, title: String, updatedAt: String = "2026-06-16T20:00:00.000Z")
+        -> [String: Any]
+    {
+        [
+            "operation": "insert", "type": "tasks", "localId": localID, "updatedAt": updatedAt,
+            "data": [
+                "project_id": projectID, "author_id": authorID, "title": title,
+                "description": "from offline", "state": ["id": "todo"],
+                "created_at": updatedAt, "updated_at": updatedAt,
+            ],
+        ]
+    }
+
+    private func updateOp(remoteID: String, localID: String, title: String, updatedAt: String)
+        -> [String: Any]
+    {
+        [
+            "operation": "update", "type": "tasks", "remoteId": remoteID, "updatedAt": updatedAt,
+            "data": [
+                "id": localID, "project_id": projectID, "author_id": authorID, "title": title,
+                "description": "edited", "state": ["id": "todo"],
+                "created_at": "2026-01-01T00:00:00.000Z", "updated_at": updatedAt,
+            ],
+        ]
+    }
+
+    private func deleteOp(remoteID: String, updatedAt: String) -> [String: Any] {
+        ["operation": "delete", "type": "tasks", "remoteId": remoteID, "updatedAt": updatedAt]
+    }
+
+    private func result(of response: [String: Any]) throws -> [String: Any] {
+        let results = try XCTUnwrap(response["results"] as? [[String: Any]])
+        return try XCTUnwrap(results.first)
+    }
+}

--- a/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
+++ b/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
@@ -118,7 +118,7 @@ public final class ProjectViewMachine {
         projectPublisher.rows.first(where: { $0.id == projectID })
     }
     public var tasks: [Task] {
-        taskPublisher.rows
+        taskPublisher.rows.filter { $0.isLocallyDeleted != true }
     }
     public var contentState: ProjectDetailContentState {
         resolveProjectDetailContentState(

--- a/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
+++ b/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
@@ -104,6 +104,9 @@ public final class ProjectsViewMachine {
     public func send(_ event: ScreenLoadEvent) {
         loadMachine.send(event, run: { [syncEngine] in
             try await syncEngine.syncProjects()
+            // Warm reference data (users + task states) on the home screen so it is cached for
+            // offline task creation — otherwise the new-task form has no options while offline.
+            try await syncEngine.syncTaskFormMetadata()
         })
     }
 

--- a/DemoCore/Sources/DemoCore/Models/DemoModels.swift
+++ b/DemoCore/Sources/DemoCore/Models/DemoModels.swift
@@ -85,6 +85,9 @@ public final class Task {
     public var createdAt: Date
     public var updatedAt: Date
 
+    // Imported from the server's `remote_id` (so a synced row knows its server id for later
+    // update/delete addressing); never exported back.
+    @RemoteKey("remote_id")
     @NotExport
     public var syncRemoteID: String?
 

--- a/DemoCore/Sources/DemoCore/Models/DemoModels.swift
+++ b/DemoCore/Sources/DemoCore/Models/DemoModels.swift
@@ -86,6 +86,14 @@ public final class Task {
     public var updatedAt: Date
 
     @NotExport
+    public var syncRemoteID: String?
+
+    // Not `isDeleted`: that name collides with PersistentModel's built-in context-deletion flag,
+    // which silently shadows a stored property of the same name.
+    @NotExport
+    public var isLocallyDeleted: Bool?
+
+    @NotExport
     public var project: Project?
 
     @NotExport
@@ -115,6 +123,8 @@ public final class Task {
         stateLabel: String = "",
         createdAt: Date = Date(),
         updatedAt: Date = Date(),
+        syncRemoteID: String? = nil,
+        isLocallyDeleted: Bool? = nil,
         project: Project? = nil,
         author: User? = nil,
         assignee: User? = nil,
@@ -132,6 +142,8 @@ public final class Task {
         self.stateLabel = stateLabel
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+        self.syncRemoteID = syncRemoteID
+        self.isLocallyDeleted = isLocallyDeleted
         self.project = project
         self.author = author
         self.assignee = assignee
@@ -139,6 +151,12 @@ public final class Task {
         self.watchers = watchers
         self.items = items
     }
+}
+
+extension Task: SyncOfflineModel {
+    public var syncLocalID: String { id }
+    public var syncUpdatedAt: Date { updatedAt }
+    public var syncIsDeleted: Bool { isLocallyDeleted ?? false }
 }
 
 @Syncable

--- a/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
+++ b/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
@@ -8,7 +8,6 @@ public enum DemoNetworkScenario: String, CaseIterable, Identifiable {
     case fastStable
     case slowNetwork
     case flakyNetwork
-    case offline
 
     public var id: String { rawValue }
 
@@ -17,7 +16,6 @@ public enum DemoNetworkScenario: String, CaseIterable, Identifiable {
         case .fastStable: "Fast Stable"
         case .slowNetwork: "Slow Network"
         case .flakyNetwork: "Flaky Network"
-        case .offline: "Offline"
         }
     }
 }
@@ -30,7 +28,7 @@ public enum DemoAPIError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .offline:
-            return "You are offline in this scenario preset."
+            return "The device is offline."
         case let .transient(endpoint):
             return "Transient network failure while calling \(endpoint)."
         case let .invalidPayload(message):
@@ -47,6 +45,12 @@ public final class FakeDemoAPIClient {
     }
 
     public var scenario: DemoNetworkScenario
+
+    /// Simulated airplane mode at the transport: when on, every endpoint is unreachable (throws
+    /// `.offline`), exactly like a device with no connectivity. This is where "offline" lives — the
+    /// link between app and server — not in business logic. The sync engine reacts to it (reads keep
+    /// serving the local cache, writes queue).
+    public var isOffline = false
 
     private let backend: DemoServerSimulator
     private let networkDelayMode: NetworkDelayMode
@@ -154,12 +158,14 @@ public final class FakeDemoAPIClient {
     }
 
     private func networkGate(endpoint: String) async throws {
+        if isOffline {
+            throw DemoAPIError.offline
+        }
+
         requestCounter += 1
         let callIndex = requestCounter
 
         switch scenario {
-        case .offline:
-            throw DemoAPIError.offline
         case .flakyNetwork:
             if ((callIndex + endpoint.count) % 5) == 0 {
                 throw DemoAPIError.transient(endpoint: endpoint)
@@ -174,7 +180,6 @@ public final class FakeDemoAPIClient {
         case .fastStable: 150
         case .slowNetwork: 950
         case .flakyNetwork: 450
-        case .offline: 0
         }
 
         let isMutation = endpoint.hasPrefix("PATCH ") || endpoint.hasPrefix("POST ") || endpoint.hasPrefix("PUT ") || endpoint.hasPrefix("DELETE ")

--- a/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
+++ b/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
@@ -146,6 +146,13 @@ public final class FakeDemoAPIClient {
         try backend.deleteTask(taskID: taskID)
     }
 
+    /// POST /sync/upload — the batched offline push. Returns the per-operation `results` array.
+    public func upload(operations: [[String: Any]]) async throws -> [[String: Any]] {
+        try await networkGate(endpoint: "POST /sync/upload")
+        let response = try backend.upload(operations: operations)
+        return (response["results"] as? [[String: Any]]) ?? []
+    }
+
     private func networkGate(endpoint: String) async throws {
         requestCounter += 1
         let callIndex = requestCounter

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -22,9 +22,12 @@ public final class DemoSyncEngine {
 
     public private(set) var isSyncing = false
 
-    /// When on, task create/edit/delete mutate the local store only — no network — and accumulate as
-    /// pending changes until `pushPendingChanges()` reconciles them with the server.
-    public var isOffline = false
+    /// Simulated airplane mode. The state lives at the transport (`apiClient`); this mirror drives it
+    /// and lets the UI bind to it. While offline, pulls keep serving the local cache, task edits queue
+    /// locally, and push is held — reconciled on reconnect.
+    public var isOffline = false {
+        didSet { apiClient.isOffline = isOffline }
+    }
 
     public private(set) var pendingChangeCount = 0
 
@@ -44,27 +47,37 @@ public final class DemoSyncEngine {
     }
 
     public func syncProjects() async throws {
-        try await runOperation("projects") {
-            try await syncProjectsData()
+        try await pull("projects") {
+            try await self.syncProjectsData()
         }
     }
 
     public func syncProjectTasks(projectID: String) async throws {
-        try await runOperation("projectTasks-\(projectID)") {
-            try await syncProjectTasksData(projectID: projectID)
+        try await pull("projectTasks-\(projectID)") {
+            try await self.syncProjectTasksData(projectID: projectID)
         }
     }
 
     public func syncTaskDetail(taskID: String) async throws {
-        try await runOperation("taskDetail-\(taskID)") {
-            try await syncTaskDetailData(taskID: taskID)
+        try await pull("taskDetail-\(taskID)") {
+            try await self.syncTaskDetailData(taskID: taskID)
         }
     }
 
     public func syncTaskFormMetadata() async throws {
-        try await runOperation("taskFormMetadata") {
-            try await syncUsersData()
-            try await syncTaskStatesData()
+        try await pull("taskFormMetadata") {
+            try await self.syncUsersData()
+            try await self.syncTaskStatesData()
+        }
+    }
+
+    /// Run an inbound pull, tolerating a dead transport: while offline the refresh is skipped and the
+    /// UI keeps reading the local cache (a failed refresh is a non-event, never a surfaced error).
+    private func pull(_ key: String, _ operation: () async throws -> Void) async throws {
+        do {
+            try await runOperation(key, operation)
+        } catch DemoAPIError.offline {
+            // Offline: keep serving what's already in the local store.
         }
     }
 

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -158,43 +158,70 @@ public final class DemoSyncEngine {
         return summary
     }
 
+    /// Serialize the pending batch into the `/sync/upload` operation list, POST it once, and map the
+    /// per-operation results back into a `SyncPushResponse`. Inserts carry the `localId` + full
+    /// resource; updates/deletes carry the server-assigned `remoteId` (from `syncRemoteID`). A `stale`
+    /// result means the server won last-writer-wins — adopt its state locally and treat the row as
+    /// resolved so it isn't re-sent.
     private func upload(_ batch: SyncPushBatch) async throws -> SyncPushResponse {
-        var response = SyncPushResponse()
+        var operations: [[String: Any]] = []
+        var remoteToLocal: [String: String] = [:]
+
         for localID in batch.inserts {
-            guard let body = try taskBody(localID: localID) else { continue }
-            do {
-                let created = try await apiClient.createTask(body: body)
-                response.assignedRemoteIDs[localID] = created.string("id") ?? localID
-            } catch {
-                response.failures.append(
-                    SyncPushFailure(localID: localID, operation: .insert, message: errorMessage(error)))
-            }
+            guard let task = try task(withID: localID) else { continue }
+            let data = syncContainer.export(task)
+            operations.append([
+                "operation": "insert", "type": "tasks", "localId": localID,
+                "updatedAt": data["updated_at"] ?? "", "data": data,
+            ])
         }
         for localID in batch.updates {
-            guard let body = try taskBody(localID: localID) else { continue }
-            do {
-                _ = try await apiClient.updateTask(taskID: localID, body: body)
-                response.confirmedUpdateLocalIDs.insert(localID)
-            } catch {
-                response.failures.append(
-                    SyncPushFailure(localID: localID, operation: .update, message: errorMessage(error)))
-            }
+            guard let task = try task(withID: localID), let remote = task.syncRemoteID else { continue }
+            remoteToLocal[remote] = localID
+            let data = syncContainer.export(task)
+            operations.append([
+                "operation": "update", "type": "tasks", "remoteId": remote,
+                "updatedAt": data["updated_at"] ?? "", "data": data,
+            ])
         }
         for localID in batch.deletes {
-            do {
-                try await apiClient.deleteTask(taskID: localID)
-                response.confirmedDeleteLocalIDs.insert(localID)
-            } catch {
+            guard let task = try task(withID: localID), let remote = task.syncRemoteID else { continue }
+            remoteToLocal[remote] = localID
+            let data = syncContainer.export(task)
+            operations.append([
+                "operation": "delete", "type": "tasks", "remoteId": remote,
+                "updatedAt": data["updated_at"] ?? "",
+            ])
+        }
+
+        let results = try await apiClient.upload(operations: operations)
+
+        var response = SyncPushResponse()
+        for result in results {
+            let operation = result["operation"] as? String
+            let status = result["status"] as? String
+            let remoteID = result["remoteId"] as? String
+            let localID = (result["localId"] as? String) ?? remoteID.flatMap { remoteToLocal[$0] }
+            switch (operation, status) {
+            case ("insert", "applied"):
+                if let localID, let remoteID { response.assignedRemoteIDs[localID] = remoteID }
+            case ("update", "applied"), ("update", "stale"):
+                if let localID { response.confirmedUpdateLocalIDs.insert(localID) }
+                if status == "stale", let server = result["server"] as? [String: Any] {
+                    try? await syncContainer.sync(item: DemoSyncPayload(dictionary: server), as: Task.self)
+                }
+            case ("delete", "applied"):
+                if let localID { response.confirmedDeleteLocalIDs.insert(localID) }
+            default:
+                let operationKind: SyncPushFailure.Operation =
+                    operation == "insert" ? .insert : (operation == "delete" ? .delete : .update)
                 response.failures.append(
-                    SyncPushFailure(localID: localID, operation: .delete, message: errorMessage(error)))
+                    SyncPushFailure(
+                        localID: localID ?? remoteID ?? "", operation: operationKind,
+                        message: (result["message"] as? String) ?? "rejected"))
             }
         }
         return response
-    }
-
-    private func taskBody(localID: String) throws -> DemoSyncPayload? {
-        guard let task = try task(withID: localID) else { return nil }
-        return try DemoSyncPayload(dictionary: syncContainer.export(task))
     }
 
     private func refreshPendingCount() {
@@ -203,25 +230,11 @@ public final class DemoSyncEngine {
         pendingChangeCount = pending.map { $0.inserts.count + $0.updates.count + $0.deletes.count } ?? 0
     }
 
-    /// Mark every task the server just reported as synced (`syncRemoteID = id`) and advance the cursor,
-    /// so freshly-pulled rows are not later mistaken for local inserts or edits.
-    private func markServerTasksSynced(payloadIDs: [String]) throws {
-        let idSet = Set(payloadIDs.filter { !$0.isEmpty })
-        if !idSet.isEmpty {
-            let tasks = try syncContainer.mainContext.fetch(FetchDescriptor<Task>())
-            var changed = false
-            for task in tasks where task.syncRemoteID == nil && idSet.contains(task.id) {
-                task.syncRemoteID = task.id
-                changed = true
-            }
-            if changed { try syncContainer.mainContext.save() }
-        }
+    /// After an inbound pull, advance the cursor so freshly-pulled rows aren't mistaken for local
+    /// edits, and refresh the pending count. (`syncRemoteID` is populated from `remote_id` on import.)
+    private func markPulled() {
         syncCursor = Date()
         refreshPendingCount()
-    }
-
-    private func errorMessage(_ error: Error) -> String {
-        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
     }
 
     private func syncProjectsData() async throws {
@@ -259,7 +272,7 @@ public final class DemoSyncEngine {
             parent: project,
             relationship: \Task.project
         )
-        try markServerTasksSynced(payloadIDs: payload.compactMap { $0.string("id") })
+        markPulled()
         try await syncProjectsData()
     }
 
@@ -283,9 +296,7 @@ public final class DemoSyncEngine {
             throw SyncTaskDetailError.missingProject(projectID)
         }
         try await syncContainer.sync(item: payload, as: Task.self)
-        if let taskID = payload.string("id") {
-            try markServerTasksSynced(payloadIDs: [taskID])
-        }
+        markPulled()
     }
 
     private func syncTaskAfterMutation(taskID: String, projectID: String?) async throws {

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -22,6 +22,17 @@ public final class DemoSyncEngine {
 
     public private(set) var isSyncing = false
 
+    /// When on, task create/edit/delete mutate the local store only — no network — and accumulate as
+    /// pending changes until `pushPendingChanges()` reconciles them with the server.
+    public var isOffline = false
+
+    public private(set) var pendingChangeCount = 0
+
+    /// Last point local state was reconciled with the server. Edits after this are pending updates;
+    /// advanced after every inbound pull (so freshly-pulled rows aren't mistaken for local edits) and
+    /// after a successful push.
+    private var syncCursor = Date()
+
     private var inFlightOperations: Set<String> = []
 
     private let syncContainer: SyncContainer
@@ -58,6 +69,14 @@ public final class DemoSyncEngine {
     }
 
     public func createTask(body: DemoSyncPayload, projectID: String) async throws {
+        if isOffline {
+            guard try project(withID: projectID) != nil else {
+                throw SyncTaskDetailError.missingProject(projectID)
+            }
+            try await syncContainer.sync(item: body, as: Task.self)
+            refreshPendingCount()
+            return
+        }
         try await runOperation("createTask-\(projectID)") {
             let created = try await apiClient.createTask(body: body)
             try await syncProjectTasksData(projectID: projectID)
@@ -68,6 +87,15 @@ public final class DemoSyncEngine {
     }
 
     public func updateTask(taskID: String, projectID: String?, body: DemoSyncPayload) async throws {
+        if isOffline {
+            try await syncContainer.sync(item: body, as: Task.self)
+            if let task = try task(withID: taskID) {
+                task.updatedAt = Date()
+                try syncContainer.mainContext.save()
+            }
+            refreshPendingCount()
+            return
+        }
         try await runOperation("updateTask-\(taskID)") {
             _ = try await apiClient.updateTask(taskID: taskID, body: body)
             try await syncTaskAfterMutation(taskID: taskID, projectID: projectID)
@@ -75,6 +103,15 @@ public final class DemoSyncEngine {
     }
 
     public func deleteTask(taskID: String, projectID: String) async throws {
+        if isOffline {
+            if let task = try task(withID: taskID) {
+                task.isLocallyDeleted = true
+                task.updatedAt = Date()
+                try syncContainer.mainContext.save()
+            }
+            refreshPendingCount()
+            return
+        }
         try await runOperation("deleteTask-\(taskID)") {
             try await apiClient.deleteTask(taskID: taskID)
             try await syncProjectTasksData(projectID: projectID)
@@ -93,6 +130,97 @@ public final class DemoSyncEngine {
             _ = try await self.apiClient.replaceTaskWatchers(taskID: taskID, watcherIDs: watcherIDs)
             try await self.syncTaskAfterMutation(taskID: taskID, projectID: projectID)
         }
+    }
+
+    /// Push every locally-pending task change to the server and apply the result. Returns `nil` if a
+    /// push is already in flight.
+    @discardableResult
+    public func pushPendingChanges() async throws -> SyncPushSummary? {
+        let key = "push"
+        guard !inFlightOperations.contains(key) else { return nil }
+
+        inFlightOperations.insert(key)
+        isSyncing = true
+        defer {
+            inFlightOperations.remove(key)
+            isSyncing = !inFlightOperations.isEmpty
+        }
+
+        let summary = try await SwiftSync.push(
+            for: Task.self,
+            in: syncContainer.mainContext,
+            changedSince: syncCursor,
+            upload: { batch in try await self.upload(batch) }
+        )
+        syncCursor = summary.cursor
+        refreshPendingCount()
+        return summary
+    }
+
+    private func upload(_ batch: SyncPushBatch) async throws -> SyncPushResponse {
+        var response = SyncPushResponse()
+        for localID in batch.inserts {
+            guard let body = try taskBody(localID: localID) else { continue }
+            do {
+                let created = try await apiClient.createTask(body: body)
+                response.assignedRemoteIDs[localID] = created.string("id") ?? localID
+            } catch {
+                response.failures.append(
+                    SyncPushFailure(localID: localID, operation: .insert, message: errorMessage(error)))
+            }
+        }
+        for localID in batch.updates {
+            guard let body = try taskBody(localID: localID) else { continue }
+            do {
+                _ = try await apiClient.updateTask(taskID: localID, body: body)
+                response.confirmedUpdateLocalIDs.insert(localID)
+            } catch {
+                response.failures.append(
+                    SyncPushFailure(localID: localID, operation: .update, message: errorMessage(error)))
+            }
+        }
+        for localID in batch.deletes {
+            do {
+                try await apiClient.deleteTask(taskID: localID)
+                response.confirmedDeleteLocalIDs.insert(localID)
+            } catch {
+                response.failures.append(
+                    SyncPushFailure(localID: localID, operation: .delete, message: errorMessage(error)))
+            }
+        }
+        return response
+    }
+
+    private func taskBody(localID: String) throws -> DemoSyncPayload? {
+        guard let task = try task(withID: localID) else { return nil }
+        return try DemoSyncPayload(dictionary: syncContainer.export(task))
+    }
+
+    private func refreshPendingCount() {
+        let pending = try? SwiftSync.pendingChanges(
+            for: Task.self, in: syncContainer.mainContext, changedSince: syncCursor)
+        pendingChangeCount = pending.map { $0.inserts.count + $0.updates.count + $0.deletes.count } ?? 0
+    }
+
+    /// Mark every task the server just reported as synced (`syncRemoteID = id`) and advance the cursor,
+    /// so freshly-pulled rows are not later mistaken for local inserts or edits.
+    private func markServerTasksSynced(payloadIDs: [String]) throws {
+        let idSet = Set(payloadIDs.filter { !$0.isEmpty })
+        if !idSet.isEmpty {
+            let tasks = try syncContainer.mainContext.fetch(FetchDescriptor<Task>())
+            var changed = false
+            for task in tasks where task.syncRemoteID == nil && idSet.contains(task.id) {
+                task.syncRemoteID = task.id
+                changed = true
+            }
+            if changed { try syncContainer.mainContext.save() }
+        }
+        syncCursor = Date()
+        refreshPendingCount()
+    }
+
+    private func errorMessage(_ error: Error) -> String {
+        (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
     }
 
     private func syncProjectsData() async throws {
@@ -130,6 +258,7 @@ public final class DemoSyncEngine {
             parent: project,
             relationship: \Task.project
         )
+        try markServerTasksSynced(payloadIDs: payload.compactMap { $0.string("id") })
         try await syncProjectsData()
     }
 
@@ -153,6 +282,9 @@ public final class DemoSyncEngine {
             throw SyncTaskDetailError.missingProject(projectID)
         }
         try await syncContainer.sync(item: payload, as: Task.self)
+        if let taskID = payload.string("id") {
+            try markServerTasksSynced(payloadIDs: [taskID])
+        }
     }
 
     private func syncTaskAfterMutation(taskID: String, projectID: String?) async throws {

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -225,6 +225,13 @@ public final class DemoSyncEngine {
                 }
             case ("delete", "applied"):
                 if let localID { response.confirmedDeleteLocalIDs.insert(localID) }
+            case ("delete", "stale"):
+                // The server has a newer edit — the delete lost LWW. Abandon the tombstone and adopt
+                // the server's state so the row reappears with the winning version (no re-send loop).
+                if let localID, let server = result["server"] as? [String: Any] {
+                    try? await syncContainer.sync(item: DemoSyncPayload(dictionary: server), as: Task.self)
+                    if let task = try task(withID: localID) { task.isLocallyDeleted = false }
+                }
             default:
                 let operationKind: SyncPushFailure.Operation =
                     operation == "insert" ? .insert : (operation == "delete" ? .delete : .update)

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -132,10 +132,11 @@ public final class DemoSyncEngine {
         }
     }
 
-    /// Push every locally-pending task change to the server and apply the result. Returns `nil` if a
-    /// push is already in flight.
+    /// Push every locally-pending task change to the server and apply the result. Returns `nil` while
+    /// offline (no network) or if a push is already in flight.
     @discardableResult
     public func pushPendingChanges() async throws -> SyncPushSummary? {
+        guard !isOffline else { return nil }
         let key = "push"
         guard !inFlightOperations.contains(key) else { return nil }
 

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -1,0 +1,106 @@
+import SwiftData
+import SwiftSync
+import XCTest
+
+@testable import DemoCore
+
+final class OfflinePushTests: XCTestCase {
+
+    @MainActor
+    func testOfflineCreateThenPushStampsRemoteIDAndReachesBackend() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        try await engine.syncProjectTasks(projectID: projectID)
+        XCTAssertEqual(engine.pendingChangeCount, 0)
+
+        let body = try createBody(
+            from: DemoSeedData.SeedIDs.Tasks.sessionTimeout,
+            newID: "OFFLINE-CREATE-1",
+            in: syncContainer
+        )
+
+        engine.isOffline = true
+        try await engine.createTask(body: body, projectID: projectID)
+
+        let local = try XCTUnwrap(fetchTask(id: "OFFLINE-CREATE-1", in: syncContainer.mainContext))
+        XCTAssertNil(local.syncRemoteID, "an offline-created row is pending until pushed")
+        XCTAssertEqual(engine.pendingChangeCount, 1)
+
+        engine.isOffline = false
+        let pushResult = try await engine.pushPendingChanges()
+        let summary = try XCTUnwrap(pushResult)
+
+        XCTAssertEqual(summary.insertedCount, 1)
+        XCTAssertTrue(summary.failures.isEmpty)
+        XCTAssertEqual(engine.pendingChangeCount, 0)
+
+        let synced = try XCTUnwrap(fetchTask(id: "OFFLINE-CREATE-1", in: syncContainer.mainContext))
+        XCTAssertEqual(synced.syncRemoteID, "OFFLINE-CREATE-1", "push stamps the server-assigned id")
+        let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-CREATE-1")
+        XCTAssertNotNil(backendDetail)
+    }
+
+    @MainActor
+    func testOfflineDeleteThenPushHardDeletesLocallyAndOnBackend() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        engine.isOffline = true
+        try await engine.deleteTask(taskID: taskID, projectID: projectID)
+
+        let tombstone = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertEqual(tombstone.isLocallyDeleted, true, "offline delete is a soft delete until pushed")
+        XCTAssertEqual(engine.pendingChangeCount, 1)
+
+        engine.isOffline = false
+        let pushResult = try await engine.pushPendingChanges()
+        let summary = try XCTUnwrap(pushResult)
+
+        XCTAssertEqual(summary.deletedCount, 1)
+        XCTAssertTrue(summary.failures.isEmpty)
+        let remaining = try fetchTask(id: taskID, in: syncContainer.mainContext)
+        XCTAssertNil(remaining, "confirmed delete is hard-deleted")
+        let detail = try await apiClient.getTaskDetail(taskID: taskID)
+        XCTAssertNil(detail)
+    }
+
+    @MainActor
+    private func createBody(from templateID: String, newID: String, in syncContainer: SyncContainer) throws
+        -> DemoSyncPayload
+    {
+        let template = try XCTUnwrap(fetchTask(id: templateID, in: syncContainer.mainContext))
+        var dictionary = syncContainer.export(template)
+        dictionary["id"] = newID
+        dictionary["title"] = "Offline task"
+        dictionary.removeValue(forKey: "items")
+        return try DemoSyncPayload(dictionary: dictionary)
+    }
+
+    @MainActor
+    private func makeSyncContainer() throws -> SyncContainer {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try SyncContainer(
+            for: Project.self,
+            User.self,
+            Task.self,
+            Item.self,
+            TaskStateOption.self,
+            configurations: configuration
+        )
+    }
+
+    @MainActor
+    private func fetchTask(id: String, in context: ModelContext) throws -> Task? {
+        try context.fetch(FetchDescriptor<Task>(predicate: #Predicate { $0.id == id })).first
+    }
+}

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -1,3 +1,4 @@
+import DemoBackend
 import SwiftData
 import SwiftSync
 import XCTest
@@ -100,8 +101,52 @@ final class OfflinePushTests: XCTestCase {
         let result = try await engine.pushPendingChanges()
         XCTAssertNil(result, "push is unavailable while offline")
         XCTAssertEqual(engine.pendingChangeCount, 1, "the pending change survives")
+
+        // Reconnect to confirm the server never received it (the transport is unreachable offline).
+        engine.isOffline = false
         let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-NOOP-1")
         XCTAssertNil(backendDetail, "nothing was uploaded while offline")
+    }
+
+    @MainActor
+    func testOfflinePullServesCacheAndDoesNotReachServer() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("offline-read-\(UUID().uuidString).sqlite")
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        let backend = try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
+        let apiClient = FakeDemoAPIClient(backend: backend)
+        let syncContainer = try makeSyncContainer()
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        try await engine.syncProjectTasks(projectID: projectID)
+        let onlineCount = try syncContainer.mainContext.fetch(FetchDescriptor<Task>()).count
+        XCTAssertGreaterThan(onlineCount, 0)
+
+        // A task appears on the server that this client has never seen.
+        _ = try backend.upload(operations: [
+            [
+                "operation": "insert", "type": "tasks", "localId": "SERVER-ONLY-1",
+                "updatedAt": "2026-06-16T20:00:00.000Z",
+                "data": [
+                    "project_id": projectID, "author_id": DemoSeedData.SeedIDs.Users.avaMartinez,
+                    "title": "Created on the server", "description": "x", "state": ["id": "todo"],
+                    "created_at": "2026-06-16T20:00:00.000Z", "updated_at": "2026-06-16T20:00:00.000Z",
+                ],
+            ]
+        ])
+
+        // Offline: a pull must not reach the server — no error, and no new data.
+        engine.isOffline = true
+        try await engine.syncProjectTasks(projectID: projectID)
+        let offlineCount = try syncContainer.mainContext.fetch(FetchDescriptor<Task>()).count
+        XCTAssertEqual(offlineCount, onlineCount, "offline pull serves the local cache, never the server")
+
+        // Reconnect: the server task is pulled in.
+        engine.isOffline = false
+        try await engine.syncProjectTasks(projectID: projectID)
+        let refreshedCount = try syncContainer.mainContext.fetch(FetchDescriptor<Task>()).count
+        XCTAssertEqual(refreshedCount, onlineCount + 1, "reconnecting refreshes from the server")
     }
 
     @MainActor

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -75,6 +75,34 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testPushWhileOfflineIsANoOp() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        let body = try createBody(
+            from: DemoSeedData.SeedIDs.Tasks.sessionTimeout,
+            newID: "OFFLINE-NOOP-1",
+            in: syncContainer
+        )
+
+        engine.isOffline = true
+        try await engine.createTask(body: body, projectID: projectID)
+        XCTAssertEqual(engine.pendingChangeCount, 1)
+
+        // Still offline: a push must not reach the server.
+        let result = try await engine.pushPendingChanges()
+        XCTAssertNil(result, "push is unavailable while offline")
+        XCTAssertEqual(engine.pendingChangeCount, 1, "the pending change survives")
+        let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-NOOP-1")
+        XCTAssertNil(backendDetail, "nothing was uploaded while offline")
+    }
+
+    @MainActor
     private func createBody(from templateID: String, newID: String, in syncContainer: SyncContainer) throws
         -> DemoSyncPayload
     {

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -39,9 +39,11 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertEqual(engine.pendingChangeCount, 0)
 
         let synced = try XCTUnwrap(fetchTask(id: "OFFLINE-CREATE-1", in: syncContainer.mainContext))
-        XCTAssertEqual(synced.syncRemoteID, "OFFLINE-CREATE-1", "push stamps the server-assigned id")
+        let remoteID = try XCTUnwrap(synced.syncRemoteID, "push stamps the server-minted remote id")
+        XCTAssertNotEqual(remoteID, "OFFLINE-CREATE-1", "the server mints its own id, distinct from localId")
+        XCTAssertTrue(remoteID.hasPrefix("srv-"))
         let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-CREATE-1")
-        XCTAssertNotNil(backendDetail)
+        XCTAssertNotNil(backendDetail, "the row reached the backend, keyed by its localId")
     }
 
     @MainActor

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Define your models once, read from local SwiftData, and let SwiftSync handle the
 - Deterministic diffing for inserts, updates, and deletes
 - Automatic relationship syncing for nested objects and foreign keys
 - Export back into API-ready JSON
+- Offline push (local → server) with two-id identity and last-writer-wins
 - Reactive local reads for SwiftUI and UIKit
 
 ## Quick Start
@@ -610,6 +611,45 @@ Best practices:
 - Use `@RemoteKey`, `@NotExport`, and container formatting options to keep transport concerns out of your UI code
 
 See [FAQ](docs/project/faq.md) and [Property Mapping Contract](docs/project/property-mapping-contract.md) for more on export.
+
+## Offline Push (local → server)
+
+`sync` and `export` cover the pull side: pull server state into SwiftData, and turn a draft into a request body. **Push** is the outbound counterpart for offline-first apps — edit locally while disconnected, then reconcile with the server when you reconnect.
+
+Identity is a two-id mapping: `syncLocalID` is the client-generated id that is stable forever; `syncRemoteID` is the server's id, `nil` until the row has been pushed and acknowledged. `syncUpdatedAt` drives last-writer-wins, and `syncIsDeleted` is a soft-delete tombstone that survives until the deletion reaches the server. Conform your model to `SyncOfflineModel`:
+
+```swift
+extension Task: SyncOfflineModel {
+  var syncLocalID: String { id }
+  var syncUpdatedAt: Date { updatedAt }
+  var syncIsDeleted: Bool { isDeleted }
+  // syncRemoteID is a stored property the push driver assigns on acknowledgement
+}
+```
+
+`pendingChanges` partitions the store into inserts, updates, and deletes relative to your last-synced cursor — by querying the store, with no save-interception:
+
+- **insert** — never synced (`syncRemoteID == nil`) and not deleted
+- **update** — synced, not deleted, and edited since the cursor
+- **delete** — soft-deleted *and* known to the server (a row inserted-then-deleted locally never reached the server, so it is dropped, not pushed)
+
+`push` drives one pass. It hands the pending ids to your `upload` closure as a `Sendable` `SyncPushBatch` (so SwiftData objects never cross into a network call — you own the request), then applies the server's `SyncPushResponse` locally: stamping server-assigned `syncRemoteID`s onto inserts, hard-deleting confirmed deletes, and returning per-item failures for you to surface (discard / edit / retry).
+
+```swift
+let summary = try await SwiftSync.push(
+  for: Task.self,
+  in: syncContainer.mainContext,
+  changedSince: lastSyncedAt,
+  upload: { batch in
+    // map batch.inserts / batch.updates / batch.deletes (syncLocalIDs) to requests,
+    // call your API, and report back what the server assigned/accepted/rejected
+    try await api.push(batch)
+  }
+)
+lastSyncedAt = summary.cursor
+```
+
+Advance your cursor to `summary.cursor` on every pass: it only moves forward when *every* pending update was acknowledged, so an unacknowledged update is safely re-detected on the next push rather than lost.
 
 ## Date Handling
 

--- a/README.md
+++ b/README.md
@@ -690,6 +690,7 @@ Open `SwiftSync.xcworkspace` if you want to see those cases working together in 
 - [Property Mapping Contract](docs/project/property-mapping-contract.md)
 - [Reactive Reads](docs/project/reactive-reads.md)
 - [Backend Contract](docs/project/backend-contract.md)
+- [Upload Endpoint Contract](docs/project/upload-endpoint-contract.md)
 - [FAQ](docs/project/faq.md)
 
 ## License

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -9,10 +9,7 @@ import SwiftData
 /// `syncRemoteID` is the server's id — `nil` until the row has been pushed and acknowledged (the
 /// push driver assigns it). `syncUpdatedAt` drives last-writer-wins; `syncIsDeleted` is a
 /// soft-delete that survives until the deletion is pushed (then the row is hard-deleted).
-///
-/// `package` while the push feature is built out; promoted to `public` (with README docs) once it
-/// is consumer-usable.
-package protocol SyncOfflineModel: PersistentModel {
+public protocol SyncOfflineModel: PersistentModel {
     var syncLocalID: String { get }
     var syncRemoteID: String? { get set }
     var syncUpdatedAt: Date { get }
@@ -20,34 +17,34 @@ package protocol SyncOfflineModel: PersistentModel {
 }
 
 /// The local rows pending a push, partitioned by operation (live models, for applying results).
-package struct SyncPendingChanges<Model: SyncOfflineModel> {
-    package let inserts: [Model]
-    package let updates: [Model]
-    package let deletes: [Model]
+public struct SyncPendingChanges<Model: SyncOfflineModel> {
+    public let inserts: [Model]
+    public let updates: [Model]
+    public let deletes: [Model]
 
-    package var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
+    public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
 /// The `syncLocalID`s to push, partitioned by operation. This — not the live models — is what the
 /// async uploader receives, so SwiftData objects never cross into a network call (the
 /// "never pass a model across contexts" rule). It's `Sendable`; the app maps each id to its payload.
-package struct SyncPushBatch: Sendable {
-    package let inserts: [String]
-    package let updates: [String]
-    package let deletes: [String]
+public struct SyncPushBatch: Sendable {
+    public let inserts: [String]
+    public let updates: [String]
+    public let deletes: [String]
 
-    package var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
+    public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
 /// One pushed item the server rejected. SwiftSync surfaces these so the app can let the user act on
 /// them (discard / edit / retry) rather than silently retrying forever.
-package struct SyncPushFailure: Equatable, Sendable {
-    package enum Operation: String, Equatable, Sendable { case insert, update, delete }
-    package let localID: String
-    package let operation: Operation
-    package let message: String
+public struct SyncPushFailure: Equatable, Sendable {
+    public enum Operation: String, Equatable, Sendable { case insert, update, delete }
+    public let localID: String
+    public let operation: Operation
+    public let message: String
 
-    package init(localID: String, operation: Operation, message: String) {
+    public init(localID: String, operation: Operation, message: String) {
         self.localID = localID
         self.operation = operation
         self.message = message
@@ -56,14 +53,14 @@ package struct SyncPushFailure: Equatable, Sendable {
 
 /// What the app's uploader reports back after talking to the server: the server-assigned ids for
 /// inserted rows, which updates/deletes were accepted, and any per-item failures.
-package struct SyncPushResponse: Sendable {
+public struct SyncPushResponse: Sendable {
     /// insert's `syncLocalID` → server-assigned `syncRemoteID`.
-    package var assignedRemoteIDs: [String: String]
-    package var confirmedUpdateLocalIDs: Set<String>
-    package var confirmedDeleteLocalIDs: Set<String>
-    package var failures: [SyncPushFailure]
+    public var assignedRemoteIDs: [String: String]
+    public var confirmedUpdateLocalIDs: Set<String>
+    public var confirmedDeleteLocalIDs: Set<String>
+    public var failures: [SyncPushFailure]
 
-    package init(
+    public init(
         assignedRemoteIDs: [String: String] = [:],
         confirmedUpdateLocalIDs: Set<String> = [],
         confirmedDeleteLocalIDs: Set<String> = [],
@@ -77,12 +74,12 @@ package struct SyncPushResponse: Sendable {
 }
 
 /// Result of a push pass. Advance the caller's stored "last synced" cursor to `cursor` on success.
-package struct SyncPushSummary {
-    package let insertedCount: Int
-    package let updatedCount: Int
-    package let deletedCount: Int
-    package let failures: [SyncPushFailure]
-    package let cursor: Date
+public struct SyncPushSummary {
+    public let insertedCount: Int
+    public let updatedCount: Int
+    public let deletedCount: Int
+    public let failures: [SyncPushFailure]
+    public let cursor: Date
 }
 
 extension SwiftSync {
@@ -93,7 +90,7 @@ extension SwiftSync {
     /// - **update**: synced (`syncRemoteID != nil`), not deleted, edited since the last sync.
     /// - **delete**: soft-deleted *and* known to the server (a row inserted-then-deleted locally
     ///   never reached the server, so it's dropped, not pushed).
-    package static func pendingChanges<Model: SyncOfflineModel>(
+    public static func pendingChanges<Model: SyncOfflineModel>(
         for _: Model.Type,
         in context: ModelContext,
         changedSince: Date
@@ -123,7 +120,7 @@ extension SwiftSync {
     /// cursor to `summary.cursor`: it only moves forward when *every* pending update was
     /// acknowledged, so an unacknowledged update is safely re-detected on the next push.
     @discardableResult
-    package static func push<Model: SyncOfflineModel>(
+    public static func push<Model: SyncOfflineModel>(
         for _: Model.Type,
         in context: ModelContext,
         changedSince: Date,

--- a/docs/project/upload-endpoint-contract.md
+++ b/docs/project/upload-endpoint-contract.md
@@ -88,8 +88,22 @@ For update/delete, the server compares the incoming `updatedAt` with the stored 
 
 ### Delete is a soft-delete tombstone
 
-A delete marks the row deleted (retained for a TTL) so other clients pull the deletion via the pull
-endpoint. It is not an immediate hard-delete.
+A delete marks the row deleted (server-side) so other clients still learn of the deletion on their
+next pull, rather than the row vanishing without a trace. It is not an immediate hard-delete on the
+server. (The *client* does hard-delete its own local row once the delete is acknowledged — tombstone
+lifecycle is purely a server concern; SwiftSync never manages it.)
+
+**Tombstone retention is the backend's responsibility, not the client's.** A tombstone must be kept
+at least as long as your longest plausible client offline window: purge too early and a client that
+was offline past the retention period never learns of the deletion and **resurrects the row** on its
+next push. Production backends therefore retain tombstones for a bounded window (≥ max offline window)
+and purge older ones with a periodic job — the same shape as Amplify DataStore's `BaseTableTTL` or
+CouchDB's purge. Pin the retention *capability* (outlast the max offline window), not a magic number
+of days.
+
+The `DemoServerSimulator` keeps tombstones indefinitely — it implements no purge, since the demo has
+no scheduler and its data is ephemeral. That is a deliberate omission: purge is production backend
+guidance, out of scope for the demo and irrelevant to the client.
 
 ### Safety: destruction is always explicit
 

--- a/docs/project/upload-endpoint-contract.md
+++ b/docs/project/upload-endpoint-contract.md
@@ -21,16 +21,21 @@ A single batched request carrying all pending local changes. Returns a per-opera
 
 Every syncable row has two ids:
 
-- **`localId`** — client-generated, stable forever, never changes. SwiftSync mints it (a UUID) the
-  moment the row is created offline. It is also the **idempotency key** (see below).
-- **`remoteId`** — the server's own canonical id, minted by the server on insert. **Opaque to
-  SwiftSync** — it may be a UUID, an integer, a slug, anything; SwiftSync carries it as a string at
-  the boundary (an integer-PK backend just stringifies). `nil` on the client until an insert is
-  acknowledged.
+- **`localId`** — client-generated, stable forever, **never changes**. SwiftSync mints it (a UUID) the
+  moment the row is created offline. It is the row's identity on both sides — the key inbound sync
+  matches on — and the **idempotency key** for inserts (see below).
+- **`remoteId`** — a second id the server **mints** for the row on insert. **Opaque to SwiftSync** — a
+  UUID, an integer, a slug, anything; SwiftSync carries it as a string at the boundary (an integer-PK
+  backend just stringifies). `nil` on the client until an insert is acknowledged. The client uses it
+  to **address** the row in subsequent `update`/`delete` operations.
 
-The server does **not** accept the client's id as canonical — it mints its own. This is what lets
-SwiftSync work with conventional backends (including legacy integer-PK ones), not just greenfield
-UUID schemas. The cost SwiftSync owns is the local id-rewrite when `remoteId` arrives.
+The server mints its own `remoteId` (so SwiftSync works with conventional backends, including legacy
+integer-PK ones, not just greenfield UUID schemas), but **`localId` remains the stable identity** the
+two sides agree on — the server echoes it back on pulls and SwiftSync matches by it. That is a
+deliberate choice: because `localId` never changes, **there is no client-side id rewrite** and inbound
+sync needs no special handling — sidestepping the Core Data id-mutation hazard. (The alternative —
+making `remoteId` the canonical identity and rewriting local references when it arrives — is viable but
+not what this contract describes.)
 
 ## Request
 

--- a/docs/project/upload-endpoint-contract.md
+++ b/docs/project/upload-endpoint-contract.md
@@ -1,0 +1,154 @@
+# Upload Endpoint Contract
+
+The wire contract for SwiftSync's **push** (local → server). A general-purpose backend
+(Django/Rails/Laravel/Spring) adds this as one thin "offline layer" endpoint *beside* its normal
+per-resource routes — backed by the framework's bulk-upsert primitive (`upsert_all` / `upsert()` /
+`saveAll`). It does not replace the existing CRUD API; it is the batched sync seam.
+
+This is a *dictated* contract: to use offline push, the backend implements this endpoint. That is the
+deliberate trade (see `docs/planning/production-sync-design.md`) — one well-defined path beats
+adapting to every backend's ad-hoc bulk convention.
+
+## Endpoint
+
+```
+POST /sync/upload
+```
+
+A single batched request carrying all pending local changes. Returns a per-operation result list.
+
+## Identity: two ids
+
+Every syncable row has two ids:
+
+- **`localId`** — client-generated, stable forever, never changes. SwiftSync mints it (a UUID) the
+  moment the row is created offline. It is also the **idempotency key** (see below).
+- **`remoteId`** — the server's own canonical id, minted by the server on insert. **Opaque to
+  SwiftSync** — it may be a UUID, an integer, a slug, anything; SwiftSync carries it as a string at
+  the boundary (an integer-PK backend just stringifies). `nil` on the client until an insert is
+  acknowledged.
+
+The server does **not** accept the client's id as canonical — it mints its own. This is what lets
+SwiftSync work with conventional backends (including legacy integer-PK ones), not just greenfield
+UUID schemas. The cost SwiftSync owns is the local id-rewrite when `remoteId` arrives.
+
+## Request
+
+```json
+{
+  "operations": [
+    { "operation": "insert", "type": "tasks", "localId": "0c1f…",
+      "updatedAt": "2026-06-16T20:00:00Z", "data": { "title": "Draft", "state": {"id": "todo"} } },
+
+    { "operation": "update", "type": "tasks", "remoteId": "8842",
+      "updatedAt": "2026-06-16T20:01:00Z", "data": { "title": "Renamed", "state": {"id": "todo"} } },
+
+    { "operation": "delete", "type": "tasks", "remoteId": "7710",
+      "updatedAt": "2026-06-16T20:02:00Z" }
+  ]
+}
+```
+
+Per operation:
+
+| field | insert | update | delete |
+|---|---|---|---|
+| `operation` | `"insert"` | `"update"` | `"delete"` |
+| `type` | resource name (consumer-chosen) | same | same |
+| `localId` | **required** | — | — |
+| `remoteId` | — | **required** | **required** |
+| `updatedAt` | required (ISO 8601) | required | required |
+| `data` | full resource | **full resource** (not a diff) | — |
+
+- **`data` is the full resource, not a delta.** SwiftSync has no field-level dirty tracking
+  (`export(row)` emits the whole object), so an update sends every field. The server applies them
+  under SwiftSync's payload semantics: a present field is set, an explicit `null` clears it.
+- Operations are applied **in array order**.
+
+## Semantics
+
+### Idempotency — the server stores `localId`
+
+Insert hazard: the client posts an insert, the server creates the row and mints `remoteId`, but the
+**response is lost** (network drop). The client still has no `remoteId`, so it retries the same
+insert. The server **must not** create a second row.
+
+The server persists `localId` (a column, unique per `type` + tenant) alongside `remoteId`. On insert
+it keys on `(type, localId)`: if a row with that `localId` already exists, it returns the **existing**
+`remoteId` (`status: "applied"`) instead of creating again. Inserts are therefore safe to retry
+indefinitely.
+
+### Conflict — server-authoritative last-writer-wins
+
+For update/delete, the server compares the incoming `updatedAt` with the stored `updatedAt`:
+
+- incoming **newer** ⇒ apply.
+- incoming **older or equal** ⇒ the server keeps its version and returns it (`status: "stale"`, with
+  the current server row in `server`). SwiftSync adopts the server state locally.
+
+### Delete is a soft-delete tombstone
+
+A delete marks the row deleted (retained for a TTL) so other clients pull the deletion via the pull
+endpoint. It is not an immediate hard-delete.
+
+### Safety: destruction is always explicit
+
+- **`operation` is required.** Missing or unknown ⇒ the operation is **rejected** — the server never
+  guesses and never falls back to delete (fail-closed).
+- **Only `"delete"` deletes.** A forgotten `data` on an insert/update is a rejected insert or a no-op
+  update — never a delete.
+
+This mirrors the payload semantics symmetrically: an *absent field* never clears a value (you must
+send explicit `null`); an *absent operation* never destroys a row (you must send explicit
+`"delete"`). The destructive path is always opt-in, never the default. (This is also why the
+op-tagged list is safer than a set-diff: a row simply not appearing means "no change," never
+"delete.")
+
+## Response
+
+A per-operation result list (partial success — one bad row never blocks the batch):
+
+```json
+{
+  "results": [
+    { "operation": "insert", "localId": "0c1f…", "remoteId": "8843", "status": "applied" },
+    { "operation": "update", "remoteId": "8842", "status": "stale",
+      "server": { "remoteId": "8842", "title": "Edited elsewhere",
+                  "updatedAt": "2026-06-16T20:05:00Z" } },
+    { "operation": "delete", "remoteId": "7710", "status": "applied" },
+    { "operation": "update", "remoteId": "9001", "status": "rejected",
+      "code": "validation", "message": "title must not be empty" }
+  ],
+  "cursor": "2026-06-16T20:02:00Z"
+}
+```
+
+| `status` | meaning | SwiftSync reaction |
+|---|---|---|
+| `applied` | written (LWW won, or idempotent re-ack) | confirm; stamp `remoteId` onto the inserted row |
+| `stale` | the client write lost LWW; `server` carries current truth | adopt the server state locally |
+| `rejected` | permanent/validation failure | surface `message` (+ `code`) in the failures inbox (discard / edit / retry) |
+
+- Insert results echo `localId` so SwiftSync can map the assigned `remoteId` back onto the right row.
+- `rejected` carries a human-readable `message` and an optional machine `code`.
+- `cursor` is an **opaque** string (a timestamp or token — the server decides). The client feeds it to
+  the pull side; SwiftSync treats it as opaque.
+
+## Pull pairing (out of scope here, for orientation)
+
+The `cursor` from a successful upload is fed to the inbound pull, conceptually
+`GET /sync/pull?since=<cursor>`, which returns changes since the cursor (including tombstones). That
+inbound direction is SwiftSync's existing `sync` (server → SwiftData). Push and pull share the cursor.
+
+## Layering on a general-purpose backend
+
+It is one custom controller action:
+
+1. Parse `operations`, group by `type`.
+2. Per operation: resolve the row (insert → by `(type, localId)`; update/delete → by `remoteId`),
+   apply LWW, upsert / tombstone via the ORM's bulk primitive.
+3. Return the per-operation `results` + a `cursor`.
+
+Existing per-resource endpoints are untouched — this sits beside them. A real backend scopes every
+operation to the authenticated principal and rejects cross-tenant references (`status: "rejected"`);
+large pushes are chunked client-side rather than capped by a hard server limit.


### PR DESCRIPTION
The complete offline-push feature, end to end, for review (stacked on #618). A general-purpose backend adds **one** `POST /sync/upload` endpoint; SwiftSync's batch push targets it; the demo drives it through the existing Online/Offline bar.

### Contract (`docs/project/upload-endpoint-contract.md`)
Flat, op-tagged operation list; two-id identity (`localId` = client key + idempotency token, server-minted **opaque** `remoteId`); full-resource updates; server-authoritative LWW; soft-delete tombstones; fail-closed deletes (explicit `operation` required); per-item `applied`/`stale`/`rejected` results + cursor.

### Backend (`DemoBackend`)
`POST /sync/upload`: mints a distinct opaque `remote_id`, idempotent inserts (keyed on `localId`), LWW on updates (`stale` returns current server state), `deleted_at` tombstones filtered from reads. The task's `id` stays the stable client key so **inbound sync needs no change**; payloads coalesce `remote_id → id` and updates match by `remote_id`-or-`id` so seeded/online rows stay addressable. Reuses `createTask`/`updateTask`.

### SwiftSync
No change — the batch `upload:` push form (from #618) is exactly the seam this targets.

### Demo (`DemoCore`)
`DemoSyncEngine` serializes the pending batch → `operations`, POSTs once, maps results back (insert → stamp minted `remoteId`; `stale` → adopt server state so it won't loop; delete → confirmed). `Task.syncRemoteID` imported from `remote_id` via `@RemoteKey` (replaces #618's id-stamping). The Online/Offline + pending + Sync-now UI is unchanged.

### Verified
- `DemoBackend`: 25 tests (4 new upload + 21 existing).
- `DemoCore`: 24 tests (offline create/delete/no-op now run through `/sync/upload`; distinct minted `remoteId` asserted).
- `SwiftSync`: 164 + 48 tests green; doc-link gate green.
- Demo app builds, launches, pulls, renders.

Open call from our thread: whether to keep `localId`-as-stable-key (no inbound change, what's built here) vs full id-rewrite to `remoteId` — happy to switch if you'd rather.