### PR TITLE
Fix flaky people-edit UI tests (realistic save-dismiss timeout)

### DIFF
--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -51,10 +51,8 @@ private enum DemoSeedTaskID {
 }
 
 final class DemoUITests: XCTestCase {
-    /// How long to wait for the task form to dismiss after a successful save. A save that edits
-    /// reviewers/watchers fans out to several simulated-latency round-trips, so the old 0.5s budget was
-    /// too tight and failed even though the save is correct (~0.6–0.9s to dismiss). 1s clears it with
-    /// margin while still asserting the form actually closes.
+    /// A people-edit save runs three sequential refresh cycles, so the form dismisses just past the old
+    /// 0.5s budget (which flaked); 1s asserts the form closes without re-introducing the flake.
     private let saveDismissTimeout: TimeInterval = 1
 
     override func setUpWithError() throws {

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -51,6 +51,12 @@ private enum DemoSeedTaskID {
 }
 
 final class DemoUITests: XCTestCase {
+    /// How long to wait for the task form to dismiss after a successful save. A save that edits
+    /// reviewers/watchers fans out to several simulated-latency round-trips, so the old 0.5s budget was
+    /// too tight and failed even though the save is correct (~0.6–0.9s to dismiss). 1s clears it with
+    /// margin while still asserting the form actually closes.
+    private let saveDismissTimeout: TimeInterval = 1
+
     override func setUpWithError() throws {
         continueAfterFailure = false
     }
@@ -91,7 +97,7 @@ final class DemoUITests: XCTestCase {
         replaceText(in: app.textFields["task-form.description"], with: "   ", app: app)
         app.buttons["task-form.save"].tap()
 
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
         XCTAssertEqual(detailElement(app, id: "task.title").label, updatedTitle)
         XCTAssertEqual(detailElement(app, id: "task.description").label, normalizedDescription)
 
@@ -157,7 +163,7 @@ final class DemoUITests: XCTestCase {
         app.buttons["task-form.items.1.delete"].tap()
         app.buttons["task-form.save"].tap()
 
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
         XCTAssertTrue(findAfterScrolling(app.staticTexts[renamedItemTitle], in: app))
         XCTAssertTrue(findAfterScrolling(app.staticTexts[addedItemTitle], in: app))
         XCTAssertFalse(app.staticTexts[deletedItemTitle].exists)
@@ -181,7 +187,7 @@ final class DemoUITests: XCTestCase {
         addPerson(app, role: "watchers", userID: DemoSeedUserID.sofiaGarcia)
         app.buttons["task-form.save"].tap()
 
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
         XCTAssertEqual(detailElement(app, id: "task.assignee").label, "Mia Patel")
 
         goBack(app)
@@ -214,7 +220,7 @@ final class DemoUITests: XCTestCase {
         tapAfterScrolling(app.buttons["task-form.assignee.option.\(DemoSeedUserID.miaPatel)"], in: app)
         app.buttons["task-form.save"].tap()
 
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
         XCTAssertEqual(detailElement(app, id: "task.assignee").label, "Mia Patel")
 
         goBack(app)
@@ -249,7 +255,7 @@ final class DemoUITests: XCTestCase {
         replaceText(in: app.textFields["task-form.title"], with: draftTitle, app: app)
         app.buttons["task-form.cancel"].tap()
 
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
         XCTAssertFalse(app.staticTexts[draftTitle].exists)
     }
 
@@ -272,7 +278,7 @@ final class DemoUITests: XCTestCase {
         replaceText(in: app.textFields["task-form.title"], with: editedTitle, app: app)
         app.buttons["task-form.cancel"].tap()
 
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
         XCTAssertEqual(detailElement(app, id: "task.title").label, originalTitle)
 
         goBack(app)
@@ -300,7 +306,7 @@ final class DemoUITests: XCTestCase {
         tapAfterScrolling(app.buttons["task-form.watchers.delete.\(DemoSeedUserID.ethanLee)"], in: app)
         app.buttons["task-form.save"].tap()
 
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
 
         goBack(app)
         openTask(app, id: DemoSeedTaskID.duplicatePushFix)

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -120,3 +120,25 @@ SwiftSync feature.
 
 Each item is its own PR (some a short series). Core stays dependency-free; any concrete transport/bridge
 is a separate SPM product (↔ Networking items 5–6).
+
+### Demo app — follow-ups
+
+- [ ] **Consolidate the online people-edit save into one round-trip.** Editing a task's assignee +
+      reviewers + watchers and saving currently fires **three serial server round-trips** —
+      `DemoSyncEngine.updateTask` → `replaceTaskReviewers` → `replaceTaskWatchers` (driven from the
+      task-form save in `ScreenMachines.swift`, the `_Concurrency.Task` that awaits all three) — and each
+      one calls `syncTaskAfterMutation` (a project-tasks pull + a task-detail pull). So one save ≈ 3
+      mutations + ~6 pulls, all serial. Measured cost with the UI-test network delay disabled is only
+      ~41ms (vs ~18ms for a single update), so it's invisible in tests — but against a **real network**
+      it's 3× serial latency for one save, and it's why the people-edit UI tests needed a looser
+      save-dismiss budget (PR #631 set `saveDismissTimeout` to 1s as a band-aid).
+      **Fix:** carry `reviewer_ids`/`watcher_ids` in the single `updateTask` upsert body (the offline
+      `DemoSyncEngine.taskData` upload path already does exactly this — `export` omits the `@NotExport`
+      reviewers/watchers, so it adds them explicitly), then do **one** `syncTaskAfterMutation`. Drop the
+      separate online `replaceTaskReviewers`/`replaceTaskWatchers` round-trips (or make them local-apply
+      + a single push).
+      **Prerequisite:** the demo backend's task-update endpoint (`DemoServerSimulator`) must honor
+      `reviewer_ids`/`watcher_ids` in the task body (today only the `/sync/upload` upsert path does).
+      **Done when:** a people-edit save is one server round-trip, and the people-edit UI tests pass at the
+      original tight `0.5s` save-dismiss timeout (the right reason), letting `saveDismissTimeout` shrink.
+      Demo-only — no SwiftSync library change.


### PR DESCRIPTION
## What

`testEditTaskPeopleFlow` and `testClearTaskReviewersOrWatchers` were failing. Fix: replace the tight `0.5s` save-dismiss assertion with a named `saveDismissTimeout` (1s).

## Root cause / when it broke

Both assert the task form dismisses within `0.5s` of tapping save. A save that edits **reviewers/watchers** fans out to several sequential simulated-latency round-trips (`updateTask` → `replaceTaskReviewers` → `replaceTaskWatchers`, each followed by a refresh), taking **~0.6–0.9s** to dismiss — just over the budget. Assignee-only edits do one round-trip, stay under `0.5s`, and passed.

Tracked it down: the people-save flow and the `0.5s` assertion both originated in the single squashed SwiftSync import commit (`7ab19239`) — there's no earlier history where they were green. They went unnoticed because **CI doesn't run the UI suite** (no UI job in the workflow), so the suite was only ever run locally. So this isn't a recent regression — it's an under-budgeted timeout that was never gated.

## Fix

A named `saveDismissTimeout` (1s) applied to all seven save-dismiss waits — asserting the behavioral contract "the form closes after a successful save" rather than probing a specific latency. 1s clears the observed ~0.6–0.9s with margin while still catching a save that never completes.

## Verification

Full `DemoUITests` suite (15 tests) green on an iPhone 17 Pro simulator (was 13/15). Confirmed the two tests fail identically on `master` first, so this is the cause.

## Follow-up (not in this PR)

- The people-save does 3 sequential mutation+refresh cycles; consolidating to fewer round-trips would speed it up — a real UX win, but a larger engine change.
- Consider wiring the UI suite into CI so this can't silently rot again.