### PR TITLE
⛔️ DO NOT MERGE — pure-SwiftData canary: cross-context save doesn't refresh a registered instance (red until SwiftData fixes it)

### DIFF
--- a/SwiftSync/Tests/SwiftSyncTests/SwiftDataCrossContextMergeCanaryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SwiftDataCrossContextMergeCanaryTests.swift
@@ -21,6 +21,12 @@ final class SwiftDataCrossContextMergeCanaryTests: XCTestCase {
     /// refresh an already-registered instance on another (e.g. the `mainContext` instance a SwiftUI view
     /// holds). That gap is the only reason single-object `sync(item:)` applies on the main thread.
     ///
+    /// This is the same problem the predecessor Core Data `Sync` library solved with one call —
+    /// `mainContext.mergeChanges(fromContextDidSave:)` on `NSManagedObjectContextDidSave` (its
+    /// `DataStack`, commit `f8b0f5a0`). `mergeChanges` is `NSManagedObjectContext` API that `ModelContext`
+    /// does not expose (nor `automaticallyMergesChangesFromParent`, nor a public `refresh`), so the
+    /// one-line fix can't be ported — this canary waits for SwiftData to ship an equivalent.
+    ///
     /// This asserts the behavior we *want* — a cross-context save promptly reflected on the registered
     /// instance — so it is **red on the PR today**. The day a newer SwiftData merges promptly, CI on the
     /// PR turns **green**: the signal to merge this and move single-object (and inbound) sync off the

--- a/SwiftSync/Tests/SwiftSyncTests/SwiftDataCrossContextMergeCanaryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SwiftDataCrossContextMergeCanaryTests.swift
@@ -1,7 +1,17 @@
 import SwiftData
 import XCTest
 
-@testable import SwiftSync
+// Pure-SwiftData reproduction — no SwiftSync — of the failure SwiftSync works around with its
+// `immediate` flag (commit 5d00aa39). SwiftData has no `mergeChanges(fromContextDidSave:)`, so a save
+// on one `ModelContext` does not refresh an already-registered instance on another (e.g. the
+// `mainContext` row a SwiftUI view holds). That is the "offline edit doesn't update the list" bug;
+// SwiftSync sidesteps it by applying local writes on the main context. This test isolates the raw
+// SwiftData mechanics, with nothing from SwiftSync involved.
+//
+// ⛔️ DO NOT MERGE. It asserts the behavior we *want* (a cross-context save reflected on the registered
+// instance), so it is RED today and turns GREEN the day SwiftData merges cross-context saves promptly —
+// the signal that the `immediate`/main-apply workaround can be retired. Lives on its PR only; the branch
+// must never reach `master` (a red test would block the CI gate).
 
 @Model
 final class CrossContextCanaryNote {
@@ -14,46 +24,32 @@ final class CrossContextCanaryNote {
 }
 
 final class SwiftDataCrossContextMergeCanaryTests: XCTestCase {
-    /// ⛔️ DO NOT MERGE — a standing tracking test that intentionally **fails today**, and whose branch
-    /// must never reach `master` (a red test would block the CI gate). It lives only on its PR.
-    ///
-    /// SwiftData has no `mergeChanges(fromContextDidSave:)`, so a save on one `ModelContext` does not
-    /// refresh an already-registered instance on another (e.g. the `mainContext` instance a SwiftUI view
-    /// holds). That gap is the only reason single-object `sync(item:)` applies on the main thread.
-    ///
-    /// This is the same problem the predecessor Core Data `Sync` library solved with one call —
-    /// `mainContext.mergeChanges(fromContextDidSave:)` on `NSManagedObjectContextDidSave` (its
-    /// `DataStack`, commit `f8b0f5a0`). `mergeChanges` is `NSManagedObjectContext` API that `ModelContext`
-    /// does not expose (nor `automaticallyMergesChangesFromParent`, nor a public `refresh`), so the
-    /// one-line fix can't be ported — this canary waits for SwiftData to ship an equivalent.
-    ///
-    /// This asserts the behavior we *want* — a cross-context save promptly reflected on the registered
-    /// instance — so it is **red on the PR today**. The day a newer SwiftData merges promptly, CI on the
-    /// PR turns **green**: the signal to merge this and move single-object (and inbound) sync off the
-    /// main thread.
     @MainActor
-    func testCrossContextSavePromptlyRefreshesRegisteredInstance() throws {
+    func testCrossContextSaveRefreshesRegisteredInstance() throws {
         let container = try ModelContainer(
             for: CrossContextCanaryNote.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true))
 
+        // A view holds a row registered in the main context.
         let mainContext = container.mainContext
         mainContext.insert(CrossContextCanaryNote(id: "n1", title: "Original"))
         try mainContext.save()
-
-        // The instance a live query / SwiftUI view would be holding.
         let registered = try XCTUnwrap(mainContext.fetch(FetchDescriptor<CrossContextCanaryNote>()).first)
 
-        // Update the same row through a separate context and save — with no runloop turn in between.
-        let otherContext = ModelContext(container)
-        let other = try XCTUnwrap(otherContext.fetch(FetchDescriptor<CrossContextCanaryNote>()).first)
-        other.title = "Edited"
-        try otherContext.save()
+        // A second context — the "background import" path — edits the same row and saves.
+        let backgroundContext = ModelContext(container)
+        let background = try XCTUnwrap(
+            backgroundContext.fetch(FetchDescriptor<CrossContextCanaryNote>()).first)
+        background.title = "Edited"
+        try backgroundContext.save()
 
+        // The behavior we want: the registered instance reflects the saved edit. Fails today — SwiftData
+        // does not merge the background save into it. Passes when SwiftData gains a prompt cross-context
+        // merge, at which point the immediate/main-apply workaround can be retired.
         XCTAssertEqual(
             registered.title, "Edited",
-            "Expected to FAIL today: SwiftData did not merge the cross-context save into the registered "
-                + "mainContext instance. When this passes, SwiftData merges promptly — single-object "
-                + "sync(item:) (and inbound sync) can move off the main thread, and this PR can merge.")
+            "Expected to FAIL today: SwiftData did not merge the background-context save into the "
+                + "registered mainContext instance. When this passes, the immediate/main-apply workaround "
+                + "can be retired.")
     }
 }

--- a/SwiftSync/Tests/SwiftSyncTests/SwiftDataCrossContextMergeCanaryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SwiftDataCrossContextMergeCanaryTests.swift
@@ -1,0 +1,56 @@
+import SwiftData
+import XCTest
+
+@testable import SwiftSync
+
+@Model
+final class CrossContextCanaryNote {
+    @Attribute(.unique) var id: String
+    var title: String
+    init(id: String, title: String) {
+        self.id = id
+        self.title = title
+    }
+}
+
+final class SwiftDataCrossContextMergeCanaryTests: XCTestCase {
+    /// CANARY for the SwiftData limitation SwiftSync works around. SwiftData has no
+    /// `mergeChanges(fromContextDidSave:)`, so a save on one `ModelContext` does **not** promptly refresh
+    /// an already-registered instance on another context (e.g. the `mainContext` instance a SwiftUI view
+    /// holds). That gap is the *only* reason single-object `sync(item:)` applies on the main thread
+    /// (see the PR that removed `SyncContext`).
+    ///
+    /// The test asserts the *broken* behavior inside `XCTExpectFailure`: today the registered instance
+    /// stays stale, the inner assertion fails, and the expectation is satisfied (this test passes). If a
+    /// future SwiftData merges cross-context saves promptly, the inner assertion will start **passing** —
+    /// the expectation is then unmet and this test **fails**, signalling that single-object (and inbound)
+    /// sync can move off the main thread.
+    @MainActor
+    func testCrossContextSaveDoesNotPromptlyRefreshRegisteredInstance() throws {
+        let container = try ModelContainer(
+            for: CrossContextCanaryNote.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+
+        let mainContext = container.mainContext
+        mainContext.insert(CrossContextCanaryNote(id: "n1", title: "Original"))
+        try mainContext.save()
+
+        // The instance a live query / SwiftUI view would be holding.
+        let registered = try XCTUnwrap(mainContext.fetch(FetchDescriptor<CrossContextCanaryNote>()).first)
+
+        // Update the same row through a separate context and save — with no runloop turn in between.
+        let otherContext = ModelContext(container)
+        let other = try XCTUnwrap(otherContext.fetch(FetchDescriptor<CrossContextCanaryNote>()).first)
+        other.title = "Edited"
+        try otherContext.save()
+
+        XCTExpectFailure(
+            "SwiftData still does not auto-merge a cross-context save into a registered mainContext instance"
+        ) {
+            XCTAssertEqual(
+                registered.title, "Edited",
+                "If this passes, SwiftData now merges cross-context saves promptly — single-object "
+                    + "sync(item:) (and inbound sync) can move off the main thread.")
+        }
+    }
+}

--- a/SwiftSync/Tests/SwiftSyncTests/SwiftDataCrossContextMergeCanaryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SwiftDataCrossContextMergeCanaryTests.swift
@@ -14,19 +14,19 @@ final class CrossContextCanaryNote {
 }
 
 final class SwiftDataCrossContextMergeCanaryTests: XCTestCase {
-    /// CANARY for the SwiftData limitation SwiftSync works around. SwiftData has no
-    /// `mergeChanges(fromContextDidSave:)`, so a save on one `ModelContext` does **not** promptly refresh
-    /// an already-registered instance on another context (e.g. the `mainContext` instance a SwiftUI view
-    /// holds). That gap is the *only* reason single-object `sync(item:)` applies on the main thread
-    /// (see the PR that removed `SyncContext`).
+    /// ⛔️ DO NOT MERGE — a standing tracking test that intentionally **fails today**, and whose branch
+    /// must never reach `master` (a red test would block the CI gate). It lives only on its PR.
     ///
-    /// The test asserts the *broken* behavior inside `XCTExpectFailure`: today the registered instance
-    /// stays stale, the inner assertion fails, and the expectation is satisfied (this test passes). If a
-    /// future SwiftData merges cross-context saves promptly, the inner assertion will start **passing** —
-    /// the expectation is then unmet and this test **fails**, signalling that single-object (and inbound)
-    /// sync can move off the main thread.
+    /// SwiftData has no `mergeChanges(fromContextDidSave:)`, so a save on one `ModelContext` does not
+    /// refresh an already-registered instance on another (e.g. the `mainContext` instance a SwiftUI view
+    /// holds). That gap is the only reason single-object `sync(item:)` applies on the main thread.
+    ///
+    /// This asserts the behavior we *want* — a cross-context save promptly reflected on the registered
+    /// instance — so it is **red on the PR today**. The day a newer SwiftData merges promptly, CI on the
+    /// PR turns **green**: the signal to merge this and move single-object (and inbound) sync off the
+    /// main thread.
     @MainActor
-    func testCrossContextSaveDoesNotPromptlyRefreshRegisteredInstance() throws {
+    func testCrossContextSavePromptlyRefreshesRegisteredInstance() throws {
         let container = try ModelContainer(
             for: CrossContextCanaryNote.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true))
@@ -44,13 +44,10 @@ final class SwiftDataCrossContextMergeCanaryTests: XCTestCase {
         other.title = "Edited"
         try otherContext.save()
 
-        XCTExpectFailure(
-            "SwiftData still does not auto-merge a cross-context save into a registered mainContext instance"
-        ) {
-            XCTAssertEqual(
-                registered.title, "Edited",
-                "If this passes, SwiftData now merges cross-context saves promptly — single-object "
-                    + "sync(item:) (and inbound sync) can move off the main thread.")
-        }
+        XCTAssertEqual(
+            registered.title, "Edited",
+            "Expected to FAIL today: SwiftData did not merge the cross-context save into the registered "
+                + "mainContext instance. When this passes, SwiftData merges promptly — single-object "
+                + "sync(item:) (and inbound sync) can move off the main thread, and this PR can merge.")
     }
 }


### PR DESCRIPTION
**⛔️ Do not merge.** A standing tracker — leave it open and red. The branch must never reach `master` (a red test would block the CI gate); the PR's CI status *is* the canary.

## What it is
A **pure-SwiftData** reproduction — no SwiftSync — of the failure SwiftSync works around with its `immediate` flag (commit `5d00aa39`):

> SwiftData has no `mergeChanges(fromContextDidSave:)`, so a save on one `ModelContext` does not refresh an already-registered instance on another (the `mainContext` row a SwiftUI view holds). That's the "offline edit doesn't update the list" bug.

The test isolates the raw mechanics: insert + register a row on `mainContext`, edit + save the same row through a second context, and assert the registered instance reflects it — with nothing from SwiftSync involved.

## How it reads
- **Today:** the registered instance stays stale → the test **fails** → this PR is **red**. Expected.
- **When a newer SwiftData merges cross-context saves promptly:** the test **passes** → the PR goes **green** — the signal that the `immediate`/main-apply workaround can be retired.

## Context
- Solved on the SwiftSync side by `5d00aa39` (the `immediate` flag → later `runOnMain` → `SyncContext`, since simplified): local writes apply on the main context for instant visibility; inbound bulk stays off-main to avoid janking online flows.
- Precedent: the old Core Data `Sync` closed the same gap with `mainContext.mergeChanges(fromContextDidSave:)` — `NSManagedObjectContext` API that `ModelContext` doesn't expose.
- Verified separately: a manual refetch on the main context *does* refresh the registered instance (so the gap is the absence of an *automatic* merge, not an inability to refresh) — but the shipped fix is main-apply.