### PR TITLE
Align commit policy with the personally-responsible-repo rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,9 @@
 
 ## Pre-Commit Checkpoint
 
-- **Do not commit unless the user explicitly asks.**
+- This is a personally-responsible repo (`3lvis` remote), so the global rule applies: commit and open a
+  **draft** PR proactively once a branch is a complete, green unit — no need to ask first or show the
+  title/body. **Never merge without an explicit ask.**
 - Before every commit:
   - run `git status --short`
   - confirm only intended files are staged


### PR DESCRIPTION
The repo's `## Pre-Commit Checkpoint` opened with a blanket *"Do not commit unless the user explicitly asks"* — which contradicts the global personally-responsible-repo rule (*commit and open a draft PR proactively once a branch is a complete, green unit*). SwiftSync is a `3lvis` remote, so the personal-repo model applies.

Replaces that bullet with the personal-repo model and keeps the parts that don't conflict (merge stays gated on an explicit ask; the `git status --short` staging check is preserved).