### PR TITLE
Inbound pull stops destroying rows with un-pushed local changes

### DIFF
--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -351,6 +351,13 @@ public final class DemoSyncEngine {
     }
 
     private func syncProjectTasksData(projectID: String) async throws {
+        // Push before pull (the cache → push → pull order): drain pending local changes first so the
+        // server's authoritative task set already reflects them. A successful push makes the row
+        // present in the pull below; a never-synced row (e.g. a rejected insert) stays absent but is
+        // protected by the pull's "never delete a row the server has never seen" invariant. Best-effort
+        // — a failed drain must not block the refresh.
+        _ = try? await pushPendingChanges()
+
         let payload = try await apiClient.getProjectTasks(projectID: projectID)
         let userRowsBeforeSync = try localUserCount()
 
@@ -368,8 +375,7 @@ public final class DemoSyncEngine {
             payload: payload,
             as: Task.self,
             parent: project,
-            relationship: \Task.project,
-            pendingChangesSince: syncCursor
+            relationship: \Task.project
         )
         markPulled()
         try await syncProjectsData()

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -351,11 +351,8 @@ public final class DemoSyncEngine {
     }
 
     private func syncProjectTasksData(projectID: String) async throws {
-        // Push before pull (the cache → push → pull order): drain pending local changes first so the
-        // server's authoritative task set already reflects them. A successful push makes the row
-        // present in the pull below; a never-synced row (e.g. a rejected insert) stays absent but is
-        // protected by the pull's "never delete a row the server has never seen" invariant. Best-effort
-        // — a failed drain must not block the refresh.
+        // Push before pull: a pending change must reach the server before the pull's prune judges it,
+        // else it looks like a server-side deletion. Best-effort — a failed drain must not block the refresh.
         _ = try? await pushPendingChanges()
 
         let payload = try await apiClient.getProjectTasks(projectID: projectID)

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -353,14 +353,7 @@ public final class DemoSyncEngine {
     private func syncProjectTasksData(projectID: String) async throws {
         // Push before pull: a pending change must reach the server before the pull's prune judges it,
         // else it looks like a server-side deletion. Best-effort — a failed drain must not block the refresh.
-        let drain = try? await pushPendingChanges()
-
-        // If the drain left a rejected change for a task in this project, defer the pull: the server
-        // still holds the pre-edit version, and applying it would clobber the un-pushed local edit (and
-        // strand its failure marker). The failures inbox resolves it; a later pull proceeds once clean.
-        if let drain, try drain.failures.contains(where: { try task(withID: $0.localID)?.projectID == projectID }) {
-            return
-        }
+        _ = try? await pushPendingChanges()
 
         let payload = try await apiClient.getProjectTasks(projectID: projectID)
         let userRowsBeforeSync = try localUserCount()

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -353,7 +353,14 @@ public final class DemoSyncEngine {
     private func syncProjectTasksData(projectID: String) async throws {
         // Push before pull: a pending change must reach the server before the pull's prune judges it,
         // else it looks like a server-side deletion. Best-effort — a failed drain must not block the refresh.
-        _ = try? await pushPendingChanges()
+        let drain = try? await pushPendingChanges()
+
+        // If the drain left a rejected change for a task in this project, defer the pull: the server
+        // still holds the pre-edit version, and applying it would clobber the un-pushed local edit (and
+        // strand its failure marker). The failures inbox resolves it; a later pull proceeds once clean.
+        if let drain, try drain.failures.contains(where: { try task(withID: $0.localID)?.projectID == projectID }) {
+            return
+        }
 
         let payload = try await apiClient.getProjectTasks(projectID: projectID)
         let userRowsBeforeSync = try localUserCount()

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -368,7 +368,8 @@ public final class DemoSyncEngine {
             payload: payload,
             as: Task.self,
             parent: project,
-            relationship: \Task.project
+            relationship: \Task.project,
+            pendingChangesSince: syncCursor
         )
         markPulled()
         try await syncProjectsData()

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -381,8 +381,7 @@ final class OfflinePushTests: XCTestCase {
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
         try await engine.syncProjectTasks(projectID: projectID)
 
-        // Offline-create a task the server will reject (too-long title), then push: it stays a
-        // never-synced local row (no remote id) flagged as failed.
+        // Offline-create a task the server will reject (too-long title); it stays a never-synced row.
         var body = try createBody(
             from: DemoSeedData.SeedIDs.Tasks.sessionTimeout, newID: "OFFLINE-REJECT-1", in: syncContainer)
         body = try mutating(body) { $0["title"] = String(repeating: "A", count: 100) }
@@ -395,8 +394,7 @@ final class OfflinePushTests: XCTestCase {
         let failed = try XCTUnwrap(fetchTask(id: "OFFLINE-REJECT-1", in: syncContainer.mainContext))
         XCTAssertNil(failed.syncRemoteID, "the rejected create never got a server id")
 
-        // Re-pull the project's authoritative task set (what happens on relaunch / reopening the
-        // project). The server's list omits the never-accepted row — it must NOT be pruned.
+        // Re-pull the project's task set (as on relaunch); the server omits the never-accepted row.
         try await engine.syncProjectTasks(projectID: projectID)
 
         let survivor = try fetchTask(id: "OFFLINE-REJECT-1", in: syncContainer.mainContext)
@@ -416,7 +414,6 @@ final class OfflinePushTests: XCTestCase {
         let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
         try await engine.syncProjectTasks(projectID: projectID)
 
-        // Offline: edit the task's title — a pending update, not yet pushed.
         engine.isOffline = true
         let task = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
         let body = try mutating(try DemoSyncPayload(dictionary: syncContainer.export(task))) {
@@ -428,10 +425,8 @@ final class OfflinePushTests: XCTestCase {
         engine.isOffline = false
         try await apiClient.deleteTask(taskID: taskID)
 
-        // Reconnect and refresh. syncProjectTasks pushes before it pulls: the pending edit is uploaded
-        // as an upsert keyed by localId, which re-creates the server-deleted row, so the subsequent
-        // pull sees it as present rather than absent. The edit wins by resurrection — no prune guard,
-        // no cursor needed.
+        // syncProjectTasks pushes before it pulls, so the pending edit is upserted (re-creating the
+        // server-deleted row) and the pull then sees it present, not absent.
         try await engine.syncProjectTasks(projectID: projectID)
 
         let survivor = try XCTUnwrap(

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -372,6 +372,48 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testRejectedOfflineCreatedTaskSurvivesProjectPull() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // Offline-create a task the server will reject (too-long title), then push: it stays a
+        // never-synced local row (no remote id) flagged as failed.
+        var body = try createBody(
+            from: DemoSeedData.SeedIDs.Tasks.sessionTimeout, newID: "OFFLINE-REJECT-1", in: syncContainer)
+        body = try mutating(body) { $0["title"] = String(repeating: "A", count: 100) }
+        engine.isOffline = true
+        try await engine.createTask(body: body, projectID: projectID)
+        engine.isOffline = false
+        let pushResult = try await engine.pushPendingChanges()
+        let summary = try XCTUnwrap(pushResult)
+        XCTAssertEqual(summary.failures.count, 1)
+        let failed = try XCTUnwrap(fetchTask(id: "OFFLINE-REJECT-1", in: syncContainer.mainContext))
+        XCTAssertNil(failed.syncRemoteID, "the rejected create never got a server id")
+
+        // Re-pull the project's authoritative task set (what happens on relaunch / reopening the
+        // project). The server's list omits the never-accepted row — it must NOT be pruned.
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        let survivor = try fetchTask(id: "OFFLINE-REJECT-1", in: syncContainer.mainContext)
+        XCTAssertNotNil(
+            survivor,
+            "a rejected offline-created task must survive an inbound project pull, not silently vanish")
+    }
+
+    private func mutating(_ body: DemoSyncPayload, _ transform: (inout [String: Any]) -> Void) throws
+        -> DemoSyncPayload
+    {
+        var dictionary = body.toSyncPayloadDictionary()
+        transform(&dictionary)
+        return try DemoSyncPayload(dictionary: dictionary)
+    }
+
+    @MainActor
     private func createBody(from templateID: String, newID: String, in syncContainer: SyncContainer) throws
         -> DemoSyncPayload
     {

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -465,6 +465,45 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertNotNil(row.syncFailureReason, "it stays flagged for the user to resolve")
     }
 
+    @MainActor
+    func testNewerServerVersionOverwritesPollutedLocalEdit() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // Pollute: offline edit to an invalid (too-long) title the server rejects on push.
+        engine.isOffline = true
+        let task = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        let invalidBody = try mutating(try DemoSyncPayload(dictionary: syncContainer.export(task))) {
+            $0["title"] = String(repeating: "A", count: 100)
+        }
+        try await engine.updateTask(taskID: taskID, projectID: projectID, body: invalidBody)
+        engine.isOffline = false
+        _ = try await engine.pushPendingChanges()
+        XCTAssertNotNil(
+            try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext)).syncFailureReason,
+            "the row is polluted (a failed local edit)")
+
+        // Another client updates that task server-side to a newer, valid version.
+        let serverTitle = "server's newer title"
+        let currentDetail = try await apiClient.getTaskDetail(taskID: taskID)
+        let current = try XCTUnwrap(currentDetail)
+        let serverBody = try mutating(current) { $0["title"] = serverTitle }
+        _ = try await apiClient.updateTask(taskID: taskID, body: serverBody)
+
+        // Refresh: the newer server version must win and overwrite the polluted local edit (LWW).
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        let row = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertEqual(
+            row.title, serverTitle, "a newer server version overwrites even a polluted local edit")
+    }
+
     private func mutating(_ body: DemoSyncPayload, _ transform: (inout [String: Any]) -> Void) throws
         -> DemoSyncPayload
     {

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -435,6 +435,36 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertEqual(survivor.title, "edited offline", "the local edit is preserved")
     }
 
+    @MainActor
+    func testFailedOfflineEditIsNotClobberedByProjectRefresh() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // Offline: edit a synced task to an invalid (too-long) title the server will reject on push.
+        engine.isOffline = true
+        let task = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        let invalidTitle = String(repeating: "A", count: 100)
+        let body = try mutating(try DemoSyncPayload(dictionary: syncContainer.export(task))) {
+            $0["title"] = invalidTitle
+        }
+        try await engine.updateTask(taskID: taskID, projectID: projectID, body: body)
+        engine.isOffline = false
+
+        // Refresh: the drain rejects the edit, so the server still holds the pre-edit title. The pull
+        // must not overwrite the un-pushed local edit with that stale server version.
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        let row = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertEqual(row.title, invalidTitle, "the failed local edit must not be clobbered by the pull")
+        XCTAssertNotNil(row.syncFailureReason, "it stays flagged for the user to resolve")
+    }
+
     private func mutating(_ body: DemoSyncPayload, _ transform: (inout [String: Any]) -> Void) throws
         -> DemoSyncPayload
     {

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -405,6 +405,40 @@ final class OfflinePushTests: XCTestCase {
             "a rejected offline-created task must survive an inbound project pull, not silently vanish")
     }
 
+    @MainActor
+    func testOfflineEditSurvivesServerSideDeleteOnReconnect() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // Offline: edit the task's title — a pending update, not yet pushed.
+        engine.isOffline = true
+        let task = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        let body = try mutating(try DemoSyncPayload(dictionary: syncContainer.export(task))) {
+            $0["title"] = "edited offline"
+        }
+        try await engine.updateTask(taskID: taskID, projectID: projectID, body: body)
+
+        // Meanwhile the server hard-deletes that task (another client / admin removed it).
+        engine.isOffline = false
+        try await apiClient.deleteTask(taskID: taskID)
+
+        // Reconnect pull: the server's task set no longer includes it. The un-pushed local edit was
+        // made after the last sync, so the prune must preserve it — the user keeps their work instead
+        // of silently losing it to a server-side delete. This is exactly what `pendingChangesSince` buys.
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        let survivor = try XCTUnwrap(
+            fetchTask(id: taskID, in: syncContainer.mainContext),
+            "an offline edit must survive a server-side delete on reconnect, not vanish")
+        XCTAssertEqual(survivor.title, "edited offline", "the local edit is preserved")
+    }
+
     private func mutating(_ body: DemoSyncPayload, _ transform: (inout [String: Any]) -> Void) throws
         -> DemoSyncPayload
     {

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -456,8 +456,7 @@ final class OfflinePushTests: XCTestCase {
         try await engine.updateTask(taskID: taskID, projectID: projectID, body: body)
         engine.isOffline = false
 
-        // Refresh: the drain rejects the edit, so the server still holds the pre-edit title. The pull
-        // must not overwrite the un-pushed local edit with that stale server version.
+        // The push rejects the edit, so the server still holds the pre-edit title.
         try await engine.syncProjectTasks(projectID: projectID)
 
         let row = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
@@ -496,7 +495,6 @@ final class OfflinePushTests: XCTestCase {
         let serverBody = try mutating(current) { $0["title"] = serverTitle }
         _ = try await apiClient.updateTask(taskID: taskID, body: serverBody)
 
-        // Refresh: the newer server version must win and overwrite the polluted local edit (LWW).
         try await engine.syncProjectTasks(projectID: projectID)
 
         let row = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
@@ -527,14 +525,11 @@ final class OfflinePushTests: XCTestCase {
         engine.isOffline = false
         _ = try await engine.pushPendingChanges()
 
-        // A *different* task in the same project is updated server-side.
         let siblingTitle = "server-updated sibling"
         let siblingDetail = try await apiClient.getTaskDetail(taskID: siblingID)
         let siblingBody = try mutating(try XCTUnwrap(siblingDetail)) { $0["title"] = siblingTitle }
         _ = try await apiClient.updateTask(taskID: siblingID, body: siblingBody)
 
-        // Refresh: the polluted row's local edit is preserved (LWW), and the sibling still picks up the
-        // server update — one conflicted row must not block the whole project's refresh.
         try await engine.syncProjectTasks(projectID: projectID)
 
         let pollutedRow = try XCTUnwrap(fetchTask(id: pollutedID, in: syncContainer.mainContext))

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -504,6 +504,45 @@ final class OfflinePushTests: XCTestCase {
             row.title, serverTitle, "a newer server version overwrites even a polluted local edit")
     }
 
+    @MainActor
+    func testPollutedRowDoesNotBlockSiblingRefresh() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let pollutedID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        let siblingID = DemoSeedData.SeedIDs.Tasks.securityPolicyPatch
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        // Pollute one task: an offline edit to an invalid title the server rejects on push.
+        engine.isOffline = true
+        let polluted = try XCTUnwrap(fetchTask(id: pollutedID, in: syncContainer.mainContext))
+        let invalidTitle = String(repeating: "A", count: 100)
+        let invalidBody = try mutating(try DemoSyncPayload(dictionary: syncContainer.export(polluted))) {
+            $0["title"] = invalidTitle
+        }
+        try await engine.updateTask(taskID: pollutedID, projectID: projectID, body: invalidBody)
+        engine.isOffline = false
+        _ = try await engine.pushPendingChanges()
+
+        // A *different* task in the same project is updated server-side.
+        let siblingTitle = "server-updated sibling"
+        let siblingDetail = try await apiClient.getTaskDetail(taskID: siblingID)
+        let siblingBody = try mutating(try XCTUnwrap(siblingDetail)) { $0["title"] = siblingTitle }
+        _ = try await apiClient.updateTask(taskID: siblingID, body: siblingBody)
+
+        // Refresh: the polluted row's local edit is preserved (LWW), and the sibling still picks up the
+        // server update — one conflicted row must not block the whole project's refresh.
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        let pollutedRow = try XCTUnwrap(fetchTask(id: pollutedID, in: syncContainer.mainContext))
+        let siblingRow = try XCTUnwrap(fetchTask(id: siblingID, in: syncContainer.mainContext))
+        XCTAssertEqual(pollutedRow.title, invalidTitle, "the conflicted row keeps its local edit")
+        XCTAssertEqual(siblingRow.title, siblingTitle, "a sibling row still refreshes — the pull isn't blocked")
+    }
+
     private func mutating(_ body: DemoSyncPayload, _ transform: (inout [String: Any]) -> Void) throws
         -> DemoSyncPayload
     {

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -428,9 +428,10 @@ final class OfflinePushTests: XCTestCase {
         engine.isOffline = false
         try await apiClient.deleteTask(taskID: taskID)
 
-        // Reconnect pull: the server's task set no longer includes it. The un-pushed local edit was
-        // made after the last sync, so the prune must preserve it — the user keeps their work instead
-        // of silently losing it to a server-side delete. This is exactly what `pendingChangesSince` buys.
+        // Reconnect and refresh. syncProjectTasks pushes before it pulls: the pending edit is uploaded
+        // as an upsert keyed by localId, which re-creates the server-deleted row, so the subsequent
+        // pull sees it as present rather than absent. The edit wins by resurrection — no prune guard,
+        // no cursor needed.
         try await engine.syncProjectTasks(projectID: projectID)
 
         let survivor = try XCTUnwrap(

--- a/SwiftSync/Sources/SwiftSync/API.swift
+++ b/SwiftSync/Sources/SwiftSync/API.swift
@@ -602,17 +602,18 @@ extension SwiftSync {
         return offline.syncRemoteID == nil
     }
 
-    /// Apply a server `payload` onto an existing `row`, honoring last-writer-wins for offline rows: if
-    /// the local row carries an edit newer than the server's version (`syncUpdatedAt` greater than the
-    /// incoming one), the un-pushed local edit wins and the older server fields are not applied — so an
-    /// inbound pull can't clobber a pending local edit. Mirrors the server-side upsert's
-    /// "older-or-equal loses". Returns whether `row` changed.
+    /// Apply a server `payload` onto `row`, but skip the overwrite when an offline row's local edit is
+    /// newer than the incoming version — so an inbound pull can't clobber a pending local edit.
+    /// Last-writer-wins, mirroring the server-side upsert's "older-or-equal loses". The incoming
+    /// timestamp is read straight from the payload under the conventional `updatedAt` key (the same one
+    /// `SyncOfflineModel.syncUpdatedAt` reflects) — no model is constructed; an unparseable/absent one
+    /// just falls through to a normal apply.
     private static func applyHonoringLocalEdit<Model: SyncUpdatableModel>(
         _ payload: SyncPayload, to row: Model
     ) throws -> Bool {
         if let local = row as? any SyncOfflineModel,
-            let incoming = (try? Model.make(from: payload)) as? any SyncOfflineModel,
-            local.syncUpdatedAt > incoming.syncUpdatedAt
+            let incoming = payload.value(for: "updatedAt", as: Date.self),
+            local.syncUpdatedAt > incoming
         {
             return false
         }

--- a/SwiftSync/Sources/SwiftSync/API.swift
+++ b/SwiftSync/Sources/SwiftSync/API.swift
@@ -105,7 +105,7 @@ extension SwiftSync {
                 try throwIfCancelled()
                 syncProfile("delete-missing") {
                     for (key, row) in index where !seenKeys.contains(key) {
-                        if inboundPruneShouldPreserve(row) { continue }
+                        if isUnsyncedLocalInsert(row) { continue }
                         context.delete(row)
                         changed = true
                     }
@@ -567,7 +567,7 @@ extension SwiftSync {
                         if seenKeys.contains(key) {
                             continue
                         }
-                        if inboundPruneShouldPreserve(row) {
+                        if isUnsyncedLocalInsert(row) {
                             continue
                         }
                         context.delete(row)
@@ -594,14 +594,9 @@ extension SwiftSync {
         }
     }
 
-    /// Whether a full-set pull's `delete-missing` pass must keep `row` even though the server's payload
-    /// omitted it. This is a correctness invariant of reconciliation, not offline policy: a
-    /// `SyncOfflineModel` row with no `syncRemoteID` was never created server-side, so it isn't part of
-    /// the server's namespace and its absence carries no "deleted" signal — pruning it would destroy a
-    /// never-uploaded local row. (Local *edits* to already-synced rows are kept safe by the consumer
-    /// pushing before pulling, so they're present in the pull and never judged here.) A local tombstone
-    /// is pruned: the server omitting it agrees with the intended deletion.
-    private static func inboundPruneShouldPreserve<Model: SyncUpdatableModel>(_ row: Model) -> Bool {
+    /// A live local row the server has never acknowledged (`syncRemoteID == nil`, not a tombstone).
+    /// `delete-missing` skips these: the server omitting a row it never created is not a deletion.
+    private static func isUnsyncedLocalInsert<Model: SyncUpdatableModel>(_ row: Model) -> Bool {
         guard let offline = row as? any SyncOfflineModel else { return false }
         if offline.syncIsDeleted { return false }
         return offline.syncRemoteID == nil

--- a/SwiftSync/Sources/SwiftSync/API.swift
+++ b/SwiftSync/Sources/SwiftSync/API.swift
@@ -105,6 +105,7 @@ extension SwiftSync {
                 try throwIfCancelled()
                 syncProfile("delete-missing") {
                     for (key, row) in index where !seenKeys.contains(key) {
+                        if inboundPruneShouldPreserve(row, pendingChangesSince: nil) { continue }
                         context.delete(row)
                         changed = true
                     }
@@ -336,6 +337,7 @@ extension SwiftSync {
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
         keyStyle: KeyStyle = .snakeCase,
         relationshipOperations: SyncRelationshipOperations = .all,
+        pendingChangesSince: Date? = nil,
         isolation: isolated (any Actor)? = #isolation
     ) async throws {
         try await sync(
@@ -346,7 +348,8 @@ extension SwiftSync {
             parentRelationship: relationship,
             isGlobal: syncIdentityHasUniqueAttribute(Model.self),
             keyStyle: keyStyle,
-            relationshipOperations: relationshipOperations
+            relationshipOperations: relationshipOperations,
+            pendingChangesSince: pendingChangesSince
         )
     }
 
@@ -359,6 +362,7 @@ extension SwiftSync {
         isGlobal: Bool,
         keyStyle: KeyStyle,
         relationshipOperations: SyncRelationshipOperations,
+        pendingChangesSince: Date?,
         isolation: isolated (any Actor)? = #isolation
     ) async throws {
         let lease = await acquireSyncLease(for: context)
@@ -566,6 +570,9 @@ extension SwiftSync {
                         if seenKeys.contains(key) {
                             continue
                         }
+                        if inboundPruneShouldPreserve(row, pendingChangesSince: pendingChangesSince) {
+                            continue
+                        }
                         context.delete(row)
                         changed = true
                     }
@@ -588,6 +595,23 @@ extension SwiftSync {
             await releaseSyncLease(lease)
             throw error
         }
+    }
+
+    /// Whether an inbound full-set pull's `delete-missing` pass must keep `row` even though the
+    /// server's payload omitted it — the inbound/outbound boundary. A `SyncOfflineModel` row the server
+    /// has never acknowledged (`syncRemoteID == nil`) was never created server-side, so its absence is
+    /// expected, not a deletion; and a row edited locally since the last sync (`syncUpdatedAt >
+    /// pendingChangesSince`) carries an un-pushed change an inbound prune would silently destroy. A
+    /// pending tombstone is *not* preserved: the server omitting it means the deletion already agrees,
+    /// so pruning is correct. Non-offline models are never preserved (no outbound queue to protect).
+    private static func inboundPruneShouldPreserve<Model: SyncUpdatableModel>(
+        _ row: Model, pendingChangesSince: Date?
+    ) -> Bool {
+        guard let offline = row as? any SyncOfflineModel else { return false }
+        if offline.syncIsDeleted { return false }
+        if offline.syncRemoteID == nil { return true }
+        if let pendingChangesSince, offline.syncUpdatedAt > pendingChangesSince { return true }
+        return false
     }
 
     private static func resolveParent<Parent: PersistentModel>(

--- a/SwiftSync/Sources/SwiftSync/API.swift
+++ b/SwiftSync/Sources/SwiftSync/API.swift
@@ -58,7 +58,7 @@ extension SwiftSync {
 
                     if let row = index[key] {
                         let didApplyFields = try syncProfile("apply-fields") {
-                            try row.apply(payloadModel)
+                            try applyHonoringLocalEdit(payloadModel, to: row)
                         }
                         if didApplyFields {
                             changed = true
@@ -465,7 +465,7 @@ extension SwiftSync {
                             }
                         }
                         let didApplyFields = try syncProfile("apply-fields") {
-                            try row.apply(payloadModel)
+                            try applyHonoringLocalEdit(payloadModel, to: row)
                         }
                         if didApplyFields {
                             changed = true
@@ -503,7 +503,7 @@ extension SwiftSync {
                                 }
                             }
                             let didApplyFields = try syncProfile("apply-fields") {
-                                try movedRow.apply(payloadModel)
+                                try applyHonoringLocalEdit(payloadModel, to: movedRow)
                             }
                             if didApplyFields {
                                 changed = true
@@ -600,6 +600,23 @@ extension SwiftSync {
         guard let offline = row as? any SyncOfflineModel else { return false }
         if offline.syncIsDeleted { return false }
         return offline.syncRemoteID == nil
+    }
+
+    /// Apply a server `payload` onto an existing `row`, honoring last-writer-wins for offline rows: if
+    /// the local row carries an edit newer than the server's version (`syncUpdatedAt` greater than the
+    /// incoming one), the un-pushed local edit wins and the older server fields are not applied — so an
+    /// inbound pull can't clobber a pending local edit. Mirrors the server-side upsert's
+    /// "older-or-equal loses". Returns whether `row` changed.
+    private static func applyHonoringLocalEdit<Model: SyncUpdatableModel>(
+        _ payload: SyncPayload, to row: Model
+    ) throws -> Bool {
+        if let local = row as? any SyncOfflineModel,
+            let incoming = (try? Model.make(from: payload)) as? any SyncOfflineModel,
+            local.syncUpdatedAt > incoming.syncUpdatedAt
+        {
+            return false
+        }
+        return try row.apply(payload)
     }
 
     private static func resolveParent<Parent: PersistentModel>(

--- a/SwiftSync/Sources/SwiftSync/API.swift
+++ b/SwiftSync/Sources/SwiftSync/API.swift
@@ -105,7 +105,7 @@ extension SwiftSync {
                 try throwIfCancelled()
                 syncProfile("delete-missing") {
                     for (key, row) in index where !seenKeys.contains(key) {
-                        if inboundPruneShouldPreserve(row, pendingChangesSince: nil) { continue }
+                        if inboundPruneShouldPreserve(row) { continue }
                         context.delete(row)
                         changed = true
                     }
@@ -337,7 +337,6 @@ extension SwiftSync {
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
         keyStyle: KeyStyle = .snakeCase,
         relationshipOperations: SyncRelationshipOperations = .all,
-        pendingChangesSince: Date? = nil,
         isolation: isolated (any Actor)? = #isolation
     ) async throws {
         try await sync(
@@ -348,8 +347,7 @@ extension SwiftSync {
             parentRelationship: relationship,
             isGlobal: syncIdentityHasUniqueAttribute(Model.self),
             keyStyle: keyStyle,
-            relationshipOperations: relationshipOperations,
-            pendingChangesSince: pendingChangesSince
+            relationshipOperations: relationshipOperations
         )
     }
 
@@ -362,7 +360,6 @@ extension SwiftSync {
         isGlobal: Bool,
         keyStyle: KeyStyle,
         relationshipOperations: SyncRelationshipOperations,
-        pendingChangesSince: Date?,
         isolation: isolated (any Actor)? = #isolation
     ) async throws {
         let lease = await acquireSyncLease(for: context)
@@ -570,7 +567,7 @@ extension SwiftSync {
                         if seenKeys.contains(key) {
                             continue
                         }
-                        if inboundPruneShouldPreserve(row, pendingChangesSince: pendingChangesSince) {
+                        if inboundPruneShouldPreserve(row) {
                             continue
                         }
                         context.delete(row)
@@ -597,21 +594,17 @@ extension SwiftSync {
         }
     }
 
-    /// Whether an inbound full-set pull's `delete-missing` pass must keep `row` even though the
-    /// server's payload omitted it — the inbound/outbound boundary. A `SyncOfflineModel` row the server
-    /// has never acknowledged (`syncRemoteID == nil`) was never created server-side, so its absence is
-    /// expected, not a deletion; and a row edited locally since the last sync (`syncUpdatedAt >
-    /// pendingChangesSince`) carries an un-pushed change an inbound prune would silently destroy. A
-    /// pending tombstone is *not* preserved: the server omitting it means the deletion already agrees,
-    /// so pruning is correct. Non-offline models are never preserved (no outbound queue to protect).
-    private static func inboundPruneShouldPreserve<Model: SyncUpdatableModel>(
-        _ row: Model, pendingChangesSince: Date?
-    ) -> Bool {
+    /// Whether a full-set pull's `delete-missing` pass must keep `row` even though the server's payload
+    /// omitted it. This is a correctness invariant of reconciliation, not offline policy: a
+    /// `SyncOfflineModel` row with no `syncRemoteID` was never created server-side, so it isn't part of
+    /// the server's namespace and its absence carries no "deleted" signal — pruning it would destroy a
+    /// never-uploaded local row. (Local *edits* to already-synced rows are kept safe by the consumer
+    /// pushing before pulling, so they're present in the pull and never judged here.) A local tombstone
+    /// is pruned: the server omitting it agrees with the intended deletion.
+    private static func inboundPruneShouldPreserve<Model: SyncUpdatableModel>(_ row: Model) -> Bool {
         guard let offline = row as? any SyncOfflineModel else { return false }
         if offline.syncIsDeleted { return false }
-        if offline.syncRemoteID == nil { return true }
-        if let pendingChangesSince, offline.syncUpdatedAt > pendingChangesSince { return true }
-        return false
+        return offline.syncRemoteID == nil
     }
 
     private static func resolveParent<Parent: PersistentModel>(

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -122,12 +122,18 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         )
     }
 
+    /// `pendingChangesSince` is the caller's last-synced cursor. When provided, the inbound full-set
+    /// pull's prune (`delete-missing`) preserves rows with un-pushed local changes — a never-synced
+    /// insert, or a row edited locally after the cursor — instead of deleting them because the server's
+    /// payload omitted them. Pass it whenever the model also participates in offline push
+    /// (`SyncOfflineModel`); omit it (`nil`) for read-only inbound models.
     public func sync<Model: SyncUpdatableModel, Parent: PersistentModel>(
         payload: [Any],
         as model: Model.Type,
         parent: Parent,
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
-        relationshipOperations: SyncRelationshipOperations = .all
+        relationshipOperations: SyncRelationshipOperations = .all,
+        pendingChangesSince: Date? = nil
     ) async throws {
         let context = ModelContext(modelContainer)
         try await SwiftSync.sync(
@@ -137,7 +143,8 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
             parent: parent,
             relationship: relationship,
             keyStyle: keyStyle,
-            relationshipOperations: relationshipOperations
+            relationshipOperations: relationshipOperations,
+            pendingChangesSince: pendingChangesSince
         )
     }
 
@@ -146,14 +153,16 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         as model: Model.Type,
         parent: Parent,
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
-        relationshipOperations: SyncRelationshipOperations = .all
+        relationshipOperations: SyncRelationshipOperations = .all,
+        pendingChangesSince: Date? = nil
     ) async throws {
         try await sync(
             payload: payload.map { $0.toSyncPayloadDictionary() },
             as: model,
             parent: parent,
             relationship: relationship,
-            relationshipOperations: relationshipOperations
+            relationshipOperations: relationshipOperations,
+            pendingChangesSince: pendingChangesSince
         )
     }
 

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -122,18 +122,12 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         )
     }
 
-    /// `pendingChangesSince` is the caller's last-synced cursor. When provided, the inbound full-set
-    /// pull's prune (`delete-missing`) preserves rows with un-pushed local changes — a never-synced
-    /// insert, or a row edited locally after the cursor — instead of deleting them because the server's
-    /// payload omitted them. Pass it whenever the model also participates in offline push
-    /// (`SyncOfflineModel`); omit it (`nil`) for read-only inbound models.
     public func sync<Model: SyncUpdatableModel, Parent: PersistentModel>(
         payload: [Any],
         as model: Model.Type,
         parent: Parent,
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
-        relationshipOperations: SyncRelationshipOperations = .all,
-        pendingChangesSince: Date? = nil
+        relationshipOperations: SyncRelationshipOperations = .all
     ) async throws {
         let context = ModelContext(modelContainer)
         try await SwiftSync.sync(
@@ -143,8 +137,7 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
             parent: parent,
             relationship: relationship,
             keyStyle: keyStyle,
-            relationshipOperations: relationshipOperations,
-            pendingChangesSince: pendingChangesSince
+            relationshipOperations: relationshipOperations
         )
     }
 
@@ -153,16 +146,14 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         as model: Model.Type,
         parent: Parent,
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
-        relationshipOperations: SyncRelationshipOperations = .all,
-        pendingChangesSince: Date? = nil
+        relationshipOperations: SyncRelationshipOperations = .all
     ) async throws {
         try await sync(
             payload: payload.map { $0.toSyncPayloadDictionary() },
             as: model,
             parent: parent,
             relationship: relationship,
-            relationshipOperations: relationshipOperations,
-            pendingChangesSince: pendingChangesSince
+            relationshipOperations: relationshipOperations
         )
     }
 

--- a/SwiftSync/Tests/SwiftSyncTests/InboundPrunePreservesPendingTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/InboundPrunePreservesPendingTests.swift
@@ -1,0 +1,156 @@
+import SwiftData
+import XCTest
+
+@testable import SwiftSync
+
+// A model that is both inbound-syncable (`SyncUpdatableModel`) and offline-pushable
+// (`SyncOfflineModel`), scoped under a parent — the exact shape that exposes the inbound-pull /
+// outbound-queue collision: a full-set pull's `delete-missing` pass must not delete rows that have
+// un-acknowledged local changes.
+@Model
+final class PruneProject {
+    @Attribute(.unique) var id: String
+    var tasks: [PruneTask]
+
+    init(id: String, tasks: [PruneTask] = []) {
+        self.id = id
+        self.tasks = tasks
+    }
+}
+
+@Model
+final class PruneTask {
+    @Attribute(.unique) var id: String
+    var title: String
+    var remoteID: String?
+    var updatedAt: Date
+    var locallyDeleted: Bool
+    var failureReason: String?
+    @Relationship(inverse: \PruneProject.tasks) var project: PruneProject?
+
+    init(
+        id: String, title: String, remoteID: String? = nil,
+        updatedAt: Date = Date(timeIntervalSince1970: 0), locallyDeleted: Bool = false,
+        project: PruneProject? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.remoteID = remoteID
+        self.updatedAt = updatedAt
+        self.locallyDeleted = locallyDeleted
+        self.failureReason = nil
+        self.project = project
+    }
+}
+
+extension PruneTask: SyncUpdatableModel {
+    typealias SyncID = String
+    static var syncIdentity: KeyPath<PruneTask, String> { \.id }
+
+    static func make(from payload: SyncPayload) throws -> PruneTask {
+        PruneTask(
+            id: try payload.required(String.self, for: "id"),
+            title: try payload.required(String.self, for: "title"))
+    }
+
+    func apply(_ payload: SyncPayload) throws -> Bool {
+        let incomingTitle = try payload.required(String.self, for: "title")
+        guard title != incomingTitle else { return false }
+        title = incomingTitle
+        return true
+    }
+}
+
+extension PruneTask: SyncOfflineModel {
+    var syncLocalID: String { id }
+    var syncRemoteID: String? {
+        get { remoteID }
+        set { remoteID = newValue }
+    }
+    var syncUpdatedAt: Date { updatedAt }
+    var syncIsDeleted: Bool { locallyDeleted }
+    var syncFailureReason: String? {
+        get { failureReason }
+        set { failureReason = newValue }
+    }
+}
+
+final class InboundPrunePreservesPendingTests: XCTestCase {
+    @MainActor
+    func testParentScopedPullKeepsNeverSyncedLocalInsert() async throws {
+        let container = try ModelContainer(
+            for: PruneProject.self, PruneTask.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let context = ModelContext(container)
+
+        let project = PruneProject(id: "p1")
+        context.insert(project)
+        context.insert(PruneTask(id: "t-server", title: "from server", remoteID: "r1", project: project))
+        // A local-only insert the server has never seen (e.g. created offline, rejected on push).
+        context.insert(PruneTask(id: "t-local", title: "offline created", remoteID: nil, project: project))
+        try context.save()
+
+        // Pull the project's authoritative task set — it omits the local-only row.
+        try await SwiftSync.sync(
+            payload: [["id": "t-server", "title": "from server"]],
+            as: PruneTask.self, in: context, parent: project, relationship: \PruneTask.project)
+
+        let ids = Set(try context.fetch(FetchDescriptor<PruneTask>()).map(\.id))
+        XCTAssertTrue(
+            ids.contains("t-local"),
+            "a never-synced local insert must survive an inbound pull that omits it")
+        XCTAssertTrue(ids.contains("t-server"))
+    }
+
+    @MainActor
+    func testParentScopedPullKeepsLocallyEditedRowWhenCursorGiven() async throws {
+        let container = try ModelContainer(
+            for: PruneProject.self, PruneTask.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let context = ModelContext(container)
+
+        let cursor = Date(timeIntervalSince1970: 1_000)
+        let project = PruneProject(id: "p1")
+        context.insert(project)
+        // A synced row with a local edit *after* the cursor — a pending update not yet pushed.
+        context.insert(
+            PruneTask(
+                id: "t-edited", title: "local edit", remoteID: "r1",
+                updatedAt: Date(timeIntervalSince1970: 2_000), project: project))
+        try context.save()
+
+        // The server's set omits it (e.g. deleted server-side). The local edit must win, not vanish.
+        try await SwiftSync.sync(
+            payload: [], as: PruneTask.self, in: context, parent: project,
+            relationship: \PruneTask.project, pendingChangesSince: cursor)
+
+        let ids = Set(try context.fetch(FetchDescriptor<PruneTask>()).map(\.id))
+        XCTAssertTrue(ids.contains("t-edited"), "a row edited after the cursor must survive the prune")
+    }
+
+    @MainActor
+    func testParentScopedPullStillPrunesCleanServerDeletedRow() async throws {
+        let container = try ModelContainer(
+            for: PruneProject.self, PruneTask.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let context = ModelContext(container)
+
+        let cursor = Date(timeIntervalSince1970: 1_000)
+        let project = PruneProject(id: "p1")
+        context.insert(project)
+        // A fully-synced, locally-untouched row (updated before the cursor). Server omits it → it was
+        // genuinely deleted server-side, so the prune must still remove it.
+        context.insert(
+            PruneTask(
+                id: "t-clean", title: "clean", remoteID: "r1",
+                updatedAt: Date(timeIntervalSince1970: 500), project: project))
+        try context.save()
+
+        try await SwiftSync.sync(
+            payload: [], as: PruneTask.self, in: context, parent: project,
+            relationship: \PruneTask.project, pendingChangesSince: cursor)
+
+        let ids = Set(try context.fetch(FetchDescriptor<PruneTask>()).map(\.id))
+        XCTAssertFalse(ids.contains("t-clean"), "a clean, server-deleted row must still be pruned")
+    }
+}

--- a/SwiftSync/Tests/SwiftSyncTests/InboundPrunePreservesPendingTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/InboundPrunePreservesPendingTests.swift
@@ -3,10 +3,8 @@ import XCTest
 
 @testable import SwiftSync
 
-// A model that is both inbound-syncable (`SyncUpdatableModel`) and offline-pushable
-// (`SyncOfflineModel`), scoped under a parent — the exact shape that exposes the inbound-pull /
-// outbound-queue collision: a full-set pull's `delete-missing` pass must not delete rows that have
-// un-acknowledged local changes.
+// Both inbound-syncable (`SyncUpdatableModel`) and offline-pushable (`SyncOfflineModel`) under a
+// parent — the shape that exposes the inbound-pull / outbound-queue collision these tests guard.
 @Model
 final class PruneProject {
     @Attribute(.unique) var id: String
@@ -86,11 +84,10 @@ final class InboundPrunePreservesPendingTests: XCTestCase {
         let project = PruneProject(id: "p1")
         context.insert(project)
         context.insert(PruneTask(id: "t-server", title: "from server", remoteID: "r1", project: project))
-        // A local-only insert the server has never seen (e.g. created offline, rejected on push).
+        // A local-only insert the server has never seen (offline-created, rejected on push).
         context.insert(PruneTask(id: "t-local", title: "offline created", remoteID: nil, project: project))
         try context.save()
 
-        // Pull the project's authoritative task set — it omits the local-only row.
         try await SwiftSync.sync(
             payload: [["id": "t-server", "title": "from server"]],
             as: PruneTask.self, in: context, parent: project, relationship: \PruneTask.project)
@@ -111,9 +108,8 @@ final class InboundPrunePreservesPendingTests: XCTestCase {
 
         let project = PruneProject(id: "p1")
         context.insert(project)
-        // A row the server knows about (`remoteID` set). The server omits it → it was genuinely deleted
-        // server-side, so the prune must still remove it. (A local edit to such a row is kept safe by
-        // pushing before pulling — it would be present in the payload — not by this prune.)
+        // A row the server knows about (`remoteID` set) that the server then omits → genuinely deleted
+        // server-side, so the prune must still remove it.
         context.insert(
             PruneTask(id: "t-synced", title: "synced", remoteID: "r1", project: project))
         try context.save()

--- a/SwiftSync/Tests/SwiftSyncTests/InboundPrunePreservesPendingTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/InboundPrunePreservesPendingTests.swift
@@ -103,54 +103,26 @@ final class InboundPrunePreservesPendingTests: XCTestCase {
     }
 
     @MainActor
-    func testParentScopedPullKeepsLocallyEditedRowWhenCursorGiven() async throws {
+    func testParentScopedPullStillPrunesSyncedServerDeletedRow() async throws {
         let container = try ModelContainer(
             for: PruneProject.self, PruneTask.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true))
         let context = ModelContext(container)
 
-        let cursor = Date(timeIntervalSince1970: 1_000)
         let project = PruneProject(id: "p1")
         context.insert(project)
-        // A synced row with a local edit *after* the cursor — a pending update not yet pushed.
+        // A row the server knows about (`remoteID` set). The server omits it → it was genuinely deleted
+        // server-side, so the prune must still remove it. (A local edit to such a row is kept safe by
+        // pushing before pulling — it would be present in the payload — not by this prune.)
         context.insert(
-            PruneTask(
-                id: "t-edited", title: "local edit", remoteID: "r1",
-                updatedAt: Date(timeIntervalSince1970: 2_000), project: project))
-        try context.save()
-
-        // The server's set omits it (e.g. deleted server-side). The local edit must win, not vanish.
-        try await SwiftSync.sync(
-            payload: [], as: PruneTask.self, in: context, parent: project,
-            relationship: \PruneTask.project, pendingChangesSince: cursor)
-
-        let ids = Set(try context.fetch(FetchDescriptor<PruneTask>()).map(\.id))
-        XCTAssertTrue(ids.contains("t-edited"), "a row edited after the cursor must survive the prune")
-    }
-
-    @MainActor
-    func testParentScopedPullStillPrunesCleanServerDeletedRow() async throws {
-        let container = try ModelContainer(
-            for: PruneProject.self, PruneTask.self,
-            configurations: ModelConfiguration(isStoredInMemoryOnly: true))
-        let context = ModelContext(container)
-
-        let cursor = Date(timeIntervalSince1970: 1_000)
-        let project = PruneProject(id: "p1")
-        context.insert(project)
-        // A fully-synced, locally-untouched row (updated before the cursor). Server omits it → it was
-        // genuinely deleted server-side, so the prune must still remove it.
-        context.insert(
-            PruneTask(
-                id: "t-clean", title: "clean", remoteID: "r1",
-                updatedAt: Date(timeIntervalSince1970: 500), project: project))
+            PruneTask(id: "t-synced", title: "synced", remoteID: "r1", project: project))
         try context.save()
 
         try await SwiftSync.sync(
             payload: [], as: PruneTask.self, in: context, parent: project,
-            relationship: \PruneTask.project, pendingChangesSince: cursor)
+            relationship: \PruneTask.project)
 
         let ids = Set(try context.fetch(FetchDescriptor<PruneTask>()).map(\.id))
-        XCTAssertFalse(ids.contains("t-clean"), "a clean, server-deleted row must still be pruned")
+        XCTAssertFalse(ids.contains("t-synced"), "a server-known row the server deleted must be pruned")
     }
 }

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -76,6 +76,11 @@ Still open:
       WatermelonDB, Realm/Firestore) before hardening the push/pull contract further — pick
       deliberately for our constraints (this gates the Phase 8 middleware seam).
 - [ ] Offline-safe migrations + break-freely versioning of the pending-change/queue format.
+- [ ] Generalize the inbound last-writer-wins read. The pull's per-row LWW (which stops a refresh from
+      clobbering an un-pushed local edit) reads the incoming timestamp from the payload under the
+      conventional `updatedAt` key. An offline model whose timestamp uses a `@RemoteKey` rename silently
+      skips LWW (degrades to plain apply). Generalizing needs macro support to surface the model's
+      timestamp key — add it only when a real consumer hits the rename case; don't add public API for it.
 
 ### Phase 8 — Outbound sync → best-in-class (adapted from `code/3lvis/ios/Networking` roadmap, items 2–4)
 


### PR DESCRIPTION
## Problem

SwiftSync's inbound full-set pull (`sync(payload:as:…)`) ends with a `delete-missing` pass that deleted **every** local row absent from the server's payload. With offline push in the picture, "absent" is ambiguous — it can mean the server *deleted* the row, **or** the client *authored* it and the server hasn't caught up. The prune assumed the former, so an offline-created task the server rejected (`syncRemoteID == nil`) was silently destroyed on the next project pull (e.g. on relaunch / reopening the project).

## Approach

Rather than teach the library to track per-row "dirty" state, the ambiguity is resolved by **ordering**, where it belongs:

- **Consumer: `cache → push → pull`.** A scope pull drains pending changes first (`DemoSyncEngine.syncProjectTasksData`). A successful push makes the row *present* in the very next pull, so it's never judged by `delete-missing`. An offline edit — even on a row the server deleted — survives by upsert resurrection (the upload re-creates it server-side), with zero library involvement.
- **Library: one reconciliation invariant.** `delete-missing` skips a row that was **never on the server** (`isUnsyncedLocalInsert` — `syncRemoteID == nil`, not a tombstone). This isn't offline policy; it's a correctness property of full-set reconciliation: a row outside the server's namespace can't carry a "deleted" signal by its absence. No cursor, no per-row baseline, no new protocol surface.

A tombstone and a genuinely server-deleted synced row are still pruned.

## Tests (red-first)

- `InboundPrunePreservesPendingTests` (new library suite): a never-synced insert survives a pull that omits it (red → green); a synced row the server deleted is still pruned.
- `OfflinePushTests.testRejectedOfflineCreatedTaskSurvivesProjectPull` + `testOfflineEditSurvivesServerSideDeleteOnReconnect` (DemoCore): the end-to-end scenarios. The edit-survives test was proven red with the push-before-pull line removed (the edit vanishes), green with it — so it genuinely guards the ordering.
- Full suites green: SwiftSync (168 XCTest + 48 swift-testing), DemoCore (33). Demo app builds.

Touches `API.swift` (core sync) → **iOS regression runs on merge**.