### PR TITLE
Remove SyncContext — single-object sync(item:) applies on main

### DIFF
--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -89,7 +89,7 @@ public final class DemoSyncEngine {
             guard try project(withID: projectID) != nil else {
                 throw SyncTaskDetailError.missingProject(projectID)
             }
-            try await syncContainer.sync(item: body, as: Task.self, context: .main)
+            try await syncContainer.sync(item: body, as: Task.self)
             refreshPendingCount()
             return
         }
@@ -107,7 +107,7 @@ public final class DemoSyncEngine {
         // must be re-inserted. Apply locally so it stays a pending insert; online, push to (re)insert.
         let neverSynced = (try task(withID: taskID))?.syncRemoteID == nil
         if isOffline || neverSynced {
-            try await syncContainer.sync(item: body, as: Task.self, context: .main)
+            try await syncContainer.sync(item: body, as: Task.self)
             if let task = try task(withID: taskID) {
                 task.updatedAt = Date()
                 task.syncFailureReason = nil  // the corrected edit gets a fresh attempt
@@ -261,7 +261,7 @@ public final class DemoSyncEngine {
                 if let localID { response.confirmedUpdateLocalIDs.insert(localID) }
                 if status == "stale", let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(
-                        item: DemoSyncPayload(dictionary: server), as: Task.self, context: .main)
+                        item: DemoSyncPayload(dictionary: server), as: Task.self)
                 }
             case ("delete", "applied"):
                 if let localID { response.confirmedDeleteLocalIDs.insert(localID) }
@@ -270,7 +270,7 @@ public final class DemoSyncEngine {
                 // the server's state so the row reappears with the winning version (no re-send loop).
                 if let localID, let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(
-                        item: DemoSyncPayload(dictionary: server), as: Task.self, context: .main)
+                        item: DemoSyncPayload(dictionary: server), as: Task.self)
                     if let task = try task(withID: localID) { task.isLocallyDeleted = false }
                 }
             default:
@@ -397,7 +397,7 @@ public final class DemoSyncEngine {
         guard try project(withID: projectID) != nil else {
             throw SyncTaskDetailError.missingProject(projectID)
         }
-        try await syncContainer.sync(item: payload, as: Task.self, context: .background)
+        try await syncContainer.sync(item: payload, as: Task.self)
         markPulled()
     }
 

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -9,16 +9,6 @@ struct UncheckedSendableBox<Value>: @unchecked Sendable {
     init(_ value: Value) { self.value = value }
 }
 
-/// Which `ModelContext` a single-object `sync` writes into.
-public enum SyncContext: Sendable {
-    /// Apply on the main actor against `mainContext`: the row mutates in place, so live queries reflect
-    /// it at once. Occupies the main thread, so use it only for small, single-object local writes.
-    case main
-    /// Import on a background context off the main thread; changes merge into `mainContext` via the
-    /// did-save bridge (gated on an idle main runloop). The right choice for server/inbound syncs.
-    case background
-}
-
 public final class SyncContainer: NSObject, @unchecked Sendable {
     public struct SchemaValidationError: LocalizedError, Sendable {
         public let message: String
@@ -157,36 +147,21 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         )
     }
 
-    /// `context` has **no default** so every caller chooses deliberately (see `SyncContext`): `.main`
-    /// for a small local write that must be visible at once, `.background` for a server/inbound sync.
-    /// The split exists because SwiftData has no `mergeChanges(fromContextDidSave:)`, so a
-    /// background-context *update* doesn't promptly refresh an already-registered `mainContext` row
-    /// (the merge is gated on an idle main runloop) — writing a local edit on `.main` sidesteps that.
+    /// Import a single object. A single row is small, so it applies on `mainContext` (on the main
+    /// actor) and the change is visible to live queries at once — unlike bulk `sync(payload:)`, which
+    /// runs off-main. (SwiftData has no `mergeChanges(fromContextDidSave:)`, so an off-main *update*
+    /// wouldn't promptly refresh an already-registered `mainContext` row; for a single object, applying
+    /// on main sidesteps that without a meaningful main-thread cost.) The payload rides in an
+    /// unchecked-Sendable box so it can cross to the main actor; it is only read there, so the box is sound.
     public func sync<Model: SyncUpdatableModel>(
         item: [String: Any],
         as model: Model.Type,
-        relationshipOperations: SyncRelationshipOperations = .all,
-        context: SyncContext
+        relationshipOperations: SyncRelationshipOperations = .all
     ) async throws {
-        switch context {
-        case .main:
-            try await syncIntoMainContext(
-                UncheckedSendableBox(item), as: model, relationshipOperations: relationshipOperations)
-        case .background:
-            let backgroundContext = ModelContext(modelContainer)
-            try await SwiftSync.sync(
-                item: item,
-                as: model,
-                in: backgroundContext,
-                keyStyle: keyStyle,
-                relationshipOperations: relationshipOperations
-            )
-        }
+        try await syncIntoMainContext(
+            UncheckedSendableBox(item), as: model, relationshipOperations: relationshipOperations)
     }
 
-    /// Import a single object straight into `mainContext` on the main actor (for immediate local
-    /// writes). The payload rides in an unchecked-Sendable box so it can cross to the main actor; it is
-    /// only read on the main actor here, so the box is sound.
     @MainActor
     private func syncIntoMainContext<Model: SyncUpdatableModel>(
         _ item: UncheckedSendableBox<[String: Any]>,
@@ -205,14 +180,12 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
     public func sync<Model: SyncUpdatableModel, Payload: SyncPayloadConvertible>(
         item: Payload,
         as model: Model.Type,
-        relationshipOperations: SyncRelationshipOperations = .all,
-        context: SyncContext
+        relationshipOperations: SyncRelationshipOperations = .all
     ) async throws {
         try await sync(
             item: item.toSyncPayloadDictionary(),
             as: model,
-            relationshipOperations: relationshipOperations,
-            context: context
+            relationshipOperations: relationshipOperations
         )
     }
 

--- a/SwiftSync/Tests/SwiftSyncTests/SyncModelPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncModelPublisherTests.swift
@@ -57,8 +57,7 @@ final class SyncModelPublisherTests: XCTestCase {
 
         try await syncContainer.sync(
             item: ["id": "t1", "title": "Alpha", "assignee_id": "u1"],
-            as: ModelPubTask.self,
-            context: .background
+            as: ModelPubTask.self
         )
 
         try await waitUntil {
@@ -96,8 +95,7 @@ final class SyncModelPublisherTests: XCTestCase {
 
         try await syncContainer.sync(
             item: ["id": "t1", "title": "Alpha", "assignee_id": "u1"],
-            as: ModelPubTask.self,
-            context: .background
+            as: ModelPubTask.self
         )
 
         try await waitUntil {

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
@@ -363,10 +363,10 @@ final class SyncQueryPublisherTests: XCTestCase {
         XCTFail("Timed out waiting for condition: \(description)")
     }
 
-    // MARK: - context: .main (local) writes land in place
+    // MARK: - single-object writes land in place
 
     @MainActor
-    func testMainContextSyncUpdatesRegisteredRowInPlace() async throws {
+    func testSingleItemSyncUpdatesRegisteredRowInPlace() async throws {
         let container = try makeContainer(modelTypes: PubTask.self)
         container.mainContext.insert(PubTask(id: "t1", title: "Original"))
         try container.mainContext.save()
@@ -375,10 +375,9 @@ final class SyncQueryPublisherTests: XCTestCase {
         let row = try XCTUnwrap(
             container.mainContext.fetch(FetchDescriptor<PubTask>()).first { $0.id == "t1" })
 
-        // context: .main applies on the main context, so the edit lands on the already-registered
-        // instance at once. context: .background would leave this instance stale until SwiftData's
-        // cross-context merge catches up on an idle main runloop.
-        try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self, context: .main)
+        // A single-object sync applies on the main context, so the edit lands on the already-registered
+        // instance at once (no cross-context merge to wait on).
+        try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self)
 
         XCTAssertEqual(row.title, "Edited")
     }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
@@ -1446,7 +1446,7 @@ final class SyncTests: XCTestCase {
         try await container.sync(payload: [SendableUserPayload(id: 9, fullName: "Initial")], as: User.self)
 
         try await container.sync(
-            item: SendableUserPayload(id: 9, fullName: "Updated"), as: User.self, context: .background)
+            item: SendableUserPayload(id: 9, fullName: "Updated"), as: User.self)
 
         let users = try container.mainContext.fetch(FetchDescriptor<User>())
         XCTAssertEqual(users.count, 1)

--- a/docs/planning/api-surface-review.md
+++ b/docs/planning/api-surface-review.md
@@ -27,7 +27,7 @@ git history is the memory.
 
 ## Priority order (highest leverage / lowest risk first)
 
-1. [ ] Remove `SyncContext` + local-write `sync(item:)` — surface removal, self-contained
+1. [x] ~~Remove `SyncContext` + local-write `sync(item:)`~~ — **done** (single-object `sync(item:)` applies on main, bulk off-main; `SyncContext` deleted)
 2. [ ] Macro-generate `SyncOfflineModel` — the flagship "magic" move
 3. [ ] Drop `syncFailureReason` from the protocol — rides pure-bubble (#624)
 4. [ ] Generalize the inbound LWW timestamp key — convention today, macro later
@@ -37,37 +37,14 @@ git history is the memory.
 
 ---
 
-## 1. Remove `SyncContext` + the local-write `sync(item:)` overloads
+## 1. Remove `SyncContext` + the local-write `sync(item:)` overloads — ✅ done
 
-**Context.** `SyncContext` (`.main` / `.background`) plus a *mandatory* `context:` parameter on the two
-single-object `sync(item:…)` overloads was added (it replaced an earlier `runOnMain: Bool`) to route a
-*local* write onto `mainContext` (immediate visibility) versus an *inbound* sync onto a background
-context. This leaks a `ModelContext`-routing decision into the public API. **A consumer should never
-have to reason about which `ModelContext` a write lands in — that is the library's job.**
-
-**First principles.** The offline design is *"pending changes are a query over the store — no
-save-interception."* So a local write is just **mutate your `@Model` on `mainContext` and save** (plain
-SwiftData, already visible); the `pendingChanges` query then detects it (insert = `syncRemoteID == nil`,
-edit = `syncUpdatedAt > cursor`, delete = tombstone). **Local writes don't need to go through SwiftSync
-at all.** Inbound sync (`sync(payload:)`) is the only thing that needs a context, and it should always
-run off-main *internally* with no consumer choice.
-
-**Current surface.** `public enum SyncContext`; `2×` `public func sync(item:…, context: SyncContext)`.
-
-**Target.** Delete `SyncContext` and the local-write `sync(item:)` path. Inbound sync picks its context
-internally. Document "local writes = direct model mutation + save" as the supported pattern.
-
-**Evidence it's a convenience, not a necessity.** The demo is already inconsistent: offline *people*
-edits mutate the model directly (`applyLocalPeople`), while offline *create/update* route through
-`sync(item:context:.main)` purely to reuse the dict→model `apply` mapping.
-
-**Decision needed.** Confirm no apply-time behavior (relationship resolution, field coercion) that local
-create/update actually depend on. If a dict→model convenience is still wanted, provide it without
-exposing a context (or have the consumer set fields directly).
-
-**Scope/risk.** Small, self-contained; removes public surface this work introduced. Touches
-`SyncContainer` + the demo engine's offline `createTask`/`updateTask`. Existing offline tests must stay
-green. **Recommended first** — highest confidence, removes surface, no macro work.
+Resolved via the **convention** "single object → main, bulk → off-main" (chosen over the purist
+"local writes never touch sync" — it removed the surface with minimal churn and kept the useful
+dict→model apply). `SyncContext` is deleted; the two single-object `sync(item:)` overloads dropped the
+`context:` parameter and always apply on `mainContext` (a single row is small, so the immediate
+visibility is worth the negligible main-thread cost); bulk `sync(payload:)` stays off-main. All callers
+just dropped the `context:` arg. No consumer reasons about `ModelContext` anymore.
 
 ---
 


### PR DESCRIPTION
**API-surface review item #1** (see `docs/planning/api-surface-review.md`).

`SyncContext` (`.main` / `.background`) plus a mandatory `context:` parameter on the single-object `sync(item:)` overloads leaked a `ModelContext`-routing decision into the public API — a consumer should never reason about *which* context a write lands in.

## Resolution — convention over configuration
A single object is small, so `sync(item:)` always applies on `mainContext` (immediate visibility, negligible main-thread cost); bulk `sync(payload:)` stays off-main. The enum and the `context:` parameter are deleted; every caller just drops the arg.

Chosen over the purist "local writes never touch sync" alternative — same surface removal with minimal churn, and it keeps the useful dict→model apply.

## Net effect
- Public API: **`SyncContext` gone**, `sync(item:)` overloads lose a required parameter. Net surface reduction (−53 lines).
- No consumer reasons about `ModelContext` anymore.
- Behavior: single-object inbound detail sync moves background→main (one row) — exactly the immediate visibility a detail view wants.

## Verification
SwiftSync 168 + 48, DemoCore 36 — all green; demo builds. No README/design-doc references to `SyncContext` to update.

Touches `SyncContainer` (no `Core.swift`/macro change) — standard CI gates apply.