### PR TITLE
R7: failures inbox — surface, edit, and discard rejected offline changes

### DIFF
--- a/Demo/Demo/App/ContentView.swift
+++ b/Demo/Demo/App/ContentView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 struct ContentView: View {
     @Bindable var runtime: DemoRuntime
+    @State private var showingFailures = false
 
     private var engine: DemoSyncEngine { runtime.syncEngine }
 
@@ -33,6 +34,9 @@ struct ContentView: View {
                     _Concurrency.Task { try? await engine.pushPendingChanges() }
                 }
             }
+            .sheet(isPresented: $showingFailures) {
+                FailuresSheet(syncContainer: runtime.syncContainer, syncEngine: engine)
+            }
     }
 
     private var offlineBar: some View {
@@ -55,6 +59,18 @@ struct ContentView: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .accessibilityIdentifier("pending-count")
+            }
+
+            if engine.failedChangeCount > 0 {
+                if engine.pendingChangeCount > 0 { Spacer().frame(width: 12) }
+                Button {
+                    showingFailures = true
+                } label: {
+                    Label("\(engine.failedChangeCount) failed", systemImage: "exclamationmark.triangle.fill")
+                        .font(.footnote)
+                }
+                .tint(.red)
+                .accessibilityIdentifier("failures-button")
             }
         }
         .padding(.horizontal)

--- a/Demo/Demo/Features/Failures/FailuresSheet.swift
+++ b/Demo/Demo/Features/Failures/FailuresSheet.swift
@@ -1,0 +1,72 @@
+import DemoCore
+import SwiftData
+import SwiftSync
+import SwiftUI
+
+/// The failures inbox: rows the server rejected (a `syncFailureReason` is set). The user resolves each
+/// by editing the task (fix → re-syncs) or discarding the change (restores the server's version).
+/// Driven by the engine's observable `failedChangeCount` so it refreshes as failures clear.
+struct FailuresSheet: View {
+    let syncContainer: SyncContainer
+    let syncEngine: DemoSyncEngine
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var rows: [Task] = []
+    @State private var editingTask: Task?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if rows.isEmpty {
+                    ContentUnavailableView("No failures", systemImage: "checkmark.circle")
+                } else {
+                    ForEach(rows, id: \.id) { task in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(task.title).font(.headline)
+                            if let reason = task.syncFailureReason {
+                                Label(reason, systemImage: "exclamationmark.triangle.fill")
+                                    .font(.footnote)
+                                    .foregroundStyle(.red)
+                            }
+                            HStack {
+                                Button("Edit") { editingTask = task }
+                                    .accessibilityIdentifier("failure.edit.\(task.id)")
+                                Spacer()
+                                Button("Discard", role: .destructive) { discard(task) }
+                                    .accessibilityIdentifier("failure.discard.\(task.id)")
+                            }
+                            .buttonStyle(.borderless)
+                            .font(.callout)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                }
+            }
+            .navigationTitle("Failed to sync")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .accessibilityIdentifier("failures-sheet")
+            .sheet(item: $editingTask) { task in
+                TaskFormSheet(mode: .edit(task: task), syncContainer: syncContainer, syncEngine: syncEngine)
+            }
+        }
+        .onAppear(perform: reload)
+        .onChange(of: syncEngine.failedChangeCount) { _, _ in reload() }
+    }
+
+    private func reload() {
+        rows = syncEngine.failedTasks()
+    }
+
+    private func discard(_ task: Task) {
+        let taskID = task.id
+        _Concurrency.Task {
+            try? await syncEngine.discardFailedChange(taskID: taskID)
+            reload()
+        }
+    }
+}

--- a/Demo/Demo/Features/Projects/ProjectView.swift
+++ b/Demo/Demo/Features/Projects/ProjectView.swift
@@ -23,24 +23,24 @@ struct ProjectView: View {
 
     var body: some View {
         List { content }
-        .listStyle(.plain)
-        .accessibilityIdentifier("project.detail")
-        .navigationTitle("Project")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar { toolbarContent }
-        .task(loadProject)
-        .animation(.snappy(duration: 0.2), value: taskIDs)
-        .projectPresentations(
-            createTaskSheetIsPresented: $isShowingCreateTaskSheet,
-            createTaskSheet: { createTaskSheet },
-            deletePromptIsPresented: deletePromptIsPresented,
-            taskPendingDelete: taskPendingDelete,
-            onConfirmDelete: confirmDelete,
-            onCancelDelete: { taskPendingDelete = nil },
-            deleteFailureIsPresented: deleteFailureIsPresented,
-            deleteFailureMessage: deleteFailureMessage,
-            onDismissDeleteFailure: { machine.sendDelete(.dismissError) }
-        )
+            .listStyle(.plain)
+            .accessibilityIdentifier("project.detail")
+            .navigationTitle("Project")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarContent }
+            .task(loadProject)
+            .animation(.snappy(duration: 0.2), value: taskIDs)
+            .projectPresentations(
+                createTaskSheetIsPresented: $isShowingCreateTaskSheet,
+                createTaskSheet: { createTaskSheet },
+                deletePromptIsPresented: deletePromptIsPresented,
+                taskPendingDelete: taskPendingDelete,
+                onConfirmDelete: confirmDelete,
+                onCancelDelete: { taskPendingDelete = nil },
+                deleteFailureIsPresented: deleteFailureIsPresented,
+                deleteFailureMessage: deleteFailureMessage,
+                onDismissDeleteFailure: { machine.sendDelete(.dismissError) }
+            )
     }
 
     private var taskIDs: [String] {
@@ -147,8 +147,10 @@ struct ProjectView: View {
                     .font(.headline)
                     .lineLimit(3)
 
-                LabeledContent("Tasks", value: projectModel.taskCount == 1 ? "1 task" : "\(projectModel.taskCount) tasks")
-                    .foregroundStyle(.secondary)
+                LabeledContent(
+                    "Tasks", value: projectModel.taskCount == 1 ? "1 task" : "\(projectModel.taskCount) tasks"
+                )
+                .foregroundStyle(.secondary)
             } else {
                 Text("Project details unavailable")
                     .foregroundStyle(.secondary)
@@ -211,8 +213,8 @@ private struct TaskDeletePrompt: Equatable {
     let title: String
 }
 
-private extension View {
-    func projectPresentations<SheetContent: View>(
+extension View {
+    fileprivate func projectPresentations<SheetContent: View>(
         createTaskSheetIsPresented: Binding<Bool>,
         @ViewBuilder createTaskSheet: @escaping () -> SheetContent,
         deletePromptIsPresented: Binding<Bool>,

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -353,6 +353,47 @@ final class DemoUITests: XCTestCase {
         XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
     }
 
+    // User journey: edit an offline-created task's title; the project list reflects the new title.
+    @MainActor
+    func testOfflineEditTaskTitleUpdatesProjectList() throws {
+        let app = configuredApp()
+        app.launch()
+
+        // Online: warm reference data (users + task states) so offline create/edit works.
+        openProject(app, id: DemoSeedProjectID.accountSecurity)
+        XCTAssertTrue(
+            app.staticTexts["Add session timeout controls to account settings"].waitForExistence(timeout: 2))
+        goBack(app)
+
+        app.buttons["offline-toggle"].tap()
+        XCTAssertEqual(app.buttons["offline-toggle"].label, "Offline")
+
+        // Create a task offline.
+        let originalTitle = uniqueTitle(prefix: "Offline Original")
+        openProject(app, id: DemoSeedProjectID.accountSecurity)
+        openCreateTaskForm(app)
+        replaceText(in: app.textFields["task-form.title"], with: originalTitle, app: app)
+        app.buttons["task-form.save"].tap()
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 1))
+        XCTAssertTrue(findAfterScrolling(app.staticTexts[originalTitle], in: app))
+
+        // Open it and rename it offline.
+        let updatedTitle = uniqueTitle(prefix: "Offline Renamed")
+        openTopProjectTask(app)
+        openEditTaskForm(app)
+        replaceText(in: app.textFields["task-form.title"], with: updatedTitle, app: app)
+        app.buttons["task-form.save"].tap()
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 1))
+        XCTAssertEqual(detailElement(app, id: "task.title").label, updatedTitle, "the detail shows the new title")
+
+        // Back on the project list, the row reflects the edit — not the stale original title.
+        goBack(app)
+        XCTAssertTrue(
+            findAfterScrolling(app.staticTexts[updatedTitle], in: app),
+            "the project list shows the edited title")
+        XCTAssertFalse(app.staticTexts[originalTitle].exists, "the stale title is gone")
+    }
+
     // User journey: a rejected offline edit lands in the failures inbox; discard resolves it.
     @MainActor
     func testRejectedOfflineEditAppearsInFailuresInboxAndDiscards() throws {
@@ -461,8 +502,8 @@ final class DemoUITests: XCTestCase {
     }
 }
 
-private extension DemoUITests {
-    func configuredApp() -> XCUIApplication {
+extension DemoUITests {
+    fileprivate func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["SWIFTSYNC_UI_TESTING"] = "1"
         app.launchEnvironment["SWIFTSYNC_UI_TEST_RUN_ID"] = UUID().uuidString
@@ -470,29 +511,29 @@ private extension DemoUITests {
         return app
     }
 
-    func uniqueTitle(prefix: String) -> String {
+    fileprivate func uniqueTitle(prefix: String) -> String {
         "\(prefix) \(UUID().uuidString.prefix(6))"
     }
 
-    func openProject(_ app: XCUIApplication, id: String) {
+    fileprivate func openProject(_ app: XCUIApplication, id: String) {
         let row = app.cells["projects.row.\(id)"]
         XCTAssertTrue(row.exists)
         row.tap()
     }
 
-    func openTask(_ app: XCUIApplication, id: String) {
+    fileprivate func openTask(_ app: XCUIApplication, id: String) {
         let taskRow = app.descendants(matching: .any)["project.task.\(id)"]
         XCTAssertTrue(taskRow.waitForExistence(timeout: 1))
         taskRow.tap()
     }
 
-    func openTaskDetail(_ app: XCUIApplication, projectID: String, taskID: String) {
+    fileprivate func openTaskDetail(_ app: XCUIApplication, projectID: String, taskID: String) {
         openProject(app, id: projectID)
         openTask(app, id: taskID)
         XCTAssertTrue(detailElement(app, id: "task.title").exists)
     }
 
-    func openTopProjectTask(_ app: XCUIApplication) {
+    fileprivate func openTopProjectTask(_ app: XCUIApplication) {
         let rows = app.descendants(matching: .any)
             .matching(NSPredicate(format: "identifier BEGINSWITH 'project.task.'"))
         let row = rows.element(boundBy: 0)
@@ -500,40 +541,40 @@ private extension DemoUITests {
         row.tap()
     }
 
-    func detailElement(_ app: XCUIApplication, id: String) -> XCUIElement {
+    fileprivate func detailElement(_ app: XCUIApplication, id: String) -> XCUIElement {
         app.descendants(matching: .any)[id]
     }
 
-    func goBack(_ app: XCUIApplication) {
+    fileprivate func goBack(_ app: XCUIApplication) {
         app.navigationBars.buttons.element(boundBy: 0).tap()
     }
 
-    func openCreateTaskForm(_ app: XCUIApplication) {
+    fileprivate func openCreateTaskForm(_ app: XCUIApplication) {
         app.buttons["New Task"].tap()
         XCTAssertTrue(app.buttons["task-form.save"].exists)
     }
 
-    func openEditTaskForm(_ app: XCUIApplication) {
+    fileprivate func openEditTaskForm(_ app: XCUIApplication) {
         app.buttons["Edit"].tap()
         XCTAssertTrue(app.buttons["task-form.save"].exists)
     }
 
-    func selectAssignee(_ app: XCUIApplication, userID: String) {
+    fileprivate func selectAssignee(_ app: XCUIApplication, userID: String) {
         tapAfterScrolling(app.buttons["task-form.summary.assignee"], in: app)
         tapAfterScrolling(app.buttons["task-form.assignee.option.\(userID)"], in: app)
     }
 
-    func selectAuthor(_ app: XCUIApplication, userID: String) {
+    fileprivate func selectAuthor(_ app: XCUIApplication, userID: String) {
         tapAfterScrolling(app.buttons["task-form.summary.author"], in: app)
         tapAfterScrolling(app.buttons["task-form.author.option.\(userID)"], in: app)
     }
 
-    func addPerson(_ app: XCUIApplication, role: String, userID: String) {
+    fileprivate func addPerson(_ app: XCUIApplication, role: String, userID: String) {
         tapAfterScrolling(app.buttons["task-form.\(role).add"], in: app)
         tapAfterScrolling(app.buttons["task-form.\(role).option.\(userID)"], in: app)
     }
 
-    func deleteTaskFromProject(_ app: XCUIApplication, id: String) {
+    fileprivate func deleteTaskFromProject(_ app: XCUIApplication, id: String) {
         let taskRow = app.descendants(matching: .any)["project.task.\(id)"]
         XCTAssertTrue(taskRow.waitForExistence(timeout: 1))
         taskRow.swipeLeft()
@@ -541,7 +582,7 @@ private extension DemoUITests {
         app.alerts["Delete Task?"].buttons["Delete"].tap()
     }
 
-    func tapAfterScrolling(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) {
+    fileprivate func tapAfterScrolling(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) {
         for _ in 0..<maxSwipes where !element.isHittable {
             if app.tables.firstMatch.exists {
                 app.tables.firstMatch.swipeUp()
@@ -557,7 +598,7 @@ private extension DemoUITests {
         element.tap()
     }
 
-    func scrollToVisible(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) {
+    fileprivate func scrollToVisible(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) {
         for _ in 0..<maxSwipes where !element.exists {
             if app.tables.firstMatch.exists {
                 app.tables.firstMatch.swipeUp()
@@ -572,12 +613,12 @@ private extension DemoUITests {
         XCTAssertTrue(element.exists)
     }
 
-    func tapVisible(_ element: XCUIElement) {
+    fileprivate func tapVisible(_ element: XCUIElement) {
         XCTAssertTrue(element.exists)
         element.tap()
     }
 
-    func findAfterScrolling(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) -> Bool {
+    fileprivate func findAfterScrolling(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) -> Bool {
         for _ in 0..<maxSwipes where !element.exists {
             if app.tables.firstMatch.exists {
                 app.tables.firstMatch.swipeUp()
@@ -590,7 +631,7 @@ private extension DemoUITests {
         return element.exists
     }
 
-    func replaceText(in element: XCUIElement, with text: String, app: XCUIApplication) {
+    fileprivate func replaceText(in element: XCUIElement, with text: String, app: XCUIApplication) {
         XCTAssertTrue(element.exists)
         element.tap()
 

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -353,6 +353,36 @@ final class DemoUITests: XCTestCase {
         XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
     }
 
+    // User journey: a rejected offline edit lands in the failures inbox; discard resolves it.
+    @MainActor
+    func testRejectedOfflineEditAppearsInFailuresInboxAndDiscards() throws {
+        let app = configuredApp()
+        app.launch()
+        openTaskDetail(
+            app, projectID: DemoSeedProjectID.accountSecurity, taskID: DemoSeedTaskID.sessionTimeout)
+
+        // Offline: rename the task to a title the server will reject (too long).
+        app.buttons["offline-toggle"].tap()
+        openEditTaskForm(app)
+        replaceText(in: app.textFields["task-form.title"], with: String(repeating: "A", count: 100), app: app)
+        app.buttons["task-form.save"].tap()
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 2))
+
+        // Reconnect: auto-sync pushes it, the server rejects it, and it surfaces in the inbox.
+        app.buttons["offline-toggle"].tap()
+        let failuresButton = app.buttons["failures-button"]
+        XCTAssertTrue(
+            failuresButton.waitForExistence(timeout: 5), "a rejected change surfaces in the failures inbox")
+        failuresButton.tap()
+
+        let discard = app.buttons["failure.discard.\(DemoSeedTaskID.sessionTimeout)"]
+        XCTAssertTrue(discard.waitForExistence(timeout: 2), "the failed task is listed with its reason")
+        discard.tap()
+
+        // Discarding resolves the failure: the row leaves the inbox.
+        XCTAssertTrue(discard.waitForNonExistence(timeout: 5), "discard clears the failure")
+    }
+
     // User journey: edit a task's reviewers offline, then sync on reconnect.
     @MainActor
     func testOfflineAddReviewerSyncsOnReconnect() throws {

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -563,8 +563,9 @@ public final class DemoServerSimulator {
 
     // MARK: - POST /sync/upload (offline batch push)
     // See docs/project/upload-endpoint-contract.md. A flat, op-tagged operation list; per-operation
-    // results (no all-or-nothing). Operations are keyed by the client's `id` (single-id upsert):
-    // `upsert` is find-by-id → update-else-create, `delete` tombstones by id. Both are idempotent.
+    // results (no all-or-nothing). Operations are keyed by the client's stable `localId`; the server
+    // mints (and returns) a distinct `remoteId` on first create. `upsert` is find-by-localId →
+    // update-else-create, `delete` tombstones by localId. Both are idempotent.
 
     public func upload(operations: [[String: Any]]) throws -> [String: Any] {
         let results = operations.map(applyUploadOperation(_:))
@@ -588,52 +589,58 @@ public final class DemoServerSimulator {
         }
     }
 
-    /// Insert-or-update keyed by the client's `id`: the row's id *is* its id (no minted second id).
-    /// Found ⇒ update (last-writer-wins); absent ⇒ create. Idempotent — re-sending converges.
+    /// Insert-or-update keyed by the client's stable `localId`. Found ⇒ update (last-writer-wins);
+    /// absent ⇒ create. The server mints its own `remoteId` on first create and returns it (the same
+    /// one on every subsequent upsert) — addressing by `localId` means a never-synced row still
+    /// upserts cleanly. Idempotent: re-sending converges, no duplicate row.
     private func uploadUpsert(_ payload: [String: Any]) throws -> [String: Any] {
         try requireTasksType(payload)
-        let id = try requireID(payload)
+        let localID = try requireLocalID(payload)
         let incoming = try requireUpdatedAt(payload)
         guard let data = payload["data"] as? [String: Any] else {
             throw DemoBackendError.validation(message: "data is required for upsert")
         }
         var body = data
-        body["id"] = id
+        body["id"] = localID
 
-        if try exists(in: "tasks", id: id) {
-            if try isStale(taskID: id, incoming: incoming) {
+        if try exists(in: "tasks", id: localID) {
+            if try isStale(localID: localID, incoming: incoming) {
                 return [
-                    "operation": "upsert", "id": id, "status": "stale",
-                    "server": try getTaskDetailPayload(taskID: id) ?? NSNull(),
+                    "operation": "upsert", "localId": localID,
+                    "remoteId": try ensureRemoteID(forLocalID: localID), "status": "stale",
+                    "server": try getTaskDetailPayload(taskID: localID) ?? NSNull(),
                 ]
             }
-            _ = try updateTask(taskID: id, body: body)
+            _ = try updateTask(taskID: localID, body: body)
         } else {
             _ = try createTask(body: body)
         }
         // Relationship edits (reviewers/watchers) ride in the same operation when present.
         if let reviewerIDs = data["reviewer_ids"] as? [String] {
-            _ = try replaceTaskReviewers(taskID: id, reviewerIDs: reviewerIDs)
+            _ = try replaceTaskReviewers(taskID: localID, reviewerIDs: reviewerIDs)
         }
         if let watcherIDs = data["watcher_ids"] as? [String] {
-            _ = try replaceTaskWatchers(taskID: id, watcherIDs: watcherIDs)
+            _ = try replaceTaskWatchers(taskID: localID, watcherIDs: watcherIDs)
         }
-        return ["operation": "upsert", "id": id, "status": "applied"]
+        return [
+            "operation": "upsert", "localId": localID,
+            "remoteId": try ensureRemoteID(forLocalID: localID), "status": "applied",
+        ]
     }
 
     private func uploadDelete(_ payload: [String: Any]) throws -> [String: Any] {
         try requireTasksType(payload)
-        let id = try requireID(payload)
+        let localID = try requireLocalID(payload)
         let incoming = try requireUpdatedAt(payload)
-        guard try exists(in: "tasks", id: id) else {
-            // Already absent ⇒ idempotent success.
-            return ["operation": "delete", "id": id, "status": "applied"]
+        guard try exists(in: "tasks", id: localID) else {
+            // Already absent (or never synced) ⇒ idempotent success.
+            return ["operation": "delete", "localId": localID, "status": "applied"]
         }
         // Last-writer-wins applies to deletes too: an older delete must not erase a newer server edit.
-        if try isStale(taskID: id, incoming: incoming) {
+        if try isStale(localID: localID, incoming: incoming) {
             return [
-                "operation": "delete", "id": id, "status": "stale",
-                "server": try getTaskDetailPayload(taskID: id) ?? NSNull(),
+                "operation": "delete", "localId": localID, "status": "stale",
+                "server": try getTaskDetailPayload(taskID: localID) ?? NSNull(),
             ]
         }
         suspendAmbientMutationsAfterWrite()
@@ -641,10 +648,10 @@ public final class DemoServerSimulator {
             "UPDATE tasks SET deleted_at = ? WHERE id = ?",
             bind: { stmt in
                 self.sqlite.bind(double: Date().timeIntervalSince1970, at: 1, in: stmt)
-                self.sqlite.bind(text: id, at: 2, in: stmt)
+                self.sqlite.bind(text: localID, at: 2, in: stmt)
             }
         )
-        return ["operation": "delete", "id": id, "status": "applied"]
+        return ["operation": "delete", "localId": localID, "status": "applied"]
     }
 
     private func requireTasksType(_ payload: [String: Any]) throws {
@@ -653,11 +660,11 @@ public final class DemoServerSimulator {
         }
     }
 
-    private func requireID(_ payload: [String: Any]) throws -> String {
-        guard let id = payload["id"] as? String, !id.isEmpty else {
-            throw DemoBackendError.validation(message: "id is required")
+    private func requireLocalID(_ payload: [String: Any]) throws -> String {
+        guard let localID = payload["localId"] as? String, !localID.isEmpty else {
+            throw DemoBackendError.validation(message: "localId is required")
         }
-        return id
+        return localID
     }
 
     private func requireUpdatedAt(_ payload: [String: Any]) throws -> Date {
@@ -667,10 +674,29 @@ public final class DemoServerSimulator {
         return date
     }
 
-    private func isStale(taskID: String, incoming: Date) throws -> Bool {
+    /// The server's own id for a row, minted (and persisted) on first sight, returned unchanged after.
+    /// Opaque to the client; distinct from `localId` so the demo exercises a backend that owns its PKs.
+    private func ensureRemoteID(forLocalID localID: String) throws -> String {
+        let rows = try self.sqlite.query(
+            "SELECT remote_id FROM tasks WHERE id = ? LIMIT 1",
+            bind: { stmt in self.sqlite.bind(text: localID, at: 1, in: stmt) }
+        )
+        if let existing = rows.first?.nullableString("remote_id") { return existing }
+        let remote = "srv-\(UUID().uuidString.lowercased())"
+        try self.sqlite.execute(
+            "UPDATE tasks SET remote_id = ? WHERE id = ?",
+            bind: { stmt in
+                self.sqlite.bind(text: remote, at: 1, in: stmt)
+                self.sqlite.bind(text: localID, at: 2, in: stmt)
+            }
+        )
+        return remote
+    }
+
+    private func isStale(localID: String, incoming: Date) throws -> Bool {
         let rows = try self.sqlite.query(
             "SELECT updated_at FROM tasks WHERE id = ? LIMIT 1",
-            bind: { stmt in self.sqlite.bind(text: taskID, at: 1, in: stmt) }
+            bind: { stmt in self.sqlite.bind(text: localID, at: 1, in: stmt) }
         )
         guard let stored = rows.first?.double("updated_at") else { return false }
         // Contract: an incoming write older *or equal* loses (server wins ties).
@@ -680,7 +706,7 @@ public final class DemoServerSimulator {
     private func rejected(_ payload: [String: Any], code: String, message: String) -> [String: Any] {
         var result: [String: Any] = ["status": "rejected", "code": code, "message": message]
         if let operation = payload["operation"] as? String { result["operation"] = operation }
-        if let id = payload["id"] as? String { result["id"] = id }
+        if let localID = payload["localId"] as? String { result["localId"] = localID }
         return result
     }
 
@@ -802,9 +828,9 @@ public final class DemoServerSimulator {
         let stateID = row.string("state")
         return [
             "id": taskID,
-            // Single-id upsert model: a row's own id is its canonical server id. We still echo
-            // remote_id (= id) so the client's @RemoteKey("remote_id") "synced" marker is set.
-            "remote_id": taskID,
+            // Rows created before the upload path (seed / per-resource POST) have no minted
+            // remote_id; their own id is their canonical server id, so coalesce to it.
+            "remote_id": row.nullableString("remote_id") ?? taskID,
             "project_id": row.string("project_id"),
             "assignee_id": row.nullableString("assignee_id") ?? NSNull(),
             "reviewer_ids": try reviewerIDsFor(taskID: taskID),

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -611,6 +611,12 @@ public final class DemoServerSimulator {
                     "server": try getTaskDetailPayload(taskID: localID) ?? NSNull(),
                 ]
             }
+            // An edit newer than a delete wins LWW: revive the tombstoned row before updating it
+            // (updateTask ignores tombstoned rows). A no-op for a live row.
+            try self.sqlite.execute(
+                "UPDATE tasks SET deleted_at = NULL WHERE id = ?",
+                bind: { stmt in self.sqlite.bind(text: localID, at: 1, in: stmt) }
+            )
             _ = try updateTask(taskID: localID, body: body)
         } else {
             _ = try createTask(body: body)
@@ -644,11 +650,14 @@ public final class DemoServerSimulator {
             ]
         }
         suspendAmbientMutationsAfterWrite()
+        // Record the delete's logical timestamp in updated_at too, so a later upsert that targets this
+        // (now tombstoned) row compares LWW against *the delete*, not the pre-delete edit.
         try self.sqlite.execute(
-            "UPDATE tasks SET deleted_at = ? WHERE id = ?",
+            "UPDATE tasks SET deleted_at = ?, updated_at = ? WHERE id = ?",
             bind: { stmt in
                 self.sqlite.bind(double: Date().timeIntervalSince1970, at: 1, in: stmt)
-                self.sqlite.bind(text: localID, at: 2, in: stmt)
+                self.sqlite.bind(double: incoming.timeIntervalSince1970, at: 2, in: stmt)
+                self.sqlite.bind(text: localID, at: 3, in: stmt)
             }
         )
         return ["operation": "delete", "localId": localID, "status": "applied"]

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -10,15 +10,15 @@ public enum DemoBackendError: LocalizedError {
 
     public var errorDescription: String? {
         switch self {
-        case let .openDatabase(path):
+        case .openDatabase(let path):
             return "Failed to open demo backend database at \(path)."
-        case let .sqlite(message):
+        case .sqlite(let message):
             return "SQLite error: \(message)"
-        case let .notFound(entity, id):
+        case .notFound(let entity, let id):
             return "\(entity) not found: \(id)"
-        case let .invalidReference(entity, id):
+        case .invalidReference(let entity, let id):
             return "Invalid reference \(entity)=\(id)"
-        case let .validation(message):
+        case .validation(let message):
             return "Validation error: \(message)"
         }
     }
@@ -73,7 +73,7 @@ public final class DemoServerSimulator {
                 "name": row.string("name"),
                 "task_count": Int(row.int64("task_count")),
                 "created_at": iso8601(row.double("created_at")),
-                "updated_at": iso8601(row.double("updated_at"))
+                "updated_at": iso8601(row.double("updated_at")),
             ]
         }
     }
@@ -111,7 +111,7 @@ public final class DemoServerSimulator {
                 "id": row.string("id"),
                 "display_name": row.string("display_name"),
                 "created_at": iso8601(row.double("created_at")),
-                "updated_at": iso8601(row.double("updated_at"))
+                "updated_at": iso8601(row.double("updated_at")),
             ]
         }
     }
@@ -124,22 +124,22 @@ public final class DemoServerSimulator {
                 "label": "To Do",
                 "sort_order": 0,
                 "created_at": timestamp,
-                "updated_at": timestamp
+                "updated_at": timestamp,
             ],
             [
                 "id": "inProgress",
                 "label": "In Progress",
                 "sort_order": 1,
                 "created_at": timestamp,
-                "updated_at": timestamp
+                "updated_at": timestamp,
             ],
             [
                 "id": "done",
                 "label": "Done",
                 "sort_order": 2,
                 "created_at": timestamp,
-                "updated_at": timestamp
-            ]
+                "updated_at": timestamp,
+            ],
         ]
     }
 
@@ -334,18 +334,21 @@ public final class DemoServerSimulator {
             throw DemoBackendError.validation(message: "description is required")
         }
         guard let stateDict = body["state"] as? [String: Any],
-              let stateID = stateDict["id"] as? String else {
+            let stateID = stateDict["id"] as? String
+        else {
             throw DemoBackendError.validation(message: "state.id is required")
         }
         guard let authorID = body["author_id"] as? String else {
             throw DemoBackendError.validation(message: "author_id is required")
         }
         guard let createdAtString = body["created_at"] as? String,
-              let createdAt = parseISO8601String(createdAtString) else {
+            let createdAt = parseISO8601String(createdAtString)
+        else {
             throw DemoBackendError.validation(message: "created_at is required (ISO 8601)")
         }
         guard let updatedAtString = body["updated_at"] as? String,
-              let updatedAt = parseISO8601String(updatedAtString) else {
+            let updatedAt = parseISO8601String(updatedAtString)
+        else {
             throw DemoBackendError.validation(message: "updated_at is required (ISO 8601)")
         }
         let assigneeID = body["assignee_id"] as? String
@@ -461,7 +464,8 @@ public final class DemoServerSimulator {
             throw DemoBackendError.validation(message: "description is required")
         }
         guard let stateDict = body["state"] as? [String: Any],
-              let stateID = stateDict["id"] as? String else {
+            let stateID = stateDict["id"] as? String
+        else {
             throw DemoBackendError.validation(message: "state.id is required")
         }
 
@@ -477,7 +481,8 @@ public final class DemoServerSimulator {
             let existingTitlesByID = Dictionary(
                 uniqueKeysWithValues: existingRows.compactMap { row -> (String, String)? in
                     guard let id = row["id"] as? String,
-                          let title = row["title"] as? String else { return nil }
+                        let title = row["title"] as? String
+                    else { return nil }
                     return (id, title)
                 }
             )
@@ -489,7 +494,7 @@ public final class DemoServerSimulator {
         // assignee_id: present key means update (NSNull clears, String sets)
         let assigneeID: String?
         if body.keys.contains("assignee_id") {
-            assigneeID = body["assignee_id"] as? String   // nil if NSNull
+            assigneeID = body["assignee_id"] as? String  // nil if NSNull
         } else {
             // Preserve current value if key is absent
             assigneeID = current["assignee_id"] as? String
@@ -558,8 +563,8 @@ public final class DemoServerSimulator {
 
     // MARK: - POST /sync/upload (offline batch push)
     // See docs/project/upload-endpoint-contract.md. A flat, op-tagged operation list; per-operation
-    // results (no all-or-nothing). The server mints an opaque `remote_id`; `localId` (the task's `id`)
-    // is the stable client key and the idempotency key.
+    // results (no all-or-nothing). Operations are keyed by the client's `id` (single-id upsert):
+    // `upsert` is find-by-id → update-else-create, `delete` tombstones by id. Both are idempotent.
 
     public func upload(operations: [[String: Any]]) throws -> [String: Any] {
         let results = operations.map(applyUploadOperation(_:))
@@ -569,8 +574,7 @@ public final class DemoServerSimulator {
     private func applyUploadOperation(_ payload: [String: Any]) -> [String: Any] {
         do {
             switch payload["operation"] as? String {
-            case "insert": return try uploadInsert(payload)
-            case "update": return try uploadUpdate(payload)
+            case "upsert": return try uploadUpsert(payload)
             case "delete": return try uploadDelete(payload)
             case .none:
                 return rejected(payload, code: "missing_operation", message: "operation is required")
@@ -584,71 +588,52 @@ public final class DemoServerSimulator {
         }
     }
 
-    private func uploadInsert(_ payload: [String: Any]) throws -> [String: Any] {
+    /// Insert-or-update keyed by the client's `id`: the row's id *is* its id (no minted second id).
+    /// Found ⇒ update (last-writer-wins); absent ⇒ create. Idempotent — re-sending converges.
+    private func uploadUpsert(_ payload: [String: Any]) throws -> [String: Any] {
         try requireTasksType(payload)
-        guard let localID = payload["localId"] as? String, !localID.isEmpty else {
-            throw DemoBackendError.validation(message: "localId is required for insert")
-        }
-        // Idempotency: a row already keyed by this localId ⇒ return its remote_id (retry-safe).
-        if try !exists(in: "tasks", id: localID) {
-            guard let data = payload["data"] as? [String: Any] else {
-                throw DemoBackendError.validation(message: "data is required for insert")
-            }
-            var body = data
-            body["id"] = localID
-            _ = try createTask(body: body)
-            if let reviewerIDs = data["reviewer_ids"] as? [String], !reviewerIDs.isEmpty {
-                _ = try replaceTaskReviewers(taskID: localID, reviewerIDs: reviewerIDs)
-            }
-            if let watcherIDs = data["watcher_ids"] as? [String], !watcherIDs.isEmpty {
-                _ = try replaceTaskWatchers(taskID: localID, watcherIDs: watcherIDs)
-            }
-        }
-        let remote = try ensureRemoteID(forLocalID: localID)
-        return ["operation": "insert", "localId": localID, "remoteId": remote, "status": "applied"]
-    }
-
-    private func uploadUpdate(_ payload: [String: Any]) throws -> [String: Any] {
-        try requireTasksType(payload)
-        let remote = try requireRemoteID(payload)
+        let id = try requireID(payload)
         let incoming = try requireUpdatedAt(payload)
-        guard let localID = try localID(forRemoteID: remote) else {
-            throw DemoBackendError.notFound(entity: "task", id: remote)
+        guard let data = payload["data"] as? [String: Any] else {
+            throw DemoBackendError.validation(message: "data is required for upsert")
         }
-        if try isStale(localID: localID, incoming: incoming) {
-            return [
-                "operation": "update", "remoteId": remote, "status": "stale",
-                "server": try getTaskDetailPayload(taskID: localID) ?? NSNull(),
-            ]
+        var body = data
+        body["id"] = id
+
+        if try exists(in: "tasks", id: id) {
+            if try isStale(taskID: id, incoming: incoming) {
+                return [
+                    "operation": "upsert", "id": id, "status": "stale",
+                    "server": try getTaskDetailPayload(taskID: id) ?? NSNull(),
+                ]
+            }
+            _ = try updateTask(taskID: id, body: body)
+        } else {
+            _ = try createTask(body: body)
         }
-        guard var body = payload["data"] as? [String: Any] else {
-            throw DemoBackendError.validation(message: "data is required for update")
-        }
-        body["id"] = localID
-        _ = try updateTask(taskID: localID, body: body)
         // Relationship edits (reviewers/watchers) ride in the same operation when present.
-        if let reviewerIDs = body["reviewer_ids"] as? [String] {
-            _ = try replaceTaskReviewers(taskID: localID, reviewerIDs: reviewerIDs)
+        if let reviewerIDs = data["reviewer_ids"] as? [String] {
+            _ = try replaceTaskReviewers(taskID: id, reviewerIDs: reviewerIDs)
         }
-        if let watcherIDs = body["watcher_ids"] as? [String] {
-            _ = try replaceTaskWatchers(taskID: localID, watcherIDs: watcherIDs)
+        if let watcherIDs = data["watcher_ids"] as? [String] {
+            _ = try replaceTaskWatchers(taskID: id, watcherIDs: watcherIDs)
         }
-        return ["operation": "update", "remoteId": remote, "status": "applied"]
+        return ["operation": "upsert", "id": id, "status": "applied"]
     }
 
     private func uploadDelete(_ payload: [String: Any]) throws -> [String: Any] {
         try requireTasksType(payload)
-        let remote = try requireRemoteID(payload)
+        let id = try requireID(payload)
         let incoming = try requireUpdatedAt(payload)
-        guard let localID = try localID(forRemoteID: remote) else {
+        guard try exists(in: "tasks", id: id) else {
             // Already absent ⇒ idempotent success.
-            return ["operation": "delete", "remoteId": remote, "status": "applied"]
+            return ["operation": "delete", "id": id, "status": "applied"]
         }
         // Last-writer-wins applies to deletes too: an older delete must not erase a newer server edit.
-        if try isStale(localID: localID, incoming: incoming) {
+        if try isStale(taskID: id, incoming: incoming) {
             return [
-                "operation": "delete", "remoteId": remote, "status": "stale",
-                "server": try getTaskDetailPayload(taskID: localID) ?? NSNull(),
+                "operation": "delete", "id": id, "status": "stale",
+                "server": try getTaskDetailPayload(taskID: id) ?? NSNull(),
             ]
         }
         suspendAmbientMutationsAfterWrite()
@@ -656,10 +641,10 @@ public final class DemoServerSimulator {
             "UPDATE tasks SET deleted_at = ? WHERE id = ?",
             bind: { stmt in
                 self.sqlite.bind(double: Date().timeIntervalSince1970, at: 1, in: stmt)
-                self.sqlite.bind(text: localID, at: 2, in: stmt)
+                self.sqlite.bind(text: id, at: 2, in: stmt)
             }
         )
-        return ["operation": "delete", "remoteId": remote, "status": "applied"]
+        return ["operation": "delete", "id": id, "status": "applied"]
     }
 
     private func requireTasksType(_ payload: [String: Any]) throws {
@@ -668,11 +653,11 @@ public final class DemoServerSimulator {
         }
     }
 
-    private func requireRemoteID(_ payload: [String: Any]) throws -> String {
-        guard let remote = payload["remoteId"] as? String, !remote.isEmpty else {
-            throw DemoBackendError.validation(message: "remoteId is required")
+    private func requireID(_ payload: [String: Any]) throws -> String {
+        guard let id = payload["id"] as? String, !id.isEmpty else {
+            throw DemoBackendError.validation(message: "id is required")
         }
-        return remote
+        return id
     }
 
     private func requireUpdatedAt(_ payload: [String: Any]) throws -> Date {
@@ -682,44 +667,10 @@ public final class DemoServerSimulator {
         return date
     }
 
-    private func ensureRemoteID(forLocalID localID: String) throws -> String {
-        let rows = try self.sqlite.query(
-            "SELECT remote_id FROM tasks WHERE id = ? LIMIT 1",
-            bind: { stmt in self.sqlite.bind(text: localID, at: 1, in: stmt) }
-        )
-        if let existing = rows.first?.nullableString("remote_id") { return existing }
-        let remote = "srv-\(UUID().uuidString.lowercased())"
-        try self.sqlite.execute(
-            "UPDATE tasks SET remote_id = ? WHERE id = ?",
-            bind: { stmt in
-                self.sqlite.bind(text: remote, at: 1, in: stmt)
-                self.sqlite.bind(text: localID, at: 2, in: stmt)
-            }
-        )
-        return remote
-    }
-
-    private func localID(forRemoteID remote: String) throws -> String? {
-        // Match the minted remote_id, or fall back to id for pre-upload rows whose remote_id the
-        // payload coalesced to their id.
-        let rows = try self.sqlite.query(
-            """
-            SELECT id FROM tasks
-            WHERE (remote_id = ? OR (remote_id IS NULL AND id = ?)) AND deleted_at IS NULL
-            LIMIT 1
-            """,
-            bind: { stmt in
-                self.sqlite.bind(text: remote, at: 1, in: stmt)
-                self.sqlite.bind(text: remote, at: 2, in: stmt)
-            }
-        )
-        return rows.first.map { $0.string("id") }
-    }
-
-    private func isStale(localID: String, incoming: Date) throws -> Bool {
+    private func isStale(taskID: String, incoming: Date) throws -> Bool {
         let rows = try self.sqlite.query(
             "SELECT updated_at FROM tasks WHERE id = ? LIMIT 1",
-            bind: { stmt in self.sqlite.bind(text: localID, at: 1, in: stmt) }
+            bind: { stmt in self.sqlite.bind(text: taskID, at: 1, in: stmt) }
         )
         guard let stored = rows.first?.double("updated_at") else { return false }
         // Contract: an incoming write older *or equal* loses (server wins ties).
@@ -729,8 +680,7 @@ public final class DemoServerSimulator {
     private func rejected(_ payload: [String: Any], code: String, message: String) -> [String: Any] {
         var result: [String: Any] = ["status": "rejected", "code": code, "message": message]
         if let operation = payload["operation"] as? String { result["operation"] = operation }
-        if let localID = payload["localId"] as? String { result["localId"] = localID }
-        if let remoteID = payload["remoteId"] as? String { result["remoteId"] = remoteID }
+        if let id = payload["id"] as? String { result["id"] = id }
         return result
     }
 
@@ -818,7 +768,7 @@ public final class DemoServerSimulator {
             "Polish empty state after scoped delete",
             "Add regression check for task list animation",
             "Confirm assignee clear flow matches API contract",
-            "Re-run parent-scoped sync smoke test"
+            "Re-run parent-scoped sync smoke test",
         ]
         let states = ["todo", "inProgress", "done"]
         let selectedTitle = titles[step % titles.count]
@@ -852,9 +802,9 @@ public final class DemoServerSimulator {
         let stateID = row.string("state")
         return [
             "id": taskID,
-            // Rows created before the upload path (seed / per-resource POST) have no minted
-            // remote_id; their own id is their canonical server id, so coalesce to it.
-            "remote_id": row.nullableString("remote_id") ?? taskID,
+            // Single-id upsert model: a row's own id is its canonical server id. We still echo
+            // remote_id (= id) so the client's @RemoteKey("remote_id") "synced" marker is set.
+            "remote_id": taskID,
             "project_id": row.string("project_id"),
             "assignee_id": row.nullableString("assignee_id") ?? NSNull(),
             "reviewer_ids": try reviewerIDsFor(taskID: taskID),
@@ -865,7 +815,7 @@ public final class DemoServerSimulator {
             "watcher_ids": try watcherIDs(forTaskID: taskID),
             "items": try itemsPayload(taskID: taskID),
             "created_at": iso8601(row.double("created_at")),
-            "updated_at": iso8601(row.double("updated_at"))
+            "updated_at": iso8601(row.double("updated_at")),
         ]
     }
 
@@ -888,7 +838,7 @@ public final class DemoServerSimulator {
                 "title": row.string("title"),
                 "position": Int(row.int64("position")),
                 "created_at": iso8601(row.double("created_at")),
-                "updated_at": iso8601(row.double("updated_at"))
+                "updated_at": iso8601(row.double("updated_at")),
             ]
         }
     }
@@ -905,7 +855,7 @@ public final class DemoServerSimulator {
     private func labeledValuePayload(id: String, label: String) -> [String: Any] {
         [
             "id": id,
-            "label": label
+            "label": label,
         ]
     }
 
@@ -918,7 +868,7 @@ public final class DemoServerSimulator {
                 "label": id,
                 "sort_order": index,
                 "created_at": timestamp,
-                "updated_at": timestamp
+                "updated_at": timestamp,
             ]
         }
     }
@@ -983,7 +933,8 @@ public final class DemoServerSimulator {
             let createdAt: Date
             if let createdAtValue = item["created_at"] {
                 guard let createdAtString = createdAtValue as? String,
-                      let parsedCreatedAt = parseISO8601String(createdAtString) else {
+                    let parsedCreatedAt = parseISO8601String(createdAtString)
+                else {
                     throw DemoBackendError.validation(message: "items[\(index)].created_at must be ISO 8601")
                 }
                 createdAt = parsedCreatedAt
@@ -994,7 +945,8 @@ public final class DemoServerSimulator {
             let updatedAt: Date
             if let updatedAtValue = item["updated_at"] {
                 guard let updatedAtString = updatedAtValue as? String,
-                      let parsedUpdatedAt = parseISO8601String(updatedAtString) else {
+                    let parsedUpdatedAt = parseISO8601String(updatedAtString)
+                else {
                     throw DemoBackendError.validation(message: "items[\(index)].updated_at must be ISO 8601")
                 }
                 updatedAt = parsedUpdatedAt
@@ -1180,18 +1132,18 @@ public final class DemoServerSimulator {
         try sqlite.execute("BEGIN TRANSACTION;")
         do {
             for project in seedData.projects {
-            try sqlite.execute(
-                """
-                INSERT INTO projects (id, name, created_at, updated_at)
-                VALUES (?, ?, ?, ?)
-                """,
-                bind: { stmt in
-                    sqlite.bind(text: project.id, at: 1, in: stmt)
-                    sqlite.bind(text: project.name, at: 2, in: stmt)
-                    sqlite.bind(double: project.createdAt.timeIntervalSince1970, at: 3, in: stmt)
-                    sqlite.bind(double: project.updatedAt.timeIntervalSince1970, at: 4, in: stmt)
-                }
-            )
+                try sqlite.execute(
+                    """
+                    INSERT INTO projects (id, name, created_at, updated_at)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    bind: { stmt in
+                        sqlite.bind(text: project.id, at: 1, in: stmt)
+                        sqlite.bind(text: project.name, at: 2, in: stmt)
+                        sqlite.bind(double: project.createdAt.timeIntervalSince1970, at: 3, in: stmt)
+                        sqlite.bind(double: project.updatedAt.timeIntervalSince1970, at: 4, in: stmt)
+                    }
+                )
             }
 
             for user in seedData.users {
@@ -1392,20 +1344,20 @@ private struct DemoSQLiteRow {
     }
 
     func string(_ key: String) -> String {
-        guard case let .string(value)? = values[key] else { return "" }
+        guard case .string(let value)? = values[key] else { return "" }
         return value
     }
 
     func nullableString(_ key: String) -> String? {
         guard let value = values[key] else { return nil }
         switch value {
-        case let .string(string):
+        case .string(let string):
             return string
         case .null:
             return nil
-        case let .int64(number):
+        case .int64(let number):
             return String(number)
-        case let .double(number):
+        case .double(let number):
             return String(number)
         }
     }
@@ -1413,11 +1365,11 @@ private struct DemoSQLiteRow {
     func int64(_ key: String) -> Int64 {
         guard let value = values[key] else { return 0 }
         switch value {
-        case let .int64(number):
+        case .int64(let number):
             return number
-        case let .double(number):
+        case .double(let number):
             return Int64(number)
-        case let .string(string):
+        case .string(let string):
             return Int64(string) ?? 0
         case .null:
             return 0
@@ -1427,11 +1379,11 @@ private struct DemoSQLiteRow {
     func double(_ key: String) -> Double {
         guard let value = values[key] else { return 0 }
         switch value {
-        case let .double(number):
+        case .double(let number):
             return number
-        case let .int64(number):
+        case .int64(let number):
             return Double(number)
-        case let .string(string):
+        case .string(let string):
             return Double(string) ?? 0
         case .null:
             return 0
@@ -1439,7 +1391,6 @@ private struct DemoSQLiteRow {
     }
 
 }
-
 
 private enum DemoSQLiteValue {
     case null

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -1048,10 +1048,16 @@ public final class DemoServerSimulator {
         return rows.map { $0.string("id") }
     }
 
+    private static let maxTitleLength = 80
+
     private func validatedNonEmpty(_ value: String, field: String) throws -> String {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw DemoBackendError.validation(message: "\(field) must not be empty")
+        }
+        guard trimmed.count <= Self.maxTitleLength else {
+            throw DemoBackendError.validation(
+                message: "\(field) must be \(Self.maxTitleLength) characters or fewer")
         }
         return trimmed
     }

--- a/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
@@ -7,105 +7,110 @@ final class UploadEndpointTests: XCTestCase {
     private let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
     private let authorID = DemoSeedData.SeedIDs.Users.avaMartinez
 
-    func testUploadUpsertCreatesThenUpdatesIdempotently() throws {
+    func testUploadUpsertMintsDistinctRemoteIDAndIsIdempotent() throws {
         let backend = try makeBackend()
-        let id = "LOCAL-UPSERT-1"
+        let localID = "LOCAL-UPSERT-1"
         let before = try backend.getProjectTasksPayload(projectID: projectID).count
 
-        let first = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
+        let first = try result(of: backend.upload(operations: [upsertOp(localID: localID, title: "Offline task")]))
         XCTAssertEqual(first["status"] as? String, "applied")
-        XCTAssertEqual(first["id"] as? String, id)
+        XCTAssertEqual(first["localId"] as? String, localID)
+        let remoteID = try XCTUnwrap(first["remoteId"] as? String)
+        XCTAssertNotEqual(remoteID, localID, "the server mints its own remote id, distinct from localId")
+        XCTAssertTrue(remoteID.hasPrefix("srv-"))
 
         let tasks = try backend.getProjectTasksPayload(projectID: projectID)
         XCTAssertEqual(tasks.count, before + 1)
-        let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == id })
-        // Single-id model: the row's own id is its canonical server id, echoed back as remote_id.
-        XCTAssertEqual(inserted["remote_id"] as? String, id)
+        let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == localID })
+        XCTAssertEqual(inserted["remote_id"] as? String, remoteID)
 
-        // Re-upsert the same id (lost-response retry): converged, no duplicate row. The identical
-        // updatedAt loses the LWW tie (server wins ties), so the resend is a no-op marked "stale" —
-        // not a failure, and not a second row.
-        let retry = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
+        // Re-upsert the same localId (lost-response retry): same remote id, no duplicate row. The
+        // identical updatedAt loses the LWW tie, so it's a converged no-op — not a failure.
+        let retry = try result(of: backend.upload(operations: [upsertOp(localID: localID, title: "Offline task")]))
         XCTAssertNotEqual(retry["status"] as? String, "rejected")
+        XCTAssertEqual(retry["remoteId"] as? String, remoteID, "the minted remote id is stable across retries")
         XCTAssertEqual(try backend.getProjectTasksPayload(projectID: projectID).count, before + 1)
     }
 
     func testUploadUpsertIsLastWriterWins() throws {
         let backend = try makeBackend()
-        let id = "LOCAL-UPSERT-LWW-1"
-        _ = try result(
+        let localID = "LOCAL-UPSERT-LWW-1"
+        let created = try result(
             of: backend.upload(operations: [
-                upsertOp(id: id, title: "Original", updatedAt: "2026-01-01T00:00:00.000Z")
+                upsertOp(localID: localID, title: "Original", updatedAt: "2026-01-01T00:00:00.000Z")
             ]))
+        let remoteID = try XCTUnwrap(created["remoteId"] as? String)
 
-        // Older write loses: kept server state returned, title unchanged.
+        // Older write loses: kept server state returned, title unchanged, same remote id.
         let stale = try result(
             of: backend.upload(operations: [
-                upsertOp(id: id, title: "Stale edit", updatedAt: "2020-01-01T00:00:00.000Z")
+                upsertOp(localID: localID, title: "Stale edit", updatedAt: "2020-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(stale["status"] as? String, "stale")
+        XCTAssertEqual(stale["remoteId"] as? String, remoteID)
         let server = try XCTUnwrap(stale["server"] as? [String: Any])
         XCTAssertEqual(server["title"] as? String, "Original")
 
         // Newer write wins.
         let applied = try result(
             of: backend.upload(operations: [
-                upsertOp(id: id, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
+                upsertOp(localID: localID, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(applied["status"] as? String, "applied")
-        let detail = try XCTUnwrap(backend.getTaskDetailPayload(taskID: id))
+        XCTAssertEqual(applied["remoteId"] as? String, remoteID, "an update keeps the existing remote id")
+        let detail = try XCTUnwrap(backend.getTaskDetailPayload(taskID: localID))
         XCTAssertEqual(detail["title"] as? String, "Fresh edit")
     }
 
     func testUploadDeleteTombstonesAndHidesFromReads() throws {
         let backend = try makeBackend()
-        let id = "LOCAL-DELETE-1"
-        _ = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Doomed")]))
+        let localID = "LOCAL-DELETE-1"
+        _ = try result(of: backend.upload(operations: [upsertOp(localID: localID, title: "Doomed")]))
 
         let deleted = try result(
             of: backend.upload(operations: [
-                deleteOp(id: id, updatedAt: "2030-01-01T00:00:00.000Z")
+                deleteOp(localID: localID, updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(deleted["status"] as? String, "applied")
 
-        XCTAssertNil(try backend.getTaskDetailPayload(taskID: id), "tombstoned row is hidden from detail")
+        XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID), "tombstoned row is hidden from detail")
         XCTAssertFalse(
-            try backend.getProjectTasksPayload(projectID: projectID).contains { ($0["id"] as? String) == id },
+            try backend.getProjectTasksPayload(projectID: projectID).contains { ($0["id"] as? String) == localID },
             "tombstoned row is hidden from the list")
     }
 
     func testUploadDeleteIsLastWriterWins() throws {
         let backend = try makeBackend()
-        let id = "LOCAL-DELETE-LWW-1"
+        let localID = "LOCAL-DELETE-LWW-1"
         _ = try result(
             of: backend.upload(operations: [
-                upsertOp(id: id, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
+                upsertOp(localID: localID, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
 
         // A delete older than the server's version must lose: stale + server state, not a tombstone.
         let stale = try result(
             of: backend.upload(operations: [
-                deleteOp(id: id, updatedAt: "2020-01-01T00:00:00.000Z")
+                deleteOp(localID: localID, updatedAt: "2020-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(stale["status"] as? String, "stale")
         XCTAssertNotNil(stale["server"] as? [String: Any])
         XCTAssertNotNil(
-            try backend.getTaskDetailPayload(taskID: id), "a stale delete must not tombstone the row")
+            try backend.getTaskDetailPayload(taskID: localID), "a stale delete must not tombstone the row")
 
         // A newer delete wins.
         let applied = try result(
             of: backend.upload(operations: [
-                deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
+                deleteOp(localID: localID, updatedAt: "2040-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(applied["status"] as? String, "applied")
-        XCTAssertNil(try backend.getTaskDetailPayload(taskID: id))
+        XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID))
     }
 
     func testUploadFailsClosedOnMissingOrUnknownOperation() throws {
         let backend = try makeBackend()
         let response = try backend.upload(operations: [
-            ["type": "tasks", "id": "x", "data": [:]],  // no operation
-            ["operation": "destroy", "type": "tasks", "id": "y"],  // unknown
+            ["type": "tasks", "localId": "x", "data": [:]],  // no operation
+            ["operation": "destroy", "type": "tasks", "localId": "y"],  // unknown
         ])
         let results = try XCTUnwrap(response["results"] as? [[String: Any]])
         XCTAssertEqual(results.allSatisfy { ($0["status"] as? String) == "rejected" }, true)
@@ -122,21 +127,21 @@ final class UploadEndpointTests: XCTestCase {
         return try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
     }
 
-    private func upsertOp(id: String, title: String, updatedAt: String = "2026-06-16T20:00:00.000Z")
+    private func upsertOp(localID: String, title: String, updatedAt: String = "2026-06-16T20:00:00.000Z")
         -> [String: Any]
     {
         [
-            "operation": "upsert", "type": "tasks", "id": id, "updatedAt": updatedAt,
+            "operation": "upsert", "type": "tasks", "localId": localID, "updatedAt": updatedAt,
             "data": [
-                "id": id, "project_id": projectID, "author_id": authorID, "title": title,
+                "id": localID, "project_id": projectID, "author_id": authorID, "title": title,
                 "description": "from offline", "state": ["id": "todo"],
                 "created_at": updatedAt, "updated_at": updatedAt,
             ],
         ]
     }
 
-    private func deleteOp(id: String, updatedAt: String) -> [String: Any] {
-        ["operation": "delete", "type": "tasks", "id": id, "updatedAt": updatedAt]
+    private func deleteOp(localID: String, updatedAt: String) -> [String: Any] {
+        ["operation": "delete", "type": "tasks", "localId": localID, "updatedAt": updatedAt]
     }
 
     private func result(of response: [String: Any]) throws -> [String: Any] {

--- a/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
@@ -106,6 +106,51 @@ final class UploadEndpointTests: XCTestCase {
         XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID))
     }
 
+    func testUploadUpsertRevivesTombstonedRowWhenEditIsNewer() throws {
+        let backend = try makeBackend()
+        let localID = "REVIVE-1"
+        _ = try result(
+            of: backend.upload(operations: [
+                upsertOp(localID: localID, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
+            ]))
+        _ = try result(
+            of: backend.upload(operations: [
+                deleteOp(localID: localID, updatedAt: "2040-01-01T00:00:00.000Z")
+            ]))
+        XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID), "precondition: tombstoned")
+
+        // An edit newer than the delete wins LWW: it revives the row, not a phantom "applied".
+        let revived = try result(
+            of: backend.upload(operations: [
+                upsertOp(localID: localID, title: "Revived", updatedAt: "2050-01-01T00:00:00.000Z")
+            ]))
+        XCTAssertEqual(revived["status"] as? String, "applied")
+        let detail = try XCTUnwrap(
+            backend.getTaskDetailPayload(taskID: localID), "a newer edit must resurrect the tombstoned row")
+        XCTAssertEqual(detail["title"] as? String, "Revived")
+    }
+
+    func testUploadUpsertOnTombstonedRowStaysDeletedWhenEditIsOlder() throws {
+        let backend = try makeBackend()
+        let localID = "REVIVE-2"
+        _ = try result(
+            of: backend.upload(operations: [
+                upsertOp(localID: localID, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
+            ]))
+        _ = try result(
+            of: backend.upload(operations: [
+                deleteOp(localID: localID, updatedAt: "2040-01-01T00:00:00.000Z")
+            ]))
+
+        // An edit older than the delete loses LWW: stale, and the row stays deleted (no phantom apply).
+        let stale = try result(
+            of: backend.upload(operations: [
+                upsertOp(localID: localID, title: "Too late", updatedAt: "2035-01-01T00:00:00.000Z")
+            ]))
+        XCTAssertEqual(stale["status"] as? String, "stale")
+        XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID), "the row stays deleted")
+    }
+
     func testUploadFailsClosedOnMissingOrUnknownOperation() throws {
         let backend = try makeBackend()
         let response = try backend.upload(operations: [

--- a/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
@@ -7,100 +7,105 @@ final class UploadEndpointTests: XCTestCase {
     private let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
     private let authorID = DemoSeedData.SeedIDs.Users.avaMartinez
 
-    func testUploadInsertMintsDistinctRemoteIDAndIsIdempotent() throws {
+    func testUploadUpsertCreatesThenUpdatesIdempotently() throws {
         let backend = try makeBackend()
-        let localID = "LOCAL-INSERT-1"
+        let id = "LOCAL-UPSERT-1"
         let before = try backend.getProjectTasksPayload(projectID: projectID).count
 
-        let first = try result(of: backend.upload(operations: [insertOp(localID: localID, title: "Offline task")]))
+        let first = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
         XCTAssertEqual(first["status"] as? String, "applied")
-        let remoteID = try XCTUnwrap(first["remoteId"] as? String)
-        XCTAssertNotEqual(remoteID, localID, "the server mints its own remote id, distinct from localId")
-        XCTAssertTrue(remoteID.hasPrefix("srv-"))
+        XCTAssertEqual(first["id"] as? String, id)
 
         let tasks = try backend.getProjectTasksPayload(projectID: projectID)
         XCTAssertEqual(tasks.count, before + 1)
-        let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == localID })
-        XCTAssertEqual(inserted["remote_id"] as? String, remoteID)
+        let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == id })
+        // Single-id model: the row's own id is its canonical server id, echoed back as remote_id.
+        XCTAssertEqual(inserted["remote_id"] as? String, id)
 
-        // Retry the same insert (lost-response scenario): same remote id, no duplicate row.
-        let retry = try result(of: backend.upload(operations: [insertOp(localID: localID, title: "Offline task")]))
-        XCTAssertEqual(retry["remoteId"] as? String, remoteID)
+        // Re-upsert the same id (lost-response retry): converged, no duplicate row. The identical
+        // updatedAt loses the LWW tie (server wins ties), so the resend is a no-op marked "stale" —
+        // not a failure, and not a second row.
+        let retry = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
+        XCTAssertNotEqual(retry["status"] as? String, "rejected")
         XCTAssertEqual(try backend.getProjectTasksPayload(projectID: projectID).count, before + 1)
     }
 
-    func testUploadUpdateIsLastWriterWins() throws {
+    func testUploadUpsertIsLastWriterWins() throws {
         let backend = try makeBackend()
-        let localID = "LOCAL-UPDATE-1"
-        let inserted = try result(of: backend.upload(operations: [
-            insertOp(localID: localID, title: "Original", updatedAt: "2026-01-01T00:00:00.000Z")
-        ]))
-        let remoteID = try XCTUnwrap(inserted["remoteId"] as? String)
+        let id = "LOCAL-UPSERT-LWW-1"
+        _ = try result(
+            of: backend.upload(operations: [
+                upsertOp(id: id, title: "Original", updatedAt: "2026-01-01T00:00:00.000Z")
+            ]))
 
         // Older write loses: kept server state returned, title unchanged.
-        let stale = try result(of: backend.upload(operations: [
-            updateOp(remoteID: remoteID, localID: localID, title: "Stale edit", updatedAt: "2020-01-01T00:00:00.000Z")
-        ]))
+        let stale = try result(
+            of: backend.upload(operations: [
+                upsertOp(id: id, title: "Stale edit", updatedAt: "2020-01-01T00:00:00.000Z")
+            ]))
         XCTAssertEqual(stale["status"] as? String, "stale")
         let server = try XCTUnwrap(stale["server"] as? [String: Any])
         XCTAssertEqual(server["title"] as? String, "Original")
 
         // Newer write wins.
-        let applied = try result(of: backend.upload(operations: [
-            updateOp(remoteID: remoteID, localID: localID, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
-        ]))
+        let applied = try result(
+            of: backend.upload(operations: [
+                upsertOp(id: id, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
+            ]))
         XCTAssertEqual(applied["status"] as? String, "applied")
-        let detail = try XCTUnwrap(backend.getTaskDetailPayload(taskID: localID))
+        let detail = try XCTUnwrap(backend.getTaskDetailPayload(taskID: id))
         XCTAssertEqual(detail["title"] as? String, "Fresh edit")
     }
 
     func testUploadDeleteTombstonesAndHidesFromReads() throws {
         let backend = try makeBackend()
-        let localID = "LOCAL-DELETE-1"
-        let inserted = try result(of: backend.upload(operations: [insertOp(localID: localID, title: "Doomed")]))
-        let remoteID = try XCTUnwrap(inserted["remoteId"] as? String)
+        let id = "LOCAL-DELETE-1"
+        _ = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Doomed")]))
 
-        let deleted = try result(of: backend.upload(operations: [
-            deleteOp(remoteID: remoteID, updatedAt: "2030-01-01T00:00:00.000Z")
-        ]))
+        let deleted = try result(
+            of: backend.upload(operations: [
+                deleteOp(id: id, updatedAt: "2030-01-01T00:00:00.000Z")
+            ]))
         XCTAssertEqual(deleted["status"] as? String, "applied")
 
-        XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID), "tombstoned row is hidden from detail")
+        XCTAssertNil(try backend.getTaskDetailPayload(taskID: id), "tombstoned row is hidden from detail")
         XCTAssertFalse(
-            try backend.getProjectTasksPayload(projectID: projectID).contains { ($0["id"] as? String) == localID },
+            try backend.getProjectTasksPayload(projectID: projectID).contains { ($0["id"] as? String) == id },
             "tombstoned row is hidden from the list")
     }
 
     func testUploadDeleteIsLastWriterWins() throws {
         let backend = try makeBackend()
-        let localID = "LOCAL-DELETE-LWW-1"
-        let inserted = try result(of: backend.upload(operations: [
-            insertOp(localID: localID, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
-        ]))
-        let remoteID = try XCTUnwrap(inserted["remoteId"] as? String)
+        let id = "LOCAL-DELETE-LWW-1"
+        _ = try result(
+            of: backend.upload(operations: [
+                upsertOp(id: id, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
+            ]))
 
         // A delete older than the server's version must lose: stale + server state, not a tombstone.
-        let stale = try result(of: backend.upload(operations: [
-            deleteOp(remoteID: remoteID, updatedAt: "2020-01-01T00:00:00.000Z")
-        ]))
+        let stale = try result(
+            of: backend.upload(operations: [
+                deleteOp(id: id, updatedAt: "2020-01-01T00:00:00.000Z")
+            ]))
         XCTAssertEqual(stale["status"] as? String, "stale")
         XCTAssertNotNil(stale["server"] as? [String: Any])
         XCTAssertNotNil(
-            try backend.getTaskDetailPayload(taskID: localID), "a stale delete must not tombstone the row")
+            try backend.getTaskDetailPayload(taskID: id), "a stale delete must not tombstone the row")
 
         // A newer delete wins.
-        let applied = try result(of: backend.upload(operations: [
-            deleteOp(remoteID: remoteID, updatedAt: "2040-01-01T00:00:00.000Z")
-        ]))
+        let applied = try result(
+            of: backend.upload(operations: [
+                deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
+            ]))
         XCTAssertEqual(applied["status"] as? String, "applied")
-        XCTAssertNil(try backend.getTaskDetailPayload(taskID: localID))
+        XCTAssertNil(try backend.getTaskDetailPayload(taskID: id))
     }
 
     func testUploadFailsClosedOnMissingOrUnknownOperation() throws {
         let backend = try makeBackend()
         let response = try backend.upload(operations: [
-            ["type": "tasks", "localId": "x", "data": [:]],  // no operation
-            ["operation": "destroy", "type": "tasks", "remoteId": "y"],  // unknown
+            ["type": "tasks", "id": "x", "data": [:]],  // no operation
+            ["operation": "destroy", "type": "tasks", "id": "y"],  // unknown
         ])
         let results = try XCTUnwrap(response["results"] as? [[String: Any]])
         XCTAssertEqual(results.allSatisfy { ($0["status"] as? String) == "rejected" }, true)
@@ -117,34 +122,21 @@ final class UploadEndpointTests: XCTestCase {
         return try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
     }
 
-    private func insertOp(localID: String, title: String, updatedAt: String = "2026-06-16T20:00:00.000Z")
+    private func upsertOp(id: String, title: String, updatedAt: String = "2026-06-16T20:00:00.000Z")
         -> [String: Any]
     {
         [
-            "operation": "insert", "type": "tasks", "localId": localID, "updatedAt": updatedAt,
+            "operation": "upsert", "type": "tasks", "id": id, "updatedAt": updatedAt,
             "data": [
-                "project_id": projectID, "author_id": authorID, "title": title,
+                "id": id, "project_id": projectID, "author_id": authorID, "title": title,
                 "description": "from offline", "state": ["id": "todo"],
                 "created_at": updatedAt, "updated_at": updatedAt,
             ],
         ]
     }
 
-    private func updateOp(remoteID: String, localID: String, title: String, updatedAt: String)
-        -> [String: Any]
-    {
-        [
-            "operation": "update", "type": "tasks", "remoteId": remoteID, "updatedAt": updatedAt,
-            "data": [
-                "id": localID, "project_id": projectID, "author_id": authorID, "title": title,
-                "description": "edited", "state": ["id": "todo"],
-                "created_at": "2026-01-01T00:00:00.000Z", "updated_at": updatedAt,
-            ],
-        ]
-    }
-
-    private func deleteOp(remoteID: String, updatedAt: String) -> [String: Any] {
-        ["operation": "delete", "type": "tasks", "remoteId": remoteID, "updatedAt": updatedAt]
+    private func deleteOp(id: String, updatedAt: String) -> [String: Any] {
+        ["operation": "delete", "type": "tasks", "id": id, "updatedAt": updatedAt]
     }
 
     private func result(of response: [String: Any]) throws -> [String: Any] {

--- a/DemoCore/Sources/DemoCore/Models/DemoModels.swift
+++ b/DemoCore/Sources/DemoCore/Models/DemoModels.swift
@@ -96,8 +96,6 @@ public final class Task {
     @NotExport
     public var isLocallyDeleted: Bool?
 
-    // Set by the push driver when the server rejects this row; cleared on a successful push. Local
-    // bookkeeping, never exported.
     @NotExport
     public var syncFailureReason: String?
 

--- a/DemoCore/Sources/DemoCore/Models/DemoModels.swift
+++ b/DemoCore/Sources/DemoCore/Models/DemoModels.swift
@@ -96,6 +96,11 @@ public final class Task {
     @NotExport
     public var isLocallyDeleted: Bool?
 
+    // Set by the push driver when the server rejects this row; cleared on a successful push. Local
+    // bookkeeping, never exported.
+    @NotExport
+    public var syncFailureReason: String?
+
     @NotExport
     public var project: Project?
 
@@ -128,6 +133,7 @@ public final class Task {
         updatedAt: Date = Date(),
         syncRemoteID: String? = nil,
         isLocallyDeleted: Bool? = nil,
+        syncFailureReason: String? = nil,
         project: Project? = nil,
         author: User? = nil,
         assignee: User? = nil,
@@ -147,6 +153,7 @@ public final class Task {
         self.updatedAt = updatedAt
         self.syncRemoteID = syncRemoteID
         self.isLocallyDeleted = isLocallyDeleted
+        self.syncFailureReason = syncFailureReason
         self.project = project
         self.author = author
         self.assignee = assignee

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -89,7 +89,7 @@ public final class DemoSyncEngine {
             guard try project(withID: projectID) != nil else {
                 throw SyncTaskDetailError.missingProject(projectID)
             }
-            try await syncContainer.sync(item: body, as: Task.self, immediate: true)
+            try await syncContainer.sync(item: body, as: Task.self, runOnMain: true)
             refreshPendingCount()
             return
         }
@@ -107,7 +107,7 @@ public final class DemoSyncEngine {
         // must be re-inserted. Apply locally so it stays a pending insert; online, push to (re)insert.
         let neverSynced = (try task(withID: taskID))?.syncRemoteID == nil
         if isOffline || neverSynced {
-            try await syncContainer.sync(item: body, as: Task.self, immediate: true)
+            try await syncContainer.sync(item: body, as: Task.self, runOnMain: true)
             if let task = try task(withID: taskID) {
                 task.updatedAt = Date()
                 task.syncFailureReason = nil  // the corrected edit gets a fresh attempt
@@ -261,7 +261,7 @@ public final class DemoSyncEngine {
                 if let localID { response.confirmedUpdateLocalIDs.insert(localID) }
                 if status == "stale", let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(
-                        item: DemoSyncPayload(dictionary: server), as: Task.self, immediate: true)
+                        item: DemoSyncPayload(dictionary: server), as: Task.self, runOnMain: true)
                 }
             case ("delete", "applied"):
                 if let localID { response.confirmedDeleteLocalIDs.insert(localID) }
@@ -270,7 +270,7 @@ public final class DemoSyncEngine {
                 // the server's state so the row reappears with the winning version (no re-send loop).
                 if let localID, let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(
-                        item: DemoSyncPayload(dictionary: server), as: Task.self, immediate: true)
+                        item: DemoSyncPayload(dictionary: server), as: Task.self, runOnMain: true)
                     if let task = try task(withID: localID) { task.isLocallyDeleted = false }
                 }
             default:
@@ -393,7 +393,7 @@ public final class DemoSyncEngine {
         guard try project(withID: projectID) != nil else {
             throw SyncTaskDetailError.missingProject(projectID)
         }
-        try await syncContainer.sync(item: payload, as: Task.self)
+        try await syncContainer.sync(item: payload, as: Task.self, runOnMain: false)
         markPulled()
     }
 

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -122,6 +122,14 @@ public final class DemoSyncEngine {
         try await runOperation("updateTask-\(taskID)") {
             _ = try await apiClient.updateTask(taskID: taskID, body: body)
             try await syncTaskAfterMutation(taskID: taskID, projectID: projectID)
+            // A successful online edit resolves any prior failure on this row (e.g. fixing a rejected
+            // offline edit from the failures inbox). syncFailureReason is @NotExport, so the server
+            // refresh won't clear it — do it explicitly.
+            if let task = try task(withID: taskID), task.syncFailureReason != nil {
+                task.syncFailureReason = nil
+                try syncContainer.mainContext.save()
+                refreshPendingCount()
+            }
         }
     }
 
@@ -212,25 +220,26 @@ public final class DemoSyncEngine {
 
     /// Serialize the pending batch into the `/sync/upload` operation list, POST it once, and map the
     /// per-operation results back into a `SyncPushResponse`. Every created-or-edited row is an `upsert`
-    /// keyed by its `id` (the server find-by-id → update-else-creates); tombstones are a `delete` by
-    /// the same `id`. A `stale` result means the server won last-writer-wins — adopt its state locally
-    /// and treat the row as resolved so it isn't re-sent.
+    /// keyed by its stable `localId` (the server find-by-localId → update-else-creates, minting and
+    /// returning a distinct `remoteId` on first create); tombstones are a `delete` by the same
+    /// `localId`. A `stale` result means the server won last-writer-wins — adopt its state locally and
+    /// treat the row as resolved so it isn't re-sent.
     private func upload(_ batch: SyncPushBatch) async throws -> SyncPushResponse {
         var operations: [[String: Any]] = []
 
-        for id in batch.inserts + batch.updates {
-            guard let task = try task(withID: id) else { continue }
+        for localID in batch.inserts + batch.updates {
+            guard let task = try task(withID: localID) else { continue }
             let data = taskData(task)
             operations.append([
-                "operation": "upsert", "type": "tasks", "id": id,
+                "operation": "upsert", "type": "tasks", "localId": localID,
                 "updatedAt": data["updated_at"] ?? "", "data": data,
             ])
         }
-        for id in batch.deletes {
-            guard let task = try task(withID: id) else { continue }
+        for localID in batch.deletes {
+            guard let task = try task(withID: localID) else { continue }
             let data = syncContainer.export(task)
             operations.append([
-                "operation": "delete", "type": "tasks", "id": id,
+                "operation": "delete", "type": "tasks", "localId": localID,
                 "updatedAt": data["updated_at"] ?? "",
             ])
         }
@@ -241,31 +250,31 @@ public final class DemoSyncEngine {
         for result in results {
             let operation = result["operation"] as? String
             let status = result["status"] as? String
-            let id = result["id"] as? String
+            let localID = result["localId"] as? String
+            let remoteID = result["remoteId"] as? String
             switch (operation, status) {
             case ("upsert", "applied"), ("upsert", "stale"):
-                // An applied upsert resolves both inserts (stamp syncRemoteID = id) and updates;
-                // SyncSync scopes each field to its own batch slice, so populating both is safe.
-                if let id {
-                    response.assignedRemoteIDs[id] = id
-                    response.confirmedUpdateLocalIDs.insert(id)
-                }
+                // An applied upsert resolves both inserts (stamp the server-minted remoteId) and
+                // updates; SwiftSync scopes each field to its own batch slice, so populating both is
+                // safe.
+                if let localID, let remoteID { response.assignedRemoteIDs[localID] = remoteID }
+                if let localID { response.confirmedUpdateLocalIDs.insert(localID) }
                 if status == "stale", let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(item: DemoSyncPayload(dictionary: server), as: Task.self)
                 }
             case ("delete", "applied"):
-                if let id { response.confirmedDeleteLocalIDs.insert(id) }
+                if let localID { response.confirmedDeleteLocalIDs.insert(localID) }
             case ("delete", "stale"):
                 // The server has a newer edit — the delete lost LWW. Abandon the tombstone and adopt
                 // the server's state so the row reappears with the winning version (no re-send loop).
-                if let id, let server = result["server"] as? [String: Any] {
+                if let localID, let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(item: DemoSyncPayload(dictionary: server), as: Task.self)
-                    if let task = try task(withID: id) { task.isLocallyDeleted = false }
+                    if let task = try task(withID: localID) { task.isLocallyDeleted = false }
                 }
             default:
                 response.failures.append(
                     SyncPushFailure(
-                        localID: id ?? "",
+                        localID: localID ?? "",
                         operation: operation == "delete" ? .delete : .update,
                         message: (result["message"] as? String) ?? "rejected"))
             }

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -89,7 +89,7 @@ public final class DemoSyncEngine {
             guard try project(withID: projectID) != nil else {
                 throw SyncTaskDetailError.missingProject(projectID)
             }
-            try await syncContainer.sync(item: body, as: Task.self)
+            try await syncContainer.applyLocal(item: body, as: Task.self)
             refreshPendingCount()
             return
         }
@@ -107,7 +107,7 @@ public final class DemoSyncEngine {
         // must be re-inserted. Apply locally so it stays a pending insert; online, push to (re)insert.
         let neverSynced = (try task(withID: taskID))?.syncRemoteID == nil
         if isOffline || neverSynced {
-            try await syncContainer.sync(item: body, as: Task.self)
+            try await syncContainer.applyLocal(item: body, as: Task.self)
             if let task = try task(withID: taskID) {
                 task.updatedAt = Date()
                 task.syncFailureReason = nil  // the corrected edit gets a fresh attempt

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -89,7 +89,7 @@ public final class DemoSyncEngine {
             guard try project(withID: projectID) != nil else {
                 throw SyncTaskDetailError.missingProject(projectID)
             }
-            try await syncContainer.applyLocal(item: body, as: Task.self)
+            try await syncContainer.sync(item: body, as: Task.self, immediate: true)
             refreshPendingCount()
             return
         }
@@ -107,7 +107,7 @@ public final class DemoSyncEngine {
         // must be re-inserted. Apply locally so it stays a pending insert; online, push to (re)insert.
         let neverSynced = (try task(withID: taskID))?.syncRemoteID == nil
         if isOffline || neverSynced {
-            try await syncContainer.applyLocal(item: body, as: Task.self)
+            try await syncContainer.sync(item: body, as: Task.self, immediate: true)
             if let task = try task(withID: taskID) {
                 task.updatedAt = Date()
                 task.syncFailureReason = nil  // the corrected edit gets a fresh attempt

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -260,7 +260,8 @@ public final class DemoSyncEngine {
                 if let localID, let remoteID { response.assignedRemoteIDs[localID] = remoteID }
                 if let localID { response.confirmedUpdateLocalIDs.insert(localID) }
                 if status == "stale", let server = result["server"] as? [String: Any] {
-                    try? await syncContainer.sync(item: DemoSyncPayload(dictionary: server), as: Task.self)
+                    try? await syncContainer.sync(
+                        item: DemoSyncPayload(dictionary: server), as: Task.self, immediate: true)
                 }
             case ("delete", "applied"):
                 if let localID { response.confirmedDeleteLocalIDs.insert(localID) }
@@ -268,7 +269,8 @@ public final class DemoSyncEngine {
                 // The server has a newer edit — the delete lost LWW. Abandon the tombstone and adopt
                 // the server's state so the row reappears with the winning version (no re-send loop).
                 if let localID, let server = result["server"] as? [String: Any] {
-                    try? await syncContainer.sync(item: DemoSyncPayload(dictionary: server), as: Task.self)
+                    try? await syncContainer.sync(
+                        item: DemoSyncPayload(dictionary: server), as: Task.self, immediate: true)
                     if let task = try task(withID: localID) { task.isLocallyDeleted = false }
                 }
             default:

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -31,6 +31,9 @@ public final class DemoSyncEngine {
 
     public private(set) var pendingChangeCount = 0
 
+    /// Rows the server rejected (a failure reason is set). Drives the failures inbox.
+    public private(set) var failedChangeCount = 0
+
     /// Last point local state was reconciled with the server. Edits after this are pending updates;
     /// advanced after every inbound pull (so freshly-pulled rows aren't mistaken for local edits) and
     /// after a successful push.
@@ -286,6 +289,35 @@ public final class DemoSyncEngine {
         let pending = try? SwiftSync.pendingChanges(
             for: Task.self, in: syncContainer.mainContext, changedSince: syncCursor)
         pendingChangeCount = pending.map { $0.inserts.count + $0.updates.count + $0.deletes.count } ?? 0
+
+        let failed = try? syncContainer.mainContext.fetch(
+            FetchDescriptor<Task>(predicate: #Predicate { $0.syncFailureReason != nil }))
+        failedChangeCount = failed?.count ?? 0
+    }
+
+    /// Tasks the server rejected (a failure reason is set), newest first — the failures inbox.
+    public func failedTasks() -> [Task] {
+        (try? syncContainer.mainContext.fetch(
+            FetchDescriptor<Task>(
+                predicate: #Predicate { $0.syncFailureReason != nil },
+                sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]))) ?? []
+    }
+
+    /// Resolve a rejected change: drop a never-synced row, or restore the server's version of an
+    /// edited row (abandoning the local edit) and clear its failure.
+    public func discardFailedChange(taskID: String) async throws {
+        guard let task = try task(withID: taskID) else { return }
+        if task.syncRemoteID == nil {
+            syncContainer.mainContext.delete(task)
+            try syncContainer.mainContext.save()
+        } else {
+            try await syncTaskDetail(taskID: taskID)
+            if let refreshed = try self.task(withID: taskID) {
+                refreshed.syncFailureReason = nil
+                try syncContainer.mainContext.save()
+            }
+        }
+        refreshPendingCount()
     }
 
     /// After an inbound pull, advance the cursor so freshly-pulled rows aren't mistaken for local

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -89,7 +89,7 @@ public final class DemoSyncEngine {
             guard try project(withID: projectID) != nil else {
                 throw SyncTaskDetailError.missingProject(projectID)
             }
-            try await syncContainer.sync(item: body, as: Task.self, runOnMain: true)
+            try await syncContainer.sync(item: body, as: Task.self, context: .main)
             refreshPendingCount()
             return
         }
@@ -107,7 +107,7 @@ public final class DemoSyncEngine {
         // must be re-inserted. Apply locally so it stays a pending insert; online, push to (re)insert.
         let neverSynced = (try task(withID: taskID))?.syncRemoteID == nil
         if isOffline || neverSynced {
-            try await syncContainer.sync(item: body, as: Task.self, runOnMain: true)
+            try await syncContainer.sync(item: body, as: Task.self, context: .main)
             if let task = try task(withID: taskID) {
                 task.updatedAt = Date()
                 task.syncFailureReason = nil  // the corrected edit gets a fresh attempt
@@ -261,7 +261,7 @@ public final class DemoSyncEngine {
                 if let localID { response.confirmedUpdateLocalIDs.insert(localID) }
                 if status == "stale", let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(
-                        item: DemoSyncPayload(dictionary: server), as: Task.self, runOnMain: true)
+                        item: DemoSyncPayload(dictionary: server), as: Task.self, context: .main)
                 }
             case ("delete", "applied"):
                 if let localID { response.confirmedDeleteLocalIDs.insert(localID) }
@@ -270,7 +270,7 @@ public final class DemoSyncEngine {
                 // the server's state so the row reappears with the winning version (no re-send loop).
                 if let localID, let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(
-                        item: DemoSyncPayload(dictionary: server), as: Task.self, runOnMain: true)
+                        item: DemoSyncPayload(dictionary: server), as: Task.self, context: .main)
                     if let task = try task(withID: localID) { task.isLocallyDeleted = false }
                 }
             default:
@@ -393,7 +393,7 @@ public final class DemoSyncEngine {
         guard try project(withID: projectID) != nil else {
             throw SyncTaskDetailError.missingProject(projectID)
         }
-        try await syncContainer.sync(item: payload, as: Task.self, runOnMain: false)
+        try await syncContainer.sync(item: payload, as: Task.self, context: .background)
         markPulled()
     }
 

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -14,7 +14,7 @@ public final class DemoSyncEngine {
             switch self {
             case .missingProjectID:
                 return "Task detail payload is missing project_id."
-            case let .missingProject(projectID):
+            case .missingProject(let projectID):
                 return "Task detail sync requires project \(projectID) to exist locally."
             }
         }
@@ -103,13 +103,20 @@ public final class DemoSyncEngine {
     }
 
     public func updateTask(taskID: String, projectID: String?, body: DemoSyncPayload) async throws {
-        if isOffline {
+        // A row the server doesn't have yet (offline-created, or a rejected insert) can't be PUT — it
+        // must be re-inserted. Apply locally so it stays a pending insert; online, push to (re)insert.
+        let neverSynced = (try task(withID: taskID))?.syncRemoteID == nil
+        if isOffline || neverSynced {
             try await syncContainer.sync(item: body, as: Task.self)
             if let task = try task(withID: taskID) {
                 task.updatedAt = Date()
+                task.syncFailureReason = nil  // the corrected edit gets a fresh attempt
                 try syncContainer.mainContext.save()
             }
             refreshPendingCount()
+            if !isOffline {
+                _ = try await pushPendingChanges()
+            }
             return
         }
         try await runOperation("updateTask-\(taskID)") {
@@ -204,37 +211,26 @@ public final class DemoSyncEngine {
     }
 
     /// Serialize the pending batch into the `/sync/upload` operation list, POST it once, and map the
-    /// per-operation results back into a `SyncPushResponse`. Inserts carry the `localId` + full
-    /// resource; updates/deletes carry the server-assigned `remoteId` (from `syncRemoteID`). A `stale`
-    /// result means the server won last-writer-wins — adopt its state locally and treat the row as
-    /// resolved so it isn't re-sent.
+    /// per-operation results back into a `SyncPushResponse`. Every created-or-edited row is an `upsert`
+    /// keyed by its `id` (the server find-by-id → update-else-creates); tombstones are a `delete` by
+    /// the same `id`. A `stale` result means the server won last-writer-wins — adopt its state locally
+    /// and treat the row as resolved so it isn't re-sent.
     private func upload(_ batch: SyncPushBatch) async throws -> SyncPushResponse {
         var operations: [[String: Any]] = []
-        var remoteToLocal: [String: String] = [:]
 
-        for localID in batch.inserts {
-            guard let task = try task(withID: localID) else { continue }
+        for id in batch.inserts + batch.updates {
+            guard let task = try task(withID: id) else { continue }
             let data = taskData(task)
             operations.append([
-                "operation": "insert", "type": "tasks", "localId": localID,
+                "operation": "upsert", "type": "tasks", "id": id,
                 "updatedAt": data["updated_at"] ?? "", "data": data,
             ])
         }
-        for localID in batch.updates {
-            guard let task = try task(withID: localID), let remote = task.syncRemoteID else { continue }
-            remoteToLocal[remote] = localID
-            let data = taskData(task)
-            operations.append([
-                "operation": "update", "type": "tasks", "remoteId": remote,
-                "updatedAt": data["updated_at"] ?? "", "data": data,
-            ])
-        }
-        for localID in batch.deletes {
-            guard let task = try task(withID: localID), let remote = task.syncRemoteID else { continue }
-            remoteToLocal[remote] = localID
+        for id in batch.deletes {
+            guard let task = try task(withID: id) else { continue }
             let data = syncContainer.export(task)
             operations.append([
-                "operation": "delete", "type": "tasks", "remoteId": remote,
+                "operation": "delete", "type": "tasks", "id": id,
                 "updatedAt": data["updated_at"] ?? "",
             ])
         }
@@ -245,31 +241,32 @@ public final class DemoSyncEngine {
         for result in results {
             let operation = result["operation"] as? String
             let status = result["status"] as? String
-            let remoteID = result["remoteId"] as? String
-            let localID = (result["localId"] as? String) ?? remoteID.flatMap { remoteToLocal[$0] }
+            let id = result["id"] as? String
             switch (operation, status) {
-            case ("insert", "applied"):
-                if let localID, let remoteID { response.assignedRemoteIDs[localID] = remoteID }
-            case ("update", "applied"), ("update", "stale"):
-                if let localID { response.confirmedUpdateLocalIDs.insert(localID) }
+            case ("upsert", "applied"), ("upsert", "stale"):
+                // An applied upsert resolves both inserts (stamp syncRemoteID = id) and updates;
+                // SyncSync scopes each field to its own batch slice, so populating both is safe.
+                if let id {
+                    response.assignedRemoteIDs[id] = id
+                    response.confirmedUpdateLocalIDs.insert(id)
+                }
                 if status == "stale", let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(item: DemoSyncPayload(dictionary: server), as: Task.self)
                 }
             case ("delete", "applied"):
-                if let localID { response.confirmedDeleteLocalIDs.insert(localID) }
+                if let id { response.confirmedDeleteLocalIDs.insert(id) }
             case ("delete", "stale"):
                 // The server has a newer edit — the delete lost LWW. Abandon the tombstone and adopt
                 // the server's state so the row reappears with the winning version (no re-send loop).
-                if let localID, let server = result["server"] as? [String: Any] {
+                if let id, let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(item: DemoSyncPayload(dictionary: server), as: Task.self)
-                    if let task = try task(withID: localID) { task.isLocallyDeleted = false }
+                    if let task = try task(withID: id) { task.isLocallyDeleted = false }
                 }
             default:
-                let operationKind: SyncPushFailure.Operation =
-                    operation == "insert" ? .insert : (operation == "delete" ? .delete : .update)
                 response.failures.append(
                     SyncPushFailure(
-                        localID: localID ?? remoteID ?? "", operation: operationKind,
+                        localID: id ?? "",
+                        operation: operation == "delete" ? .delete : .update,
                         message: (result["message"] as? String) ?? "rejected"))
             }
         }

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -78,6 +78,36 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testRejectedPushPersistsFailureReasonOnTheRow() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // Offline: rename the task to an over-long title the server will reject.
+        engine.isOffline = true
+        let task = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        var dictionary = syncContainer.export(task)
+        dictionary["title"] = String(repeating: "A", count: 100)
+        try await engine.updateTask(
+            taskID: taskID, projectID: projectID, body: try DemoSyncPayload(dictionary: dictionary))
+
+        // Reconnect + push: the server rejects, and the failure is recorded on the row.
+        engine.isOffline = false
+        let pushResult = try await engine.pushPendingChanges()
+        let summary = try XCTUnwrap(pushResult)
+        XCTAssertEqual(summary.failures.count, 1)
+
+        let failed = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        let reason = try XCTUnwrap(failed.syncFailureReason, "the rejection is persisted on the row")
+        XCTAssertTrue(reason.contains("80 characters"), "the failure carries the server's reason: \(reason)")
+    }
+
+    @MainActor
     func testPushWhileOfflineIsANoOp() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -223,6 +223,36 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testOfflineEditOfCreatedTaskUpdatesTitleAndKeepsProjectLink() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        engine.isOffline = true
+        let createBody = try createBody(
+            from: DemoSeedData.SeedIDs.Tasks.sessionTimeout, newID: "OFFLINE-EDIT-1", in: syncContainer)
+        try await engine.createTask(body: createBody, projectID: projectID)
+
+        let created = try XCTUnwrap(fetchTask(id: "OFFLINE-EDIT-1", in: syncContainer.mainContext))
+        XCTAssertEqual(created.project?.id, projectID, "precondition: the created task is linked to its project")
+
+        var editDictionary = syncContainer.export(created)
+        editDictionary["title"] = "Renamed offline"
+        editDictionary.removeValue(forKey: "items")
+        try await engine.updateTask(
+            taskID: "OFFLINE-EDIT-1", projectID: projectID,
+            body: try DemoSyncPayload(dictionary: editDictionary))
+
+        let edited = try XCTUnwrap(fetchTask(id: "OFFLINE-EDIT-1", in: syncContainer.mainContext))
+        XCTAssertEqual(edited.title, "Renamed offline", "the edit updates the local row's title")
+        XCTAssertEqual(edited.project?.id, projectID, "the edit must not drop the project link")
+    }
+
+    @MainActor
     func testPushWhileOfflineIsANoOp() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -223,6 +223,52 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testConflictStaleAdoptionReflectsServerStateImmediately() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("stale-adopt-\(UUID().uuidString).sqlite")
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        let backend = try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
+        let apiClient = FakeDemoAPIClient(backend: backend)
+        let syncContainer = try makeSyncContainer()
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // A detail view holds the registered main-context row.
+        let held = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+
+        // Offline edit first (timestamp T1).
+        engine.isOffline = true
+        var localEdit = syncContainer.export(held)
+        localEdit["title"] = "Local edit"
+        localEdit.removeValue(forKey: "items")
+        try await engine.updateTask(
+            taskID: taskID, projectID: projectID, body: try DemoSyncPayload(dictionary: localEdit))
+
+        // Then another client advances the server's copy (timestamp T2 > T1), so our edit loses LWW.
+        let serverTitle = "Server wins \(UUID().uuidString.prefix(6))"
+        var serverData = syncContainer.export(held)
+        serverData["title"] = serverTitle
+        serverData["updated_at"] = "2099-01-01T00:00:00.000Z"
+        serverData.removeValue(forKey: "items")
+        _ = try backend.upload(operations: [
+            [
+                "operation": "upsert", "type": "tasks", "localId": taskID,
+                "updatedAt": "2099-01-01T00:00:00.000Z", "data": serverData,
+            ]
+        ])
+
+        // Reconnect and push → server returns stale; the engine adopts the server's version.
+        engine.isOffline = false
+        _ = try await engine.pushPendingChanges()
+
+        // The held row must show the adopted server value at once — not the stale local edit.
+        XCTAssertEqual(held.title, serverTitle, "conflict resolution must reflect on the live row immediately")
+    }
+
+    @MainActor
     func testOfflineEditOfCreatedTaskUpdatesTitleAndKeepsProjectLink() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -108,6 +108,37 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testDiscardFailedChangeRestoresServerStateAndClearsFailure() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+        let originalTitle = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext)).title
+
+        // Offline over-long rename → reject on push → failure recorded.
+        engine.isOffline = true
+        let task = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        var dictionary = syncContainer.export(task)
+        dictionary["title"] = String(repeating: "A", count: 100)
+        try await engine.updateTask(
+            taskID: taskID, projectID: projectID, body: try DemoSyncPayload(dictionary: dictionary))
+        engine.isOffline = false
+        _ = try await engine.pushPendingChanges()
+        XCTAssertNotNil(try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext)).syncFailureReason)
+
+        // Discard: restores the server's title and clears the failure.
+        try await engine.discardFailedChange(taskID: taskID)
+        let discarded = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertNil(discarded.syncFailureReason, "discard clears the failure")
+        XCTAssertEqual(discarded.title, originalTitle, "discard restores the server's version")
+        XCTAssertEqual(engine.failedChangeCount, 0)
+    }
+
+    @MainActor
     func testPushWhileOfflineIsANoOp() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -40,11 +40,11 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertEqual(engine.pendingChangeCount, 0)
 
         let synced = try XCTUnwrap(fetchTask(id: "OFFLINE-CREATE-1", in: syncContainer.mainContext))
-        // Single-id upsert: the row's id *is* its server id, so the push marks it synced by stamping
-        // syncRemoteID = id (no distinct minted id).
-        XCTAssertEqual(synced.syncRemoteID, "OFFLINE-CREATE-1", "push marks the row synced under its own id")
+        let remoteID = try XCTUnwrap(synced.syncRemoteID, "push stamps the server-minted remote id")
+        XCTAssertNotEqual(remoteID, "OFFLINE-CREATE-1", "the server mints its own id, distinct from localId")
+        XCTAssertTrue(remoteID.hasPrefix("srv-"))
         let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-CREATE-1")
-        XCTAssertNotNil(backendDetail, "the row reached the backend, keyed by its id")
+        XCTAssertNotNil(backendDetail, "the row reached the backend, keyed by its localId")
     }
 
     @MainActor
@@ -182,6 +182,47 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testEditingAFailedSyncedRowOnlineClearsFailure() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // Offline edit of an already-synced row to an over-long title → the update is rejected on push.
+        engine.isOffline = true
+        let synced = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertNotNil(synced.syncRemoteID, "precondition: the row is already synced")
+        var badDictionary = syncContainer.export(synced)
+        badDictionary["title"] = String(repeating: "A", count: 100)
+        badDictionary.removeValue(forKey: "items")
+        try await engine.updateTask(
+            taskID: taskID, projectID: projectID, body: try DemoSyncPayload(dictionary: badDictionary))
+
+        engine.isOffline = false
+        _ = try await engine.pushPendingChanges()
+        let failed = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertNotNil(failed.syncFailureReason, "the rejected edit is flagged")
+        XCTAssertNotNil(failed.syncRemoteID, "it is still a synced row, not a fresh insert")
+        XCTAssertEqual(engine.failedChangeCount, 1)
+
+        // Fix it with a valid title while online: the corrected save must resolve the failure.
+        var fixDictionary = syncContainer.export(failed)
+        fixDictionary["title"] = "Fixed online"
+        fixDictionary.removeValue(forKey: "items")
+        try await engine.updateTask(
+            taskID: taskID, projectID: projectID, body: try DemoSyncPayload(dictionary: fixDictionary))
+
+        let fixed = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertNil(fixed.syncFailureReason, "the failure clears once the corrected edit saves")
+        XCTAssertEqual(engine.failedChangeCount, 0, "the row leaves the failures inbox")
+        XCTAssertEqual(fixed.title, "Fixed online")
+    }
+
+    @MainActor
     func testPushWhileOfflineIsANoOp() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
@@ -230,7 +271,7 @@ final class OfflinePushTests: XCTestCase {
         // A task appears on the server that this client has never seen.
         _ = try backend.upload(operations: [
             [
-                "operation": "upsert", "type": "tasks", "id": "SERVER-ONLY-1",
+                "operation": "upsert", "type": "tasks", "localId": "SERVER-ONLY-1",
                 "updatedAt": "2026-06-16T20:00:00.000Z",
                 "data": [
                     "id": "SERVER-ONLY-1",

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -40,11 +40,11 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertEqual(engine.pendingChangeCount, 0)
 
         let synced = try XCTUnwrap(fetchTask(id: "OFFLINE-CREATE-1", in: syncContainer.mainContext))
-        let remoteID = try XCTUnwrap(synced.syncRemoteID, "push stamps the server-minted remote id")
-        XCTAssertNotEqual(remoteID, "OFFLINE-CREATE-1", "the server mints its own id, distinct from localId")
-        XCTAssertTrue(remoteID.hasPrefix("srv-"))
+        // Single-id upsert: the row's id *is* its server id, so the push marks it synced by stamping
+        // syncRemoteID = id (no distinct minted id).
+        XCTAssertEqual(synced.syncRemoteID, "OFFLINE-CREATE-1", "push marks the row synced under its own id")
         let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-CREATE-1")
-        XCTAssertNotNil(backendDetail, "the row reached the backend, keyed by its localId")
+        XCTAssertNotNil(backendDetail, "the row reached the backend, keyed by its id")
     }
 
     @MainActor
@@ -139,6 +139,49 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testEditingAFailedInsertReinsertsInsteadOf404() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let localID = "FAILED-INSERT-1"
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // Offline create with an over-long title → the insert is rejected on push.
+        engine.isOffline = true
+        let template = try XCTUnwrap(
+            fetchTask(id: DemoSeedData.SeedIDs.Tasks.sessionTimeout, in: syncContainer.mainContext))
+        var createDictionary = syncContainer.export(template)
+        createDictionary["id"] = localID
+        createDictionary["title"] = String(repeating: "A", count: 100)
+        createDictionary.removeValue(forKey: "items")
+        try await engine.createTask(
+            body: try DemoSyncPayload(dictionary: createDictionary), projectID: projectID)
+
+        engine.isOffline = false
+        _ = try await engine.pushPendingChanges()
+        let failed = try XCTUnwrap(fetchTask(id: localID, in: syncContainer.mainContext))
+        XCTAssertNotNil(failed.syncFailureReason, "the rejected insert is flagged")
+        XCTAssertNil(failed.syncRemoteID, "it never reached the server")
+
+        // Edit it to a valid title (online): a never-synced row must be re-inserted, not PUT/404'd.
+        var fixDictionary = syncContainer.export(failed)
+        fixDictionary["title"] = "Fixed"
+        fixDictionary.removeValue(forKey: "items")
+        try await engine.updateTask(
+            taskID: localID, projectID: projectID, body: try DemoSyncPayload(dictionary: fixDictionary))
+
+        let fixed = try XCTUnwrap(fetchTask(id: localID, in: syncContainer.mainContext))
+        XCTAssertNotNil(fixed.syncRemoteID, "the corrected task is inserted on the server")
+        XCTAssertNil(fixed.syncFailureReason, "the failure is resolved")
+        XCTAssertEqual(fixed.title, "Fixed")
+        let backendDetail = try await apiClient.getTaskDetail(taskID: localID)
+        XCTAssertNotNil(backendDetail, "it now exists on the server")
+    }
+
+    @MainActor
     func testPushWhileOfflineIsANoOp() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
@@ -187,9 +230,10 @@ final class OfflinePushTests: XCTestCase {
         // A task appears on the server that this client has never seen.
         _ = try backend.upload(operations: [
             [
-                "operation": "insert", "type": "tasks", "localId": "SERVER-ONLY-1",
+                "operation": "upsert", "type": "tasks", "id": "SERVER-ONLY-1",
                 "updatedAt": "2026-06-16T20:00:00.000Z",
                 "data": [
+                    "id": "SERVER-ONLY-1",
                     "project_id": projectID, "author_id": DemoSeedData.SeedIDs.Users.avaMartinez,
                     "title": "Created on the server", "description": "x", "state": ["id": "todo"],
                     "created_at": "2026-06-16T20:00:00.000Z", "updated_at": "2026-06-16T20:00:00.000Z",

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -143,8 +143,6 @@ extension SwiftSync {
             deletes: pending.deletes.map(\.syncLocalID))
         let response = try await upload(batch)
 
-        // Per-item rejection reasons are stamped onto the rows (and cleared on success), so they
-        // persist for the app to surface — a failures inbox is then just a query for set reasons.
         let failureReasons = Dictionary(
             response.failures.map { ($0.localID, $0.message) }, uniquingKeysWith: { first, _ in first })
 

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -148,17 +148,27 @@ extension SwiftSync {
         let failureReasons = Dictionary(
             response.failures.map { ($0.localID, $0.message) }, uniquingKeysWith: { first, _ in first })
 
+        // Clear a persisted failure only on *actual* success (remote id assigned / confirmed update /
+        // confirmed delete). A row the response neither acknowledged nor freshly failed is still
+        // pending — same as the cursor logic below treats it — so leave its existing marker untouched
+        // rather than silently dropping it from the failures inbox.
         var insertedCount = 0
         for insert in pending.inserts {
             if let remoteID = response.assignedRemoteIDs[insert.syncLocalID] {
                 insert.syncRemoteID = remoteID
                 insertedCount += 1
+                insert.syncFailureReason = nil
+            } else if let reason = failureReasons[insert.syncLocalID] {
+                insert.syncFailureReason = reason
             }
-            insert.syncFailureReason = failureReasons[insert.syncLocalID]
         }
 
         for update in pending.updates {
-            update.syncFailureReason = failureReasons[update.syncLocalID]
+            if response.confirmedUpdateLocalIDs.contains(update.syncLocalID) {
+                update.syncFailureReason = nil
+            } else if let reason = failureReasons[update.syncLocalID] {
+                update.syncFailureReason = reason
+            }
         }
 
         var deletedCount = 0
@@ -166,8 +176,8 @@ extension SwiftSync {
             if response.confirmedDeleteLocalIDs.contains(delete.syncLocalID) {
                 context.delete(delete)
                 deletedCount += 1
-            } else {
-                delete.syncFailureReason = failureReasons[delete.syncLocalID]
+            } else if let reason = failureReasons[delete.syncLocalID] {
+                delete.syncFailureReason = reason
             }
         }
 

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -14,6 +14,9 @@ public protocol SyncOfflineModel: PersistentModel {
     var syncRemoteID: String? { get set }
     var syncUpdatedAt: Date { get }
     var syncIsDeleted: Bool { get }
+    /// Why the server last rejected this row's push (`nil` if none). `push` stamps it on a per-item
+    /// failure and clears it on success, so a failures inbox is just a query for rows where it's set.
+    var syncFailureReason: String? { get set }
 }
 
 /// The local rows pending a push, partitioned by operation (live models, for applying results).
@@ -140,18 +143,32 @@ extension SwiftSync {
             deletes: pending.deletes.map(\.syncLocalID))
         let response = try await upload(batch)
 
+        // Per-item rejection reasons are stamped onto the rows (and cleared on success), so they
+        // persist for the app to surface — a failures inbox is then just a query for set reasons.
+        let failureReasons = Dictionary(
+            response.failures.map { ($0.localID, $0.message) }, uniquingKeysWith: { first, _ in first })
+
         var insertedCount = 0
         for insert in pending.inserts {
             if let remoteID = response.assignedRemoteIDs[insert.syncLocalID] {
                 insert.syncRemoteID = remoteID
                 insertedCount += 1
             }
+            insert.syncFailureReason = failureReasons[insert.syncLocalID]
+        }
+
+        for update in pending.updates {
+            update.syncFailureReason = failureReasons[update.syncLocalID]
         }
 
         var deletedCount = 0
-        for delete in pending.deletes where response.confirmedDeleteLocalIDs.contains(delete.syncLocalID) {
-            context.delete(delete)
-            deletedCount += 1
+        for delete in pending.deletes {
+            if response.confirmedDeleteLocalIDs.contains(delete.syncLocalID) {
+                context.delete(delete)
+                deletedCount += 1
+            } else {
+                delete.syncFailureReason = failureReasons[delete.syncLocalID]
+            }
         }
 
         try context.save()

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -9,7 +9,7 @@ struct UncheckedSendableBox<Value>: @unchecked Sendable {
     init(_ value: Value) { self.value = value }
 }
 
-/// Which `ModelContext` a single-object `sync` writes into — the one knob a caller actually chooses.
+/// Which `ModelContext` a single-object `sync` writes into.
 public enum SyncContext: Sendable {
     /// Apply on the main actor against `mainContext`: the row mutates in place, so live queries reflect
     /// it at once. Occupies the main thread, so use it only for small, single-object local writes.
@@ -157,8 +157,6 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         )
     }
 
-    /// Sync a single object.
-    ///
     /// `context` has **no default** so every caller chooses deliberately (see `SyncContext`): `.main`
     /// for a small local write that must be visible at once, `.background` for a server/inbound sync.
     /// The split exists because SwiftData has no `mergeChanges(fromContextDidSave:)`, so a

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -2,6 +2,13 @@ import Foundation
 import ObjCExceptionCatcher
 import SwiftData
 
+/// Carries a non-Sendable value across an actor hop. Sound only when the value is handed off (not used
+/// concurrently) — here, a sync payload passed to the main actor and read only there.
+struct UncheckedSendableBox<Value>: @unchecked Sendable {
+    let value: Value
+    init(_ value: Value) { self.value = value }
+}
+
 public final class SyncContainer: NSObject, @unchecked Sendable {
     public struct SchemaValidationError: LocalizedError, Sendable {
         public let message: String
@@ -140,16 +147,49 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         )
     }
 
+    /// Sync a single object.
+    ///
+    /// Set `immediate: true` for a *local* write (a UI/offline create or edit) that must be visible at
+    /// once: it is applied directly to `mainContext` on the main actor, mutating the row in place so
+    /// live queries update synchronously. Leave it `false` (default) for a server/background sync — that
+    /// imports on a background context off the main thread (its changes reach `mainContext` via the
+    /// did-save bridge). The split exists because SwiftData has no `mergeChanges(fromContextDidSave:)`,
+    /// so a background-context *update* doesn't promptly refresh an already-registered `mainContext`
+    /// row (the merge is gated on an idle main runloop) — `immediate` sidesteps that for local edits.
     public func sync<Model: SyncUpdatableModel>(
         item: [String: Any],
         as model: Model.Type,
-        relationshipOperations: SyncRelationshipOperations = .all
+        relationshipOperations: SyncRelationshipOperations = .all,
+        immediate: Bool = false
     ) async throws {
-        let context = ModelContext(modelContainer)
+        if immediate {
+            try await syncIntoMainContext(
+                UncheckedSendableBox(item), as: model, relationshipOperations: relationshipOperations)
+        } else {
+            let context = ModelContext(modelContainer)
+            try await SwiftSync.sync(
+                item: item,
+                as: model,
+                in: context,
+                keyStyle: keyStyle,
+                relationshipOperations: relationshipOperations
+            )
+        }
+    }
+
+    /// Import a single object straight into `mainContext` on the main actor (for immediate local
+    /// writes). The payload rides in an unchecked-Sendable box so it can cross to the main actor; it is
+    /// only read on the main actor here, so the box is sound.
+    @MainActor
+    private func syncIntoMainContext<Model: SyncUpdatableModel>(
+        _ item: UncheckedSendableBox<[String: Any]>,
+        as model: Model.Type,
+        relationshipOperations: SyncRelationshipOperations
+    ) async throws {
         try await SwiftSync.sync(
-            item: item,
+            item: item.value,
             as: model,
-            in: context,
+            in: mainContext,
             keyStyle: keyStyle,
             relationshipOperations: relationshipOperations
         )
@@ -158,12 +198,14 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
     public func sync<Model: SyncUpdatableModel, Payload: SyncPayloadConvertible>(
         item: Payload,
         as model: Model.Type,
-        relationshipOperations: SyncRelationshipOperations = .all
+        relationshipOperations: SyncRelationshipOperations = .all,
+        immediate: Bool = false
     ) async throws {
         try await sync(
             item: item.toSyncPayloadDictionary(),
             as: model,
-            relationshipOperations: relationshipOperations
+            relationshipOperations: relationshipOperations,
+            immediate: immediate
         )
     }
 
@@ -204,46 +246,6 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
 
     public func export<Model: SyncUpdatableModel>(_ model: Model) -> [String: Any] {
         model.export(keyStyle: keyStyle, dateFormatter: dateFormatter)
-    }
-
-    /// Apply a *local* (offline) write directly to `mainContext`, then notify query publishers.
-    ///
-    /// `sync(...)` imports through a background context. SwiftData's cross-context merge does not
-    /// promptly refresh an already-registered `mainContext` row on *update*, so an offline edit can
-    /// take a noticeable delay to surface in a live query (a fresh insert has no stale row, so it is
-    /// fine — which is why offline *create* already works but *edit* lags). Writing straight to
-    /// `mainContext` mutates the row in place, so the change is observable immediately. `mainContext`
-    /// saves are skipped by the did-save bridge, so the change notification is posted explicitly here.
-    public func applyLocal<Model: SyncUpdatableModel>(
-        item: [String: Any],
-        as model: Model.Type,
-        relationshipOperations: SyncRelationshipOperations = .all
-    ) async throws {
-        try await SwiftSync.sync(
-            item: item, as: model, in: mainContext,
-            keyStyle: keyStyle, relationshipOperations: relationshipOperations)
-        postLocalChange(modelTypeName: String(reflecting: Model.self))
-    }
-
-    public func applyLocal<Model: SyncUpdatableModel, Payload: SyncPayloadConvertible>(
-        item: Payload,
-        as model: Model.Type,
-        relationshipOperations: SyncRelationshipOperations = .all
-    ) async throws {
-        try await applyLocal(
-            item: item.toSyncPayloadDictionary(), as: model,
-            relationshipOperations: relationshipOperations)
-    }
-
-    private func postLocalChange(modelTypeName: String) {
-        NotificationCenter.default.post(
-            name: Self.didSaveChangesNotification,
-            object: self,
-            userInfo: [
-                Self.changedIdentifiersUserInfoKey: Set<PersistentIdentifier>(),
-                Self.changedModelTypeNamesUserInfoKey: Set([modelTypeName]),
-            ]
-        )
     }
 
     private func installDidSaveObserver() {
@@ -415,14 +417,24 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
     private func modelContextDidSave(_ notification: Notification) {
         guard let sourceContext = notification.object as? ModelContext else { return }
         guard sourceContext.container == modelContainer else { return }
-        guard sourceContext != mainContext else { return }
 
         let changedIDs = changedIdentifiers(from: notification.userInfo)
-        for identifier in changedIDs {
-            _ = mainContext.model(for: identifier)
+        let changedModelTypeNames: Set<String>
+        if sourceContext == mainContext {
+            // A local (immediate) write already landed in the main context, so its rows are current
+            // here — don't re-touch the context during its own did-save (avoid reentrancy); just notify
+            // publishers to re-fetch. Type names come from the source (main) context: a safe read.
+            changedModelTypeNames = Set(
+                changedIDs.map { String(reflecting: type(of: sourceContext.model(for: $0))) })
+        } else {
+            // A background-context sync: register the changed rows in the main context and process its
+            // pending changes so the merge lands, then notify.
+            for identifier in changedIDs {
+                _ = mainContext.model(for: identifier)
+            }
+            changedModelTypeNames = self.changedModelTypeNames(for: changedIDs)
+            mainContext.processPendingChanges()
         }
-        let changedModelTypeNames = changedModelTypeNames(for: changedIDs)
-        mainContext.processPendingChanges()
         NotificationCenter.default.post(
             name: Self.didSaveChangesNotification,
             object: self,

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -9,6 +9,16 @@ struct UncheckedSendableBox<Value>: @unchecked Sendable {
     init(_ value: Value) { self.value = value }
 }
 
+/// Which `ModelContext` a single-object `sync` writes into — the one knob a caller actually chooses.
+public enum SyncContext: Sendable {
+    /// Apply on the main actor against `mainContext`: the row mutates in place, so live queries reflect
+    /// it at once. Occupies the main thread, so use it only for small, single-object local writes.
+    case main
+    /// Import on a background context off the main thread; changes merge into `mainContext` via the
+    /// did-save bridge (gated on an idle main runloop). The right choice for server/inbound syncs.
+    case background
+}
+
 public final class SyncContainer: NSObject, @unchecked Sendable {
     public struct SchemaValidationError: LocalizedError, Sendable {
         public let message: String
@@ -149,31 +159,27 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
 
     /// Sync a single object.
     ///
-    /// `runOnMain` has **no default** so every caller makes the choice deliberately:
-    /// - `true` for a *small, single-object local write* (a UI/offline create or edit) that must be
-    ///   visible at once: the import runs on the main actor against `mainContext`, mutating the row in
-    ///   place so live queries update synchronously. Only for small writes — it occupies the main thread.
-    /// - `false` for a server/background sync: it imports on a background context off the main thread
-    ///   (changes reach `mainContext` via the did-save bridge), so a large pull never blocks the UI.
-    ///
+    /// `context` has **no default** so every caller chooses deliberately (see `SyncContext`): `.main`
+    /// for a small local write that must be visible at once, `.background` for a server/inbound sync.
     /// The split exists because SwiftData has no `mergeChanges(fromContextDidSave:)`, so a
     /// background-context *update* doesn't promptly refresh an already-registered `mainContext` row
-    /// (the merge is gated on an idle main runloop) — running a local edit on main sidesteps that.
+    /// (the merge is gated on an idle main runloop) — writing a local edit on `.main` sidesteps that.
     public func sync<Model: SyncUpdatableModel>(
         item: [String: Any],
         as model: Model.Type,
         relationshipOperations: SyncRelationshipOperations = .all,
-        runOnMain: Bool
+        context: SyncContext
     ) async throws {
-        if runOnMain {
+        switch context {
+        case .main:
             try await syncIntoMainContext(
                 UncheckedSendableBox(item), as: model, relationshipOperations: relationshipOperations)
-        } else {
-            let context = ModelContext(modelContainer)
+        case .background:
+            let backgroundContext = ModelContext(modelContainer)
             try await SwiftSync.sync(
                 item: item,
                 as: model,
-                in: context,
+                in: backgroundContext,
                 keyStyle: keyStyle,
                 relationshipOperations: relationshipOperations
             )
@@ -202,13 +208,13 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         item: Payload,
         as model: Model.Type,
         relationshipOperations: SyncRelationshipOperations = .all,
-        runOnMain: Bool
+        context: SyncContext
     ) async throws {
         try await sync(
             item: item.toSyncPayloadDictionary(),
             as: model,
             relationshipOperations: relationshipOperations,
-            runOnMain: runOnMain
+            context: context
         )
     }
 

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -206,6 +206,46 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         model.export(keyStyle: keyStyle, dateFormatter: dateFormatter)
     }
 
+    /// Apply a *local* (offline) write directly to `mainContext`, then notify query publishers.
+    ///
+    /// `sync(...)` imports through a background context. SwiftData's cross-context merge does not
+    /// promptly refresh an already-registered `mainContext` row on *update*, so an offline edit can
+    /// take a noticeable delay to surface in a live query (a fresh insert has no stale row, so it is
+    /// fine — which is why offline *create* already works but *edit* lags). Writing straight to
+    /// `mainContext` mutates the row in place, so the change is observable immediately. `mainContext`
+    /// saves are skipped by the did-save bridge, so the change notification is posted explicitly here.
+    public func applyLocal<Model: SyncUpdatableModel>(
+        item: [String: Any],
+        as model: Model.Type,
+        relationshipOperations: SyncRelationshipOperations = .all
+    ) async throws {
+        try await SwiftSync.sync(
+            item: item, as: model, in: mainContext,
+            keyStyle: keyStyle, relationshipOperations: relationshipOperations)
+        postLocalChange(modelTypeName: String(reflecting: Model.self))
+    }
+
+    public func applyLocal<Model: SyncUpdatableModel, Payload: SyncPayloadConvertible>(
+        item: Payload,
+        as model: Model.Type,
+        relationshipOperations: SyncRelationshipOperations = .all
+    ) async throws {
+        try await applyLocal(
+            item: item.toSyncPayloadDictionary(), as: model,
+            relationshipOperations: relationshipOperations)
+    }
+
+    private func postLocalChange(modelTypeName: String) {
+        NotificationCenter.default.post(
+            name: Self.didSaveChangesNotification,
+            object: self,
+            userInfo: [
+                Self.changedIdentifiersUserInfoKey: Set<PersistentIdentifier>(),
+                Self.changedModelTypeNamesUserInfoKey: Set([modelTypeName]),
+            ]
+        )
+    }
+
     private func installDidSaveObserver() {
         NotificationCenter.default.addObserver(
             self,

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -149,20 +149,23 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
 
     /// Sync a single object.
     ///
-    /// Set `immediate: true` for a *local* write (a UI/offline create or edit) that must be visible at
-    /// once: it is applied directly to `mainContext` on the main actor, mutating the row in place so
-    /// live queries update synchronously. Leave it `false` (default) for a server/background sync — that
-    /// imports on a background context off the main thread (its changes reach `mainContext` via the
-    /// did-save bridge). The split exists because SwiftData has no `mergeChanges(fromContextDidSave:)`,
-    /// so a background-context *update* doesn't promptly refresh an already-registered `mainContext`
-    /// row (the merge is gated on an idle main runloop) — `immediate` sidesteps that for local edits.
+    /// `runOnMain` has **no default** so every caller makes the choice deliberately:
+    /// - `true` for a *small, single-object local write* (a UI/offline create or edit) that must be
+    ///   visible at once: the import runs on the main actor against `mainContext`, mutating the row in
+    ///   place so live queries update synchronously. Only for small writes — it occupies the main thread.
+    /// - `false` for a server/background sync: it imports on a background context off the main thread
+    ///   (changes reach `mainContext` via the did-save bridge), so a large pull never blocks the UI.
+    ///
+    /// The split exists because SwiftData has no `mergeChanges(fromContextDidSave:)`, so a
+    /// background-context *update* doesn't promptly refresh an already-registered `mainContext` row
+    /// (the merge is gated on an idle main runloop) — running a local edit on main sidesteps that.
     public func sync<Model: SyncUpdatableModel>(
         item: [String: Any],
         as model: Model.Type,
         relationshipOperations: SyncRelationshipOperations = .all,
-        immediate: Bool = false
+        runOnMain: Bool
     ) async throws {
-        if immediate {
+        if runOnMain {
             try await syncIntoMainContext(
                 UncheckedSendableBox(item), as: model, relationshipOperations: relationshipOperations)
         } else {
@@ -199,13 +202,13 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         item: Payload,
         as model: Model.Type,
         relationshipOperations: SyncRelationshipOperations = .all,
-        immediate: Bool = false
+        runOnMain: Bool
     ) async throws {
         try await sync(
             item: item.toSyncPayloadDictionary(),
             as: model,
             relationshipOperations: relationshipOperations,
-            immediate: immediate
+            runOnMain: runOnMain
         )
     }
 

--- a/SwiftSync/Tests/SwiftSyncTests/SyncModelPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncModelPublisherTests.swift
@@ -58,7 +58,7 @@ final class SyncModelPublisherTests: XCTestCase {
         try await syncContainer.sync(
             item: ["id": "t1", "title": "Alpha", "assignee_id": "u1"],
             as: ModelPubTask.self,
-            runOnMain: false
+            context: .background
         )
 
         try await waitUntil {
@@ -97,7 +97,7 @@ final class SyncModelPublisherTests: XCTestCase {
         try await syncContainer.sync(
             item: ["id": "t1", "title": "Alpha", "assignee_id": "u1"],
             as: ModelPubTask.self,
-            runOnMain: false
+            context: .background
         )
 
         try await waitUntil {

--- a/SwiftSync/Tests/SwiftSyncTests/SyncModelPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncModelPublisherTests.swift
@@ -57,7 +57,8 @@ final class SyncModelPublisherTests: XCTestCase {
 
         try await syncContainer.sync(
             item: ["id": "t1", "title": "Alpha", "assignee_id": "u1"],
-            as: ModelPubTask.self
+            as: ModelPubTask.self,
+            runOnMain: false
         )
 
         try await waitUntil {
@@ -95,7 +96,8 @@ final class SyncModelPublisherTests: XCTestCase {
 
         try await syncContainer.sync(
             item: ["id": "t1", "title": "Alpha", "assignee_id": "u1"],
-            as: ModelPubTask.self
+            as: ModelPubTask.self,
+            runOnMain: false
         )
 
         try await waitUntil {

--- a/SwiftSync/Tests/SwiftSyncTests/SyncPushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncPushTests.swift
@@ -178,7 +178,47 @@ final class SyncPushTests: XCTestCase {
         XCTAssertEqual(stillPending.updates.map(\.syncLocalID), ["u1"])
     }
 
-    /// P2: `updatedCount` must reflect only rows that were actually in this push batch, not whatever
+    /// A persisted failure must clear only on *actual* success, never merely because the server's
+    /// response didn't mention the row. An unacknowledged row is still pending (the cursor logic agrees
+    /// — it doesn't advance past it), so silently dropping its failure marker would make it vanish from
+    /// the failures inbox while still unsynced.
+    @MainActor
+    func testPushKeepsFailureReasonForUnacknowledgedRows() async throws {
+        let context = ModelContext(
+            try ModelContainer(
+                for: OfflineNote.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
+        let lastSync = Date(timeIntervalSince1970: 1_000)
+        let edited = Date(timeIntervalSince1970: 1_500)
+
+        // An insert and an update, both already flagged from a prior push.
+        let insert = OfflineNote(
+            syncLocalID: "c1", syncRemoteID: nil, syncUpdatedAt: edited, syncIsDeleted: false,
+            title: "failed insert")
+        insert.syncFailureReason = "422 invalid"
+        context.insert(insert)
+        let update = OfflineNote(
+            syncLocalID: "u1", syncRemoteID: "r-u1", syncUpdatedAt: edited, syncIsDeleted: false,
+            title: "failed update")
+        update.syncFailureReason = "500 server error"
+        context.insert(update)
+        try context.save()
+
+        // The next push returns nothing for either row — neither acknowledged nor freshly failed.
+        _ = try await SwiftSync.push(
+            for: OfflineNote.self, in: context, changedSince: lastSync,
+            now: Date(timeIntervalSince1970: 2_000)
+        ) { _ in SyncPushResponse() }
+
+        let rows = Dictionary(
+            uniqueKeysWithValues: try context.fetch(FetchDescriptor<OfflineNote>()).map { ($0.syncLocalID, $0) })
+        XCTAssertEqual(
+            rows["c1"]?.syncFailureReason, "422 invalid", "an unacknowledged insert keeps its failure")
+        XCTAssertEqual(
+            rows["u1"]?.syncFailureReason, "500 server error", "an unacknowledged update keeps its failure")
+    }
+
+    /// `updatedCount` must reflect only rows that were actually in this push batch, not whatever
     /// ids the server echoed back.
     @MainActor
     func testPushUpdatedCountIgnoresIDsOutsideTheBatch() async throws {

--- a/SwiftSync/Tests/SwiftSyncTests/SyncPushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncPushTests.swift
@@ -9,6 +9,7 @@ final class OfflineNote: SyncOfflineModel {
     var syncRemoteID: String?
     var syncUpdatedAt: Date
     var syncIsDeleted: Bool
+    var syncFailureReason: String?
     var title: String
 
     init(

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
@@ -362,4 +362,25 @@ final class SyncQueryPublisherTests: XCTestCase {
         }
         XCTFail("Timed out waiting for condition: \(description)")
     }
+
+    // MARK: - Local (offline) writes
+
+    @MainActor
+    func testApplyLocalUpdatesRegisteredMainContextRowInPlace() async throws {
+        let container = try makeContainer(modelTypes: PubTask.self)
+        container.mainContext.insert(PubTask(id: "t1", title: "Original"))
+        try container.mainContext.save()
+
+        // A live query / SwiftUI view holds the registered main-context instance.
+        let row = try XCTUnwrap(
+            container.mainContext.fetch(FetchDescriptor<PubTask>()).first { $0.id == "t1" })
+
+        try await container.applyLocal(item: ["id": "t1", "title": "Edited"], as: PubTask.self)
+
+        // A local write must be visible on the already-registered instance immediately. Importing
+        // through a background context (plain `sync`) leaves this instance stale until SwiftData's
+        // cross-context merge eventually catches up — which is the offline edit-doesn't-update-the-list
+        // bug. `applyLocal` writes straight to the main context, so the change lands in place.
+        XCTAssertEqual(row.title, "Edited")
+    }
 }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
@@ -377,8 +377,7 @@ final class SyncQueryPublisherTests: XCTestCase {
 
         // runOnMain: true applies on the main context, so the edit lands on the already-registered
         // instance at once. A background-context sync (runOnMain: false) would leave this instance
-        // stale until SwiftData's cross-context merge catches up on an idle main runloop — the offline
-        // edit-doesn't-update-the-list bug.
+        // stale until SwiftData's cross-context merge catches up on an idle main runloop.
         try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self, runOnMain: true)
 
         XCTAssertEqual(row.title, "Edited")

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
@@ -363,10 +363,10 @@ final class SyncQueryPublisherTests: XCTestCase {
         XCTFail("Timed out waiting for condition: \(description)")
     }
 
-    // MARK: - Local (offline) writes
+    // MARK: - Immediate (local) writes land in place
 
     @MainActor
-    func testApplyLocalUpdatesRegisteredMainContextRowInPlace() async throws {
+    func testImmediateSyncUpdatesRegisteredRowInPlace() async throws {
         let container = try makeContainer(modelTypes: PubTask.self)
         container.mainContext.insert(PubTask(id: "t1", title: "Original"))
         try container.mainContext.save()
@@ -375,12 +375,12 @@ final class SyncQueryPublisherTests: XCTestCase {
         let row = try XCTUnwrap(
             container.mainContext.fetch(FetchDescriptor<PubTask>()).first { $0.id == "t1" })
 
-        try await container.applyLocal(item: ["id": "t1", "title": "Edited"], as: PubTask.self)
+        // immediate: true applies on the main context, so the edit lands on the already-registered
+        // instance at once. A background-context sync (immediate: false) would leave this instance
+        // stale until SwiftData's cross-context merge catches up on an idle main runloop — the offline
+        // edit-doesn't-update-the-list bug.
+        try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self, immediate: true)
 
-        // A local write must be visible on the already-registered instance immediately. Importing
-        // through a background context (plain `sync`) leaves this instance stale until SwiftData's
-        // cross-context merge eventually catches up — which is the offline edit-doesn't-update-the-list
-        // bug. `applyLocal` writes straight to the main context, so the change lands in place.
         XCTAssertEqual(row.title, "Edited")
     }
 }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
@@ -363,10 +363,10 @@ final class SyncQueryPublisherTests: XCTestCase {
         XCTFail("Timed out waiting for condition: \(description)")
     }
 
-    // MARK: - Immediate (local) writes land in place
+    // MARK: - runOnMain (local) writes land in place
 
     @MainActor
-    func testImmediateSyncUpdatesRegisteredRowInPlace() async throws {
+    func testRunOnMainSyncUpdatesRegisteredRowInPlace() async throws {
         let container = try makeContainer(modelTypes: PubTask.self)
         container.mainContext.insert(PubTask(id: "t1", title: "Original"))
         try container.mainContext.save()
@@ -375,11 +375,11 @@ final class SyncQueryPublisherTests: XCTestCase {
         let row = try XCTUnwrap(
             container.mainContext.fetch(FetchDescriptor<PubTask>()).first { $0.id == "t1" })
 
-        // immediate: true applies on the main context, so the edit lands on the already-registered
-        // instance at once. A background-context sync (immediate: false) would leave this instance
+        // runOnMain: true applies on the main context, so the edit lands on the already-registered
+        // instance at once. A background-context sync (runOnMain: false) would leave this instance
         // stale until SwiftData's cross-context merge catches up on an idle main runloop — the offline
         // edit-doesn't-update-the-list bug.
-        try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self, immediate: true)
+        try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self, runOnMain: true)
 
         XCTAssertEqual(row.title, "Edited")
     }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
@@ -363,10 +363,10 @@ final class SyncQueryPublisherTests: XCTestCase {
         XCTFail("Timed out waiting for condition: \(description)")
     }
 
-    // MARK: - runOnMain (local) writes land in place
+    // MARK: - context: .main (local) writes land in place
 
     @MainActor
-    func testRunOnMainSyncUpdatesRegisteredRowInPlace() async throws {
+    func testMainContextSyncUpdatesRegisteredRowInPlace() async throws {
         let container = try makeContainer(modelTypes: PubTask.self)
         container.mainContext.insert(PubTask(id: "t1", title: "Original"))
         try container.mainContext.save()
@@ -375,10 +375,10 @@ final class SyncQueryPublisherTests: XCTestCase {
         let row = try XCTUnwrap(
             container.mainContext.fetch(FetchDescriptor<PubTask>()).first { $0.id == "t1" })
 
-        // runOnMain: true applies on the main context, so the edit lands on the already-registered
-        // instance at once. A background-context sync (runOnMain: false) would leave this instance
-        // stale until SwiftData's cross-context merge catches up on an idle main runloop.
-        try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self, runOnMain: true)
+        // context: .main applies on the main context, so the edit lands on the already-registered
+        // instance at once. context: .background would leave this instance stale until SwiftData's
+        // cross-context merge catches up on an idle main runloop.
+        try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self, context: .main)
 
         XCTAssertEqual(row.title, "Edited")
     }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
@@ -1445,7 +1445,8 @@ final class SyncTests: XCTestCase {
         let container = try SyncContainer(for: User.self, configurations: .init(isStoredInMemoryOnly: true))
         try await container.sync(payload: [SendableUserPayload(id: 9, fullName: "Initial")], as: User.self)
 
-        try await container.sync(item: SendableUserPayload(id: 9, fullName: "Updated"), as: User.self, runOnMain: false)
+        try await container.sync(
+            item: SendableUserPayload(id: 9, fullName: "Updated"), as: User.self, context: .background)
 
         let users = try container.mainContext.fetch(FetchDescriptor<User>())
         XCTAssertEqual(users.count, 1)

--- a/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
@@ -1445,7 +1445,7 @@ final class SyncTests: XCTestCase {
         let container = try SyncContainer(for: User.self, configurations: .init(isStoredInMemoryOnly: true))
         try await container.sync(payload: [SendableUserPayload(id: 9, fullName: "Initial")], as: User.self)
 
-        try await container.sync(item: SendableUserPayload(id: 9, fullName: "Updated"), as: User.self)
+        try await container.sync(item: SendableUserPayload(id: 9, fullName: "Updated"), as: User.self, runOnMain: false)
 
         let users = try container.mainContext.fetch(FetchDescriptor<User>())
         XCTAssertEqual(users.count, 1)

--- a/docs/project/upload-endpoint-contract.md
+++ b/docs/project/upload-endpoint-contract.md
@@ -17,38 +17,31 @@ POST /sync/upload
 
 A single batched request carrying all pending local changes. Returns a per-operation result list.
 
-## Identity: two ids
+## Identity: one client-owned id
 
-Every syncable row has two ids:
+Every syncable row has a single id, **client-generated and stable forever**. SwiftSync mints it (a
+UUID) the moment the row is created offline, and it is the row's identity on both sides: the key the
+server upserts on, the key inbound sync matches on, and the idempotency key.
 
-- **`localId`** — client-generated, stable forever, **never changes**. SwiftSync mints it (a UUID) the
-  moment the row is created offline. It is the row's identity on both sides — the key inbound sync
-  matches on — and the **idempotency key** for inserts (see below).
-- **`remoteId`** — a second id the server **mints** for the row on insert. **Opaque to SwiftSync** — a
-  UUID, an integer, a slug, anything; SwiftSync carries it as a string at the boundary (an integer-PK
-  backend just stringifies). `nil` on the client until an insert is acknowledged. The client uses it
-  to **address** the row in subsequent `update`/`delete` operations.
+This is the price of admission for offline push (see the iOS conventions' "be opinionated"): the
+backend must accept client-supplied ids for synced resources rather than minting its own. In exchange
+there is **no second id and no client-side id rewrite** — the Core Data id-mutation hazard never
+arises, and `upsert`/`delete` address rows by the same id the client already holds.
 
-The server mints its own `remoteId` (so SwiftSync works with conventional backends, including legacy
-integer-PK ones, not just greenfield UUID schemas), but **`localId` remains the stable identity** the
-two sides agree on — the server echoes it back on pulls and SwiftSync matches by it. That is a
-deliberate choice: because `localId` never changes, **there is no client-side id rewrite** and inbound
-sync needs no special handling — sidestepping the Core Data id-mutation hazard. (The alternative —
-making `remoteId` the canonical identity and rewriting local references when it arrives — is viable but
-not what this contract describes.)
+(The alternative — the server minting a distinct `remoteId` so SwiftSync can reach legacy integer-PK
+backends — is the two-id variant described in `production-sync-design.md`. The demo deliberately takes
+the simpler single-id path; SwiftSync's push core supports both because `syncRemoteID` is just "the id
+the server acknowledged," which here equals the client id.)
 
 ## Request
 
 ```json
 {
   "operations": [
-    { "operation": "insert", "type": "tasks", "localId": "0c1f…",
-      "updatedAt": "2026-06-16T20:00:00Z", "data": { "title": "Draft", "state": {"id": "todo"} } },
+    { "operation": "upsert", "type": "tasks", "id": "0c1f…",
+      "updatedAt": "2026-06-16T20:00:00Z", "data": { "id": "0c1f…", "title": "Draft", "state": {"id": "todo"} } },
 
-    { "operation": "update", "type": "tasks", "remoteId": "8842",
-      "updatedAt": "2026-06-16T20:01:00Z", "data": { "title": "Renamed", "state": {"id": "todo"} } },
-
-    { "operation": "delete", "type": "tasks", "remoteId": "7710",
+    { "operation": "delete", "type": "tasks", "id": "7710",
       "updatedAt": "2026-06-16T20:02:00Z" }
   ]
 }
@@ -56,40 +49,46 @@ not what this contract describes.)
 
 Per operation:
 
-| field | insert | update | delete |
-|---|---|---|---|
-| `operation` | `"insert"` | `"update"` | `"delete"` |
-| `type` | resource name (consumer-chosen) | same | same |
-| `localId` | **required** | — | — |
-| `remoteId` | — | **required** | **required** |
-| `updatedAt` | required (ISO 8601) | required | required |
-| `data` | full resource | **full resource** (not a diff) | — |
+| field | upsert | delete |
+|---|---|---|
+| `operation` | `"upsert"` | `"delete"` |
+| `type` | resource name (consumer-chosen) | same |
+| `id` | **required** | **required** |
+| `updatedAt` | required (ISO 8601) | required |
+| `data` | full resource (includes `id`) | — |
 
+- **One operation for create and edit.** SwiftSync still classifies a local row as a fresh insert
+  (never acknowledged) or an edit (acknowledged, since changed) for *its own* bookkeeping, but both go
+  on the wire as `upsert`: the server does find-by-`id` → update-else-create. A consumer never has to
+  distinguish "does the server already have this?" — that's exactly what the id is for.
 - **`data` is the full resource, not a delta.** SwiftSync has no field-level dirty tracking
-  (`export(row)` emits the whole object), so an update sends every field. The server applies them
+  (`export(row)` emits the whole object), so an upsert sends every field. The server applies them
   under SwiftSync's payload semantics: a present field is set, an explicit `null` clears it.
 - Operations are applied **in array order**.
 
 ## Semantics
 
-### Idempotency — the server stores `localId`
+### Idempotency — keyed on the client `id`
 
-Insert hazard: the client posts an insert, the server creates the row and mints `remoteId`, but the
-**response is lost** (network drop). The client still has no `remoteId`, so it retries the same
-insert. The server **must not** create a second row.
+The client may resend an operation it never got a response for (network drop). The server **must not**
+create a duplicate. Because `upsert` is keyed on `id`:
 
-The server persists `localId` (a column, unique per `type` + tenant) alongside `remoteId`. On insert
-it keys on `(type, localId)`: if a row with that `localId` already exists, it returns the **existing**
-`remoteId` (`status: "applied"`) instead of creating again. Inserts are therefore safe to retry
-indefinitely.
+- A resent create whose row already exists takes the update branch; an identical `updatedAt` loses the
+  LWW tie (below) and returns `stale` — a converged no-op, not a duplicate and not a failure.
+- A resent delete on an already-tombstoned (or absent) row returns `applied` — idempotent.
+
+Upserts and deletes are therefore safe to retry indefinitely.
 
 ### Conflict — server-authoritative last-writer-wins
 
-For update/delete, the server compares the incoming `updatedAt` with the stored `updatedAt`:
+The server compares the incoming `updatedAt` with the stored `updatedAt`:
 
 - incoming **newer** ⇒ apply.
 - incoming **older or equal** ⇒ the server keeps its version and returns it (`status: "stale"`, with
   the current server row in `server`). SwiftSync adopts the server state locally.
+
+This applies to both `upsert` (when the row already exists) and `delete` — an older delete must not
+erase a newer server edit.
 
 ### Delete is a soft-delete tombstone
 
@@ -114,8 +113,7 @@ guidance, out of scope for the demo and irrelevant to the client.
 
 - **`operation` is required.** Missing or unknown ⇒ the operation is **rejected** — the server never
   guesses and never falls back to delete (fail-closed).
-- **Only `"delete"` deletes.** A forgotten `data` on an insert/update is a rejected insert or a no-op
-  update — never a delete.
+- **Only `"delete"` deletes.** A forgotten `data` on an upsert is a rejected upsert — never a delete.
 
 This mirrors the payload semantics symmetrically: an *absent field* never clears a value (you must
 send explicit `null`); an *absent operation* never destroys a row (you must send explicit
@@ -130,12 +128,12 @@ A per-operation result list (partial success — one bad row never blocks the ba
 ```json
 {
   "results": [
-    { "operation": "insert", "localId": "0c1f…", "remoteId": "8843", "status": "applied" },
-    { "operation": "update", "remoteId": "8842", "status": "stale",
-      "server": { "remoteId": "8842", "title": "Edited elsewhere",
+    { "operation": "upsert", "id": "0c1f…", "status": "applied" },
+    { "operation": "upsert", "id": "8842", "status": "stale",
+      "server": { "id": "8842", "title": "Edited elsewhere",
                   "updatedAt": "2026-06-16T20:05:00Z" } },
-    { "operation": "delete", "remoteId": "7710", "status": "applied" },
-    { "operation": "update", "remoteId": "9001", "status": "rejected",
+    { "operation": "delete", "id": "7710", "status": "applied" },
+    { "operation": "upsert", "id": "9001", "status": "rejected",
       "code": "validation", "message": "title must not be empty" }
   ],
   "cursor": "2026-06-16T20:02:00Z"
@@ -144,11 +142,11 @@ A per-operation result list (partial success — one bad row never blocks the ba
 
 | `status` | meaning | SwiftSync reaction |
 |---|---|---|
-| `applied` | written (LWW won, or idempotent re-ack) | confirm; stamp `remoteId` onto the inserted row |
+| `applied` | written (LWW won, or idempotent re-ack) | confirm; mark the row synced under its `id` |
 | `stale` | the client write lost LWW; `server` carries current truth | adopt the server state locally |
 | `rejected` | permanent/validation failure | surface `message` (+ `code`) in the failures inbox (discard / edit / retry) |
 
-- Insert results echo `localId` so SwiftSync can map the assigned `remoteId` back onto the right row.
+- Each result echoes the operation's `id` so SwiftSync can map it back onto the right row.
 - `rejected` carries a human-readable `message` and an optional machine `code`.
 - `cursor` is an **opaque** string (a timestamp or token — the server decides). The client feeds it to
   the pull side; SwiftSync treats it as opaque.
@@ -164,8 +162,8 @@ inbound direction is SwiftSync's existing `sync` (server → SwiftData). Push an
 It is one custom controller action:
 
 1. Parse `operations`, group by `type`.
-2. Per operation: resolve the row (insert → by `(type, localId)`; update/delete → by `remoteId`),
-   apply LWW, upsert / tombstone via the ORM's bulk primitive.
+2. Per operation: resolve the row by `(type, id)`, apply LWW, upsert / tombstone via the ORM's bulk
+   primitive.
 3. Return the per-operation `results` + a `cursor`.
 
 Existing per-resource endpoints are untouched — this sits beside them. A real backend scopes every

--- a/docs/project/upload-endpoint-contract.md
+++ b/docs/project/upload-endpoint-contract.md
@@ -95,6 +95,12 @@ The server compares the incoming `updatedAt` with the stored `updatedAt`:
 This applies to both `upsert` (when the row already exists) and `delete` — an older delete must not
 erase a newer server edit.
 
+A delete records its timestamp on the row, so a later `upsert` resolves against **the delete**: an
+upsert newer than the delete **revives** the tombstoned row (clears the tombstone, applies the edit,
+`status: "applied"`); one older or equal stays `stale` and the row remains deleted. A tombstoned row
+must never be silently updated-in-place while staying hidden — that would acknowledge an edit the
+server didn't actually surface.
+
 ### Delete is a soft-delete tombstone
 
 A delete marks the row deleted (server-side) so other clients still learn of the deletion on their

--- a/docs/project/upload-endpoint-contract.md
+++ b/docs/project/upload-endpoint-contract.md
@@ -17,31 +17,33 @@ POST /sync/upload
 
 A single batched request carrying all pending local changes. Returns a per-operation result list.
 
-## Identity: one client-owned id
+## Identity: two ids, addressed by `localId`
 
-Every syncable row has a single id, **client-generated and stable forever**. SwiftSync mints it (a
-UUID) the moment the row is created offline, and it is the row's identity on both sides: the key the
-server upserts on, the key inbound sync matches on, and the idempotency key.
+Every syncable row has two ids:
 
-This is the price of admission for offline push (see the iOS conventions' "be opinionated"): the
-backend must accept client-supplied ids for synced resources rather than minting its own. In exchange
-there is **no second id and no client-side id rewrite** — the Core Data id-mutation hazard never
-arises, and `upsert`/`delete` address rows by the same id the client already holds.
+- **`localId`** — client-generated, stable forever, **never changes**. SwiftSync mints it (a UUID) the
+  moment the row is created offline. It is the key every operation is addressed by, the key inbound
+  sync matches on, and the **idempotency key**.
+- **`remoteId`** — a second id the server **mints** for the row on first create and **returns**.
+  **Opaque to SwiftSync** — a UUID, an integer, a slug; carried as a string at the boundary (an
+  integer-PK backend just stringifies). `nil` on the client until the first upsert is acknowledged.
 
-(The alternative — the server minting a distinct `remoteId` so SwiftSync can reach legacy integer-PK
-backends — is the two-id variant described in `production-sync-design.md`. The demo deliberately takes
-the simpler single-id path; SwiftSync's push core supports both because `syncRemoteID` is just "the id
-the server acknowledged," which here equals the client id.)
+The server minting its own `remoteId` is what lets SwiftSync work with conventional backends —
+including legacy integer-PK ones — not just greenfield UUID schemas. But **`localId` is the stable
+identity the two sides agree on and the key every operation addresses**: because `localId` never
+changes, there is **no client-side id rewrite** (sidestepping the Core Data id-mutation hazard), and a
+row that has never been acknowledged (no `remoteId` yet) still upserts and deletes cleanly — there is
+nothing that must be addressed by `remoteId`.
 
 ## Request
 
 ```json
 {
   "operations": [
-    { "operation": "upsert", "type": "tasks", "id": "0c1f…",
+    { "operation": "upsert", "type": "tasks", "localId": "0c1f…",
       "updatedAt": "2026-06-16T20:00:00Z", "data": { "id": "0c1f…", "title": "Draft", "state": {"id": "todo"} } },
 
-    { "operation": "delete", "type": "tasks", "id": "7710",
+    { "operation": "delete", "type": "tasks", "localId": "7710",
       "updatedAt": "2026-06-16T20:02:00Z" }
   ]
 }
@@ -53,14 +55,16 @@ Per operation:
 |---|---|---|
 | `operation` | `"upsert"` | `"delete"` |
 | `type` | resource name (consumer-chosen) | same |
-| `id` | **required** | **required** |
+| `localId` | **required** | **required** |
 | `updatedAt` | required (ISO 8601) | required |
-| `data` | full resource (includes `id`) | — |
+| `data` | full resource | — |
 
 - **One operation for create and edit.** SwiftSync still classifies a local row as a fresh insert
   (never acknowledged) or an edit (acknowledged, since changed) for *its own* bookkeeping, but both go
-  on the wire as `upsert`: the server does find-by-`id` → update-else-create. A consumer never has to
-  distinguish "does the server already have this?" — that's exactly what the id is for.
+  on the wire as `upsert`: the server does find-by-`localId` → update-else-create, minting a `remoteId`
+  on the create branch. A consumer never has to distinguish "does the server already have this?" — and
+  a never-acknowledged row needs no `remoteId` to be edited, which is exactly why edit-after-failed-
+  insert can't 404.
 - **`data` is the full resource, not a delta.** SwiftSync has no field-level dirty tracking
   (`export(row)` emits the whole object), so an upsert sends every field. The server applies them
   under SwiftSync's payload semantics: a present field is set, an explicit `null` clears it.
@@ -68,14 +72,15 @@ Per operation:
 
 ## Semantics
 
-### Idempotency — keyed on the client `id`
+### Idempotency — keyed on `localId`
 
 The client may resend an operation it never got a response for (network drop). The server **must not**
-create a duplicate. Because `upsert` is keyed on `id`:
+create a duplicate. Because every operation is keyed on the stable `localId`:
 
-- A resent create whose row already exists takes the update branch; an identical `updatedAt` loses the
-  LWW tie (below) and returns `stale` — a converged no-op, not a duplicate and not a failure.
-- A resent delete on an already-tombstoned (or absent) row returns `applied` — idempotent.
+- A resent create whose row already exists takes the update branch and returns the **same** `remoteId`;
+  an identical `updatedAt` loses the LWW tie (below) and returns `stale` — a converged no-op, not a
+  duplicate and not a failure.
+- A resent delete on an already-tombstoned (or never-created) row returns `applied` — idempotent.
 
 Upserts and deletes are therefore safe to retry indefinitely.
 
@@ -128,12 +133,12 @@ A per-operation result list (partial success — one bad row never blocks the ba
 ```json
 {
   "results": [
-    { "operation": "upsert", "id": "0c1f…", "status": "applied" },
-    { "operation": "upsert", "id": "8842", "status": "stale",
-      "server": { "id": "8842", "title": "Edited elsewhere",
+    { "operation": "upsert", "localId": "0c1f…", "remoteId": "srv-8843", "status": "applied" },
+    { "operation": "upsert", "localId": "8842", "remoteId": "srv-8842", "status": "stale",
+      "server": { "remote_id": "srv-8842", "title": "Edited elsewhere",
                   "updatedAt": "2026-06-16T20:05:00Z" } },
-    { "operation": "delete", "id": "7710", "status": "applied" },
-    { "operation": "upsert", "id": "9001", "status": "rejected",
+    { "operation": "delete", "localId": "7710", "status": "applied" },
+    { "operation": "upsert", "localId": "9001", "status": "rejected",
       "code": "validation", "message": "title must not be empty" }
   ],
   "cursor": "2026-06-16T20:02:00Z"
@@ -142,11 +147,12 @@ A per-operation result list (partial success — one bad row never blocks the ba
 
 | `status` | meaning | SwiftSync reaction |
 |---|---|---|
-| `applied` | written (LWW won, or idempotent re-ack) | confirm; mark the row synced under its `id` |
+| `applied` | written (LWW won, or idempotent re-ack) | confirm; stamp the returned `remoteId` onto the row |
 | `stale` | the client write lost LWW; `server` carries current truth | adopt the server state locally |
 | `rejected` | permanent/validation failure | surface `message` (+ `code`) in the failures inbox (discard / edit / retry) |
 
-- Each result echoes the operation's `id` so SwiftSync can map it back onto the right row.
+- Each result echoes the operation's `localId` so SwiftSync can map it back onto the right row; an
+  `upsert` also carries the server-minted `remoteId` (the same one on every subsequent upsert).
 - `rejected` carries a human-readable `message` and an optional machine `code`.
 - `cursor` is an **opaque** string (a timestamp or token — the server decides). The client feeds it to
   the pull side; SwiftSync treats it as opaque.
@@ -162,8 +168,8 @@ inbound direction is SwiftSync's existing `sync` (server → SwiftData). Push an
 It is one custom controller action:
 
 1. Parse `operations`, group by `type`.
-2. Per operation: resolve the row by `(type, id)`, apply LWW, upsert / tombstone via the ORM's bulk
-   primitive.
+2. Per operation: resolve the row by `(type, localId)`, apply LWW, upsert (minting/returning a
+   `remoteId` on create) / tombstone via the ORM's bulk primitive.
 3. Return the per-operation `results` + a `cursor`.
 
 Existing per-resource endpoints are untouched — this sits beside them. A real backend scopes every


### PR DESCRIPTION
Demo-driven requirement, built red-first across two slices.

**The need:** when a queued offline change is permanently rejected by the server (not a transient blip), the user must see it and act — discard, or edit-and-retry. Before, a rejection just flashed and was lost.

## Slice 1 — persistent failures (the SwiftSync capability this drives)
Failures must outlive a single push pass. Added `syncFailureReason` to `SyncOfflineModel`; `push` stamps it onto rejected rows and clears it on success — so a failures inbox is just a query for set reasons. Backend gained a title-length rule (>80 chars) so an offline edit can fail permanently and deterministically.

## Slice 2 — the inbox UI
When any row has a failure, the offline bar shows a red **"N failed"** button → a sheet of rejected tasks (title + reason), each with:
- **Edit** — opens the task form; fixing it re-syncs and clears the failure.
- **Discard** — `discardFailedChange`: drops a never-synced row, or restores the server's version of an edited row and clears the failure.

(No **Retry** — these are permanent rejections; retry-as-is just re-fails, and auto-sync already re-attempts transients. Edit/discard are the real resolutions.)

## Red-first
- Unit: `testRejectedPushPersistsFailureReasonOnTheRow` (red: not persisted → green).
- Unit: `testDiscardFailedChangeRestoresServerStateAndClearsFailure`.
- UI: `testRejectedOfflineEditAppearsInFailuresInboxAndDiscards` (red: no inbox → green).

## Verified
DemoUITests **14** · DemoCore **27** · DemoBackend **26** · SwiftSync push **5**. Inbox UI checked visually (screenshot).

---

## Follow-up: edit-after-failed-insert bug + two-id upsert + review fixes

**Bug (found in review):** offline-create a task with an invalid (too-long) title → insert rejected → it shows in the inbox → Edit → fix the title → Save → **"task not found"**. The online write-through PUT `/tasks/:id` 404'd because the row had never reached the server.

**Root cause was the push addressing model.** Inserts were keyed on `localId`; updates/deletes addressed the row by a server-minted `remoteId`. A never-acknowledged row has no `remoteId`, so an edit had nothing to PUT against.

**Fix — unified `upsert` keyed on `localId`, keeping the two-id model.** `/sync/upload` is now `upsert` (find-by-`localId` → update-else-create) + `delete`, both addressed by the stable `localId`. The server still mints and returns a distinct `remoteId` on first create (so SwiftSync keeps demonstrating backends that own their PKs), but nothing needs to be addressed *by* `remoteId` — which is exactly why edit-after-failed-insert can't 404. `updateTask` routes never-synced rows through the push path so they re-upsert instead of PUT. `docs/project/upload-endpoint-contract.md` updated.

**Two more review findings, fixed red-first:**
- **P1** — a previously-synced row whose offline edit was rejected stayed flagged after an online Edit→fix→save (the write-through path never cleared `syncFailureReason`). Now cleared on a successful online save. Test: `testEditingAFailedSyncedRowOnlineClearsFailure`.
- **P2** — `SwiftSync.push` cleared `syncFailureReason` for any row absent from the failure list, including *unacknowledged* rows the response never confirmed — conflicting with the cursor logic that treats them as still pending. Now cleared only on actual success (remote id assigned / confirmed update / confirmed delete). Test: `testPushKeepsFailureReasonForUnacknowledgedRows`.

**Re-verified green:** DemoBackend **26** · DemoCore **29** · SwiftSync **165** · offline DemoUITests **4/4** · all 10 PR checks.

