### PR TITLE
ci: gate iOS simulator tier on ready, add UI tests

### DIFF
--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -30,35 +30,33 @@ jobs:
       - name: Xcode Version
         run: xcodebuild -version && swift --version
 
-      # Ask xcodebuild which simulators are eligible for the Demo scheme, not simctl: simctl lists sims
-      # across every installed runtime, but the app scheme only accepts ones meeting its deployment
-      # target, so a simctl pick can be a UDID xcodebuild rejects. Pick the newest-OS iPhone from the
-      # scheme's own eligible list — no pinned device name (survives runner-image rolls). The same sim
-      # serves the DemoCore test too (its deployment target is a subset of the app's).
-      - name: Select an eligible iPhone simulator for the Demo scheme
+      # Pick the iPhone simulator on the *newest* installed iOS runtime. simctl lists sims across every
+      # runtime; the Demo app only accepts ones meeting its deployment target (the latest runtime), so
+      # selecting by-name or first-found can yield a UDID xcodebuild rejects. Newest-runtime is the
+      # eligible set and needs no pinned device name (survives runner-image rolls). The same sim serves
+      # the DemoCore test too (its deployment target is a subset of the app's).
+      - name: Select an iPhone simulator on the newest iOS runtime
         id: sim
         run: |
-          UDID=$(xcodebuild -showdestinations -workspace SwiftSync.xcworkspace -scheme Demo 2>&1 | python3 -c '
-          import sys, re
+          UDID=$(xcrun simctl list devices available --json | python3 -c '
+          import json, sys, re
+          devices = json.load(sys.stdin)["devices"]
           best = None
-          for line in sys.stdin:
-              if "Ineligible destinations" in line:
-                  break
-              if "platform:iOS Simulator" not in line or "placeholder" in line:
+          for runtime, group in devices.items():
+              match = re.search(r"iOS-(\d+)-(\d+)", runtime)
+              if not match:
                   continue
-              ident = re.search(r"id:([0-9A-Fa-f-]+)", line)
-              name = re.search(r"name:([^}]+)\}", line)
-              version = re.search(r"OS:([0-9.]+)", line)
-              if not (ident and name) or "iPhone" not in name.group(1):
-                  continue
-              parsed = tuple(int(p) for p in (version.group(1).split(".") if version else ["0"]))
-              if best is None or parsed > best[0]:
-                  best = (parsed, ident.group(1), name.group(1).strip())
+              version = (int(match.group(1)), int(match.group(2)))
+              for device in group:
+                  if not device.get("isAvailable") or "iPhone" not in device.get("name", ""):
+                      continue
+                  if best is None or version > best[0]:
+                      best = (version, device["udid"])
           print(best[1] if best else "")
           ')
           if [ -z "$UDID" ]; then
-            echo "::error::No eligible iPhone simulator destination for the Demo scheme."
-            xcodebuild -showdestinations -workspace SwiftSync.xcworkspace -scheme Demo
+            echo "::error::No available iPhone simulator found on the runner."
+            xcrun simctl list devices available
             exit 1
           fi
           echo "Using iPhone simulator $UDID"

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -1,12 +1,10 @@
 name: iOS Simulator
 
-# Ready-gated pre-merge tier: the simulator-bound tests — the DemoUITests UI suite plus the iOS-specific
-# dirty-tracking regression (a DemoCore test that the macOS `swift test` in ci.yml can't catch, since the
-# gap only shows on iOS). One job: a simulator boot + app build is the expensive part, so both share it
-# and report a single check. It runs only once a PR is marked ready for review — not on every draft push.
-# `ready_for_review` is in `types` because marking a draft ready adds no commit and would otherwise not
-# re-trigger anything; the `if` skips the job while the PR is a draft (a skipped required check still
-# reports success, so drafts stay mergeable-clean). No `push: master` trigger: this tier is pre-merge only.
+# Ready-gated pre-merge tier: the slow simulator-bound tests — the DemoUITests suite and the iOS-specific
+# dirty-tracking regression (a DemoCore test the macOS `swift test` in ci.yml can't catch — the gap only
+# shows on iOS). `ready_for_review` is in `types` because marking a draft ready adds no commit and would
+# otherwise not re-trigger; the per-job `if` skips it while the PR is a draft — and a skipped required
+# check still reports success, so drafts stay mergeable-clean.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -30,11 +28,9 @@ jobs:
       - name: Xcode Version
         run: xcodebuild -version && swift --version
 
-      # Pick the iPhone simulator on the *newest* installed iOS runtime. simctl lists sims across every
-      # runtime; the Demo app only accepts ones meeting its deployment target (the latest runtime), so
-      # selecting by-name or first-found can yield a UDID xcodebuild rejects. Newest-runtime is the
-      # eligible set and needs no pinned device name (survives runner-image rolls). The same sim serves
-      # the DemoCore test too (its deployment target is a subset of the app's).
+      # Pick the iPhone on the newest installed iOS runtime. simctl lists sims across every runtime, but
+      # the Demo app only accepts ones meeting its deployment target (the latest runtime) — a by-name or
+      # first-found pick can yield a UDID xcodebuild rejects. No pinned device name (survives image rolls).
       - name: Select an iPhone simulator on the newest iOS runtime
         id: sim
         run: |
@@ -71,9 +67,7 @@ jobs:
             -destination "id=${{ steps.sim.outputs.udid }}" \
             -only-testing:DemoCoreTests/DirtyTrackingGapTests
 
-      # The whole DemoUITests target via the Demo app scheme. No code signing on the simulator.
-      # `-retry-tests-on-failure` absorbs the occasional first-launch/UI-timing flake without masking a
-      # genuinely broken test (a real failure still fails every attempt).
+      # -retry-tests-on-failure absorbs first-launch/UI-timing flake; a real failure still fails every attempt.
       - name: UI tests — DemoUITests
         run: |
           xcodebuild test \

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -1,13 +1,14 @@
-name: iOS Regression
+name: iOS Simulator
 
-# Pre-merge gate: the dirty-tracking gap is iOS-specific, so the macOS `swift test`
-# in ci.yml can pass while iOS behaves differently. Run the iOS-Simulator regression
-# on every PR (and on master pushes) so it can actually block a regression — a
-# post-merge-only check only reports the breakage after it has already landed.
+# Ready-gated pre-merge tier: the slow, simulator-bound checks (iOS dirty-tracking regression and the
+# UI suite). These cost a simulator boot + app build, so they run only once a PR is marked ready for
+# review — not on every draft push during iteration. `ready_for_review` is in `types` because marking a
+# draft ready adds no commit and would otherwise not re-trigger anything; the `if` on each job skips
+# them while the PR is still a draft (a skipped required check still reports success, so drafts stay
+# mergeable-clean). No `push: master` trigger: this tier gates pre-merge only.
 on:
   pull_request:
-  push:
-    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +21,7 @@ jobs:
   ios-dirty-tracking:
     name: iOS Dirty-Tracking Regression
     runs-on: macos-15
+    if: github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v5
@@ -56,3 +58,50 @@ jobs:
             -scheme DemoCore \
             -destination "id=${{ steps.sim.outputs.udid }}" \
             -only-testing:DemoCoreTests/DirtyTrackingGapTests
+
+  ui-tests:
+    name: UI Tests
+    runs-on: macos-15
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Xcode Version
+        run: xcodebuild -version && swift --version
+
+      - name: Select an available iPhone simulator
+        id: sim
+        run: |
+          UDID=$(xcrun simctl list devices available --json | python3 -c '
+          import json, sys
+          devices = json.load(sys.stdin)["devices"]
+          candidates = [
+              d for runtime, ds in devices.items() if "iOS" in runtime
+              for d in ds if d.get("isAvailable") and "iPhone" in d.get("name", "")
+          ]
+          print(candidates[0]["udid"] if candidates else "")
+          ')
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator found on the runner."
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "Using iPhone simulator $UDID"
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+
+      # The whole DemoUITests target via the Demo app scheme. No code signing on the simulator.
+      # `-retry-tests-on-failure` absorbs the occasional first-launch/UI-timing flake without masking a
+      # genuinely broken test (a real failure still fails every attempt).
+      - name: Test — DemoUITests (iOS Simulator)
+        run: |
+          xcodebuild test \
+            -workspace SwiftSync.xcworkspace \
+            -scheme Demo \
+            -destination "id=${{ steps.sim.outputs.udid }}" \
+            -only-testing:DemoUITests \
+            -parallel-testing-enabled NO \
+            -retry-tests-on-failure \
+            -test-iterations 3 \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_IDENTITY=''

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -1,11 +1,12 @@
 name: iOS Simulator
 
-# Ready-gated pre-merge tier: the slow, simulator-bound checks (iOS dirty-tracking regression and the
-# UI suite). These cost a simulator boot + app build, so they run only once a PR is marked ready for
-# review — not on every draft push during iteration. `ready_for_review` is in `types` because marking a
-# draft ready adds no commit and would otherwise not re-trigger anything; the `if` on each job skips
-# them while the PR is still a draft (a skipped required check still reports success, so drafts stay
-# mergeable-clean). No `push: master` trigger: this tier gates pre-merge only.
+# Ready-gated pre-merge tier: the simulator-bound tests — the DemoUITests UI suite plus the iOS-specific
+# dirty-tracking regression (a DemoCore test that the macOS `swift test` in ci.yml can't catch, since the
+# gap only shows on iOS). One job: a simulator boot + app build is the expensive part, so both share it
+# and report a single check. It runs only once a PR is marked ready for review — not on every draft push.
+# `ready_for_review` is in `types` because marking a draft ready adds no commit and would otherwise not
+# re-trigger anything; the `if` skips the job while the PR is a draft (a skipped required check still
+# reports success, so drafts stay mergeable-clean). No `push: master` trigger: this tier is pre-merge only.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -18,8 +19,8 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
 
 jobs:
-  ios-dirty-tracking:
-    name: iOS Dirty-Tracking Regression
+  ios-simulator:
+    name: iOS Simulator Tests
     runs-on: macos-15
     if: github.event.pull_request.draft == false
 
@@ -29,29 +30,42 @@ jobs:
       - name: Xcode Version
         run: xcodebuild -version && swift --version
 
-      # Pick whatever iPhone simulator the runner image ships — don't pin a device name,
-      # which breaks whenever GitHub rolls the macos image (e.g. iPhone 16 Pro -> 17 Pro).
-      - name: Select an available iPhone simulator
+      # Ask xcodebuild which simulators are eligible for the Demo scheme, not simctl: simctl lists sims
+      # across every installed runtime, but the app scheme only accepts ones meeting its deployment
+      # target, so a simctl pick can be a UDID xcodebuild rejects. Pick the newest-OS iPhone from the
+      # scheme's own eligible list — no pinned device name (survives runner-image rolls). The same sim
+      # serves the DemoCore test too (its deployment target is a subset of the app's).
+      - name: Select an eligible iPhone simulator for the Demo scheme
         id: sim
         run: |
-          UDID=$(xcrun simctl list devices available --json | python3 -c '
-          import json, sys
-          devices = json.load(sys.stdin)["devices"]
-          candidates = [
-              d for runtime, ds in devices.items() if "iOS" in runtime
-              for d in ds if d.get("isAvailable") and "iPhone" in d.get("name", "")
-          ]
-          print(candidates[0]["udid"] if candidates else "")
+          UDID=$(xcodebuild -showdestinations -workspace SwiftSync.xcworkspace -scheme Demo 2>&1 | python3 -c '
+          import sys, re
+          best = None
+          for line in sys.stdin:
+              if "Ineligible destinations" in line:
+                  break
+              if "platform:iOS Simulator" not in line or "placeholder" in line:
+                  continue
+              ident = re.search(r"id:([0-9A-Fa-f-]+)", line)
+              name = re.search(r"name:([^}]+)\}", line)
+              version = re.search(r"OS:([0-9.]+)", line)
+              if not (ident and name) or "iPhone" not in name.group(1):
+                  continue
+              parsed = tuple(int(p) for p in (version.group(1).split(".") if version else ["0"]))
+              if best is None or parsed > best[0]:
+                  best = (parsed, ident.group(1), name.group(1).strip())
+          print(best[1] if best else "")
           ')
           if [ -z "$UDID" ]; then
-            echo "::error::No available iPhone simulator found on the runner."
-            xcrun simctl list devices available
+            echo "::error::No eligible iPhone simulator destination for the Demo scheme."
+            xcodebuild -showdestinations -workspace SwiftSync.xcworkspace -scheme Demo
             exit 1
           fi
           echo "Using iPhone simulator $UDID"
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
 
-      - name: Test — DirtyTrackingGapTests (iOS Simulator)
+      # Fast, deterministic — run it first so a regression here fails before the slow UI suite.
+      - name: iOS regression — DirtyTrackingGapTests (DemoCore)
         working-directory: DemoCore
         run: |
           xcodebuild test \
@@ -59,41 +73,10 @@ jobs:
             -destination "id=${{ steps.sim.outputs.udid }}" \
             -only-testing:DemoCoreTests/DirtyTrackingGapTests
 
-  ui-tests:
-    name: UI Tests
-    runs-on: macos-15
-    if: github.event.pull_request.draft == false
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Xcode Version
-        run: xcodebuild -version && swift --version
-
-      - name: Select an available iPhone simulator
-        id: sim
-        run: |
-          UDID=$(xcrun simctl list devices available --json | python3 -c '
-          import json, sys
-          devices = json.load(sys.stdin)["devices"]
-          candidates = [
-              d for runtime, ds in devices.items() if "iOS" in runtime
-              for d in ds if d.get("isAvailable") and "iPhone" in d.get("name", "")
-          ]
-          print(candidates[0]["udid"] if candidates else "")
-          ')
-          if [ -z "$UDID" ]; then
-            echo "::error::No available iPhone simulator found on the runner."
-            xcrun simctl list devices available
-            exit 1
-          fi
-          echo "Using iPhone simulator $UDID"
-          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
-
       # The whole DemoUITests target via the Demo app scheme. No code signing on the simulator.
       # `-retry-tests-on-failure` absorbs the occasional first-launch/UI-timing flake without masking a
       # genuinely broken test (a real failure still fails every attempt).
-      - name: Test — DemoUITests (iOS Simulator)
+      - name: UI tests — DemoUITests
         run: |
           xcodebuild test \
             -workspace SwiftSync.xcworkspace \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@
 
 - Default: run `swift test` (macOS/SPM) only.
 - Exception: if a task changes `Demo/Demo/**`, run the relevant demo app build even if the user did not explicitly ask for `xcodebuild`.
-- iOS regression runs automatically post-merge via `ios-regression.yml` — that is the gate.
-- If a task touches `Core.swift`, `MacrosImplementation/`, or `SyncableMacro.swift`, note in
-  the plan that the iOS regression will run on merge.
+- CI is split by the draft/ready signal:
+  - **Every push (draft included)** runs the fast tier in `ci.yml`: swift-format, macOS `swift test` (×3 packages), the warnings gate, doc-links, and the perf subset.
+  - **Only when a PR is marked ready for review** does the slow simulator tier in `ios-regression.yml` run: the iOS dirty-tracking regression and the `DemoUITests` UI suite. They skip on drafts (a skipped check still reports success) and there is no master-push run — this tier is pre-merge only.
+- So mark a PR **ready** to trigger the iOS regression + UI tests, then verify them green before merging. If a task touches `Core.swift`, `MacrosImplementation/`, or `SyncableMacro.swift`, note in the plan that marking the PR ready will run that simulator tier.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,5 +111,5 @@
 - Exception: if a task changes `Demo/Demo/**`, run the relevant demo app build even if the user did not explicitly ask for `xcodebuild`.
 - CI is split by the draft/ready signal:
   - **Every push (draft included)** runs the fast tier in `ci.yml`: swift-format, macOS `swift test` (×3 packages), the warnings gate, doc-links, and the perf subset.
-  - **Only when a PR is marked ready for review** does the slow simulator tier in `ios-regression.yml` run: the iOS dirty-tracking regression and the `DemoUITests` UI suite. They skip on drafts (a skipped check still reports success) and there is no master-push run — this tier is pre-merge only.
-- So mark a PR **ready** to trigger the iOS regression + UI tests, then verify them green before merging. If a task touches `Core.swift`, `MacrosImplementation/`, or `SyncableMacro.swift`, note in the plan that marking the PR ready will run that simulator tier.
+  - **Only when a PR is marked ready for review** does the slow simulator tier in `ios-regression.yml` run — one `iOS Simulator Tests` job that runs both the `DemoUITests` UI suite and the iOS-specific dirty-tracking regression (`DirtyTrackingGapTests`) on a simulator. It skips on drafts (a skipped check still reports success) and there is no master-push run — this tier is pre-merge only.
+- So mark a PR **ready** to trigger the `iOS Simulator Tests` gate, then verify it green before merging. If a task touches `Core.swift`, `MacrosImplementation/`, or `SyncableMacro.swift`, note in the plan that marking the PR ready will run that simulator tier.

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -53,9 +53,8 @@ private enum DemoSeedTaskID {
 final class DemoUITests: XCTestCase {
     /// A people-edit save runs three sequential refresh cycles, so the form dismisses just past the old
     /// 0.5s budget (which flaked); 1s asserts the form closes without re-introducing the flake.
-    // The people-edit save is one server round-trip, so the form dismisses in well under a second;
-    // 3s is headroom for normal CI jitter. waitForNonExistence returns the instant it dismisses, so a
-    // passing test isn't slowed — and on a real failure it fails in 3s, not a bloated ceiling × retries.
+    // One-round-trip save → the form dismisses well under a second; 3s is jitter headroom. waitForNonExistence
+    // returns on dismiss, so a passing test isn't slowed and a real failure still fails fast.
     private let saveDismissTimeout: TimeInterval = 3
 
     override func setUpWithError() throws {

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -53,7 +53,10 @@ private enum DemoSeedTaskID {
 final class DemoUITests: XCTestCase {
     /// A people-edit save runs three sequential refresh cycles, so the form dismisses just past the old
     /// 0.5s budget (which flaked); 1s asserts the form closes without re-introducing the flake.
-    private let saveDismissTimeout: TimeInterval = 1
+    // Generous ceiling, not a tuned number: waitForNonExistence returns the instant the form dismisses,
+    // so a large value never slows a passing test — it only stops false failures when the shared CI
+    // runner is slow (a tight 1s flaked unrelated save tests under load).
+    private let saveDismissTimeout: TimeInterval = 10
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -339,7 +342,7 @@ final class DemoUITests: XCTestCase {
         replaceText(in: app.textFields["task-form.title"], with: title, app: app)
         XCTAssertTrue(app.buttons["task-form.save"].isEnabled, "offline create works with cached reference data")
         app.buttons["task-form.save"].tap()
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 1))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
 
         // It appears locally and is queued.
         XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
@@ -378,7 +381,7 @@ final class DemoUITests: XCTestCase {
         openCreateTaskForm(app)
         replaceText(in: app.textFields["task-form.title"], with: originalTitle, app: app)
         app.buttons["task-form.save"].tap()
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 1))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
         XCTAssertTrue(findAfterScrolling(app.staticTexts[originalTitle], in: app))
 
         // Open it and rename it offline.
@@ -387,7 +390,7 @@ final class DemoUITests: XCTestCase {
         openEditTaskForm(app)
         replaceText(in: app.textFields["task-form.title"], with: updatedTitle, app: app)
         app.buttons["task-form.save"].tap()
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 1))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
         XCTAssertEqual(detailElement(app, id: "task.title").label, updatedTitle, "the detail shows the new title")
 
         // Back on the project list, the row reflects the edit — not the stale original title.
@@ -411,7 +414,7 @@ final class DemoUITests: XCTestCase {
         openEditTaskForm(app)
         replaceText(in: app.textFields["task-form.title"], with: String(repeating: "A", count: 100), app: app)
         app.buttons["task-form.save"].tap()
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 2))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
 
         // Reconnect: auto-sync pushes it, the server rejects it, and it surfaces in the inbox.
         app.buttons["offline-toggle"].tap()
@@ -447,7 +450,8 @@ final class DemoUITests: XCTestCase {
         addPerson(app, role: "reviewers", userID: DemoSeedUserID.sofiaGarcia)
         app.buttons["task-form.save"].tap()
         XCTAssertTrue(
-            app.buttons["task-form.save"].waitForNonExistence(timeout: 2), "an offline edit saves locally")
+            app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout),
+            "an offline edit saves locally")
         XCTAssertTrue(findAfterScrolling(app.staticTexts["task.reviewer.\(DemoSeedUserID.sofiaGarcia)"], in: app))
 
         // Reconnect → the change auto-syncs.

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -53,10 +53,10 @@ private enum DemoSeedTaskID {
 final class DemoUITests: XCTestCase {
     /// A people-edit save runs three sequential refresh cycles, so the form dismisses just past the old
     /// 0.5s budget (which flaked); 1s asserts the form closes without re-introducing the flake.
-    // Generous ceiling, not a tuned number: waitForNonExistence returns the instant the form dismisses,
-    // so a large value never slows a passing test — it only stops false failures when the shared CI
-    // runner is slow (a tight 1s flaked unrelated save tests under load).
-    private let saveDismissTimeout: TimeInterval = 10
+    // The people-edit save is one server round-trip, so the form dismisses in well under a second;
+    // 3s is headroom for normal CI jitter. waitForNonExistence returns the instant it dismisses, so a
+    // passing test isn't slowed — and on a real failure it fails in 3s, not a bloated ceiling × retries.
+    private let saveDismissTimeout: TimeInterval = 3
 
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -398,8 +398,6 @@ public final class DemoServerSimulator {
             items: items
         )
 
-        // Relationship edits ride in the same create when present (mirrors /sync/upload), keeping a
-        // create-with-people a single round-trip. Reuse the row just created.
         guard body["reviewer_ids"] is [String] || body["watcher_ids"] is [String],
             let rowID = try taskRowID(forPublicID: publicID, includeTombstoned: true)
         else { return created }
@@ -595,9 +593,6 @@ public final class DemoServerSimulator {
             throw error
         }
 
-        // Relationship edits ride in the same update when present (mirrors /sync/upload), so an online
-        // people edit is one round-trip rather than separate /reviewers and /watchers calls. Absent keys
-        // leave the sets untouched; an explicit (possibly empty) array replaces them.
         if let reviewerIDs = body["reviewer_ids"] as? [String] {
             _ = try replaceReviewers(rowID: taskID, reviewerIDs: reviewerIDs)
         }
@@ -678,8 +673,6 @@ public final class DemoServerSimulator {
                 "UPDATE tasks SET deleted_at = NULL WHERE id = ?",
                 bind: { stmt in self.sqlite.bind(int: existingID, at: 1, in: stmt) }
             )
-            // updateTaskInternal/createTask apply any reviewer_ids/watcher_ids in the body themselves,
-            // so the relationship edits ride in this one operation without a second resolve.
             _ = try updateTaskInternal(rowID: existingID, body: body)
         } else {
             _ = try createTask(body: body)

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -385,7 +385,7 @@ public final class DemoServerSimulator {
             items = []
         }
 
-        return try createTaskInternal(
+        let created = try createTaskInternal(
             publicID: publicID,
             projectID: projectID,
             title: title,
@@ -397,6 +397,19 @@ public final class DemoServerSimulator {
             updatedAt: updatedAt,
             items: items
         )
+
+        // Relationship edits ride in the same create when present (mirrors /sync/upload), keeping a
+        // create-with-people a single round-trip. Reuse the row just created.
+        guard body["reviewer_ids"] is [String] || body["watcher_ids"] is [String],
+            let rowID = try taskRowID(forPublicID: publicID, includeTombstoned: true)
+        else { return created }
+        if let reviewerIDs = body["reviewer_ids"] as? [String] {
+            _ = try replaceReviewers(rowID: rowID, reviewerIDs: reviewerIDs)
+        }
+        if let watcherIDs = body["watcher_ids"] as? [String] {
+            _ = try replaceWatchers(rowID: rowID, watcherIDs: watcherIDs)
+        }
+        return try taskDetailPayload(rowID: rowID) ?? created
     }
 
     @discardableResult
@@ -582,6 +595,16 @@ public final class DemoServerSimulator {
             throw error
         }
 
+        // Relationship edits ride in the same update when present (mirrors /sync/upload), so an online
+        // people edit is one round-trip rather than separate /reviewers and /watchers calls. Absent keys
+        // leave the sets untouched; an explicit (possibly empty) array replaces them.
+        if let reviewerIDs = body["reviewer_ids"] as? [String] {
+            _ = try replaceReviewers(rowID: taskID, reviewerIDs: reviewerIDs)
+        }
+        if let watcherIDs = body["watcher_ids"] as? [String] {
+            _ = try replaceWatchers(rowID: taskID, watcherIDs: watcherIDs)
+        }
+
         guard let result = try taskDetailPayload(rowID: taskID) else {
             throw DemoBackendError.notFound(entity: "task", id: String(taskID))
         }
@@ -642,7 +665,6 @@ public final class DemoServerSimulator {
         var body = data
         body["id"] = localID
 
-        let rowID: Int
         if let existingID = try taskRowID(forPublicID: localID, includeTombstoned: true) {
             if try isStale(rowID: existingID, incoming: incoming) {
                 return [
@@ -656,22 +678,11 @@ public final class DemoServerSimulator {
                 "UPDATE tasks SET deleted_at = NULL WHERE id = ?",
                 bind: { stmt in self.sqlite.bind(int: existingID, at: 1, in: stmt) }
             )
+            // updateTaskInternal/createTask apply any reviewer_ids/watcher_ids in the body themselves,
+            // so the relationship edits ride in this one operation without a second resolve.
             _ = try updateTaskInternal(rowID: existingID, body: body)
-            rowID = existingID
         } else {
             _ = try createTask(body: body)
-            guard let createdID = try taskRowID(forPublicID: localID) else {
-                throw DemoBackendError.notFound(entity: "task", id: localID)
-            }
-            rowID = createdID
-        }
-        // Relationship edits (reviewers/watchers) ride in the same operation when present. They reuse the
-        // already-resolved row id, so they don't re-look-up the public_id.
-        if let reviewerIDs = data["reviewer_ids"] as? [String] {
-            _ = try replaceReviewers(rowID: rowID, reviewerIDs: reviewerIDs)
-        }
-        if let watcherIDs = data["watcher_ids"] as? [String] {
-            _ = try replaceWatchers(rowID: rowID, watcherIDs: watcherIDs)
         }
         return ["operation": "upsert", "localId": localID, "status": "applied"]
     }

--- a/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
@@ -614,8 +614,6 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertEqual(before["reviewer_ids"] as? [String], [userID])
         XCTAssertEqual(before["watcher_ids"] as? [String], [userID])
 
-        // A single task update carrying reviewer_ids/watcher_ids applies them in one round-trip — so a
-        // people edit need not fan out to the separate /reviewers and /watchers endpoints.
         let cleared = try backend.updateTask(
             publicID: taskID,
             body: [
@@ -634,7 +632,6 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertEqual(reset["reviewer_ids"] as? [String], [userID])
         XCTAssertEqual(reset["watcher_ids"] as? [String], [userID])
 
-        // Absent keys leave people untouched — a title-only edit must not clear reviewers/watchers.
         let titleOnly = try backend.updateTask(
             publicID: taskID,
             body: ["title": "t2", "description": "d", "state": ["id": "todo"]])

--- a/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
@@ -604,6 +604,44 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertEqual(updated["created_at"] as? String, before?["created_at"] as? String)
     }
 
+    func testUpdateTaskFromBodyHonorsReviewerAndWatcherIDs() throws {
+        let url = makeTemporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
+
+        let before = try XCTUnwrap(backend.getTaskDetailPayload(publicID: taskID))
+        XCTAssertEqual(before["reviewer_ids"] as? [String], [userID])
+        XCTAssertEqual(before["watcher_ids"] as? [String], [userID])
+
+        // A single task update carrying reviewer_ids/watcher_ids applies them in one round-trip — so a
+        // people edit need not fan out to the separate /reviewers and /watchers endpoints.
+        let cleared = try backend.updateTask(
+            publicID: taskID,
+            body: [
+                "title": "t", "description": "d", "state": ["id": "todo"],
+                "reviewer_ids": [], "watcher_ids": [],
+            ])
+        XCTAssertEqual(cleared["reviewer_ids"] as? [String], [])
+        XCTAssertEqual(cleared["watcher_ids"] as? [String], [])
+
+        let reset = try backend.updateTask(
+            publicID: taskID,
+            body: [
+                "title": "t", "description": "d", "state": ["id": "todo"],
+                "reviewer_ids": [userID], "watcher_ids": [userID],
+            ])
+        XCTAssertEqual(reset["reviewer_ids"] as? [String], [userID])
+        XCTAssertEqual(reset["watcher_ids"] as? [String], [userID])
+
+        // Absent keys leave people untouched — a title-only edit must not clear reviewers/watchers.
+        let titleOnly = try backend.updateTask(
+            publicID: taskID,
+            body: ["title": "t2", "description": "d", "state": ["id": "todo"]])
+        XCTAssertEqual(titleOnly["reviewer_ids"] as? [String], [userID])
+        XCTAssertEqual(titleOnly["watcher_ids"] as? [String], [userID])
+    }
+
     func testUpdateTaskFromBodyDictAllowsClearingDescriptionToNull() throws {
         let url = makeTemporaryDatabaseURL()
         defer { try? FileManager.default.removeItem(at: url) }

--- a/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
+++ b/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
@@ -372,9 +372,8 @@ public final class TaskFormSheetMachine {
             let capturedReviewerIDs = draft.reviewers.map(\.id).sorted()
             let capturedWatcherIDs = draft.watchers.map(\.id).sorted()
 
-            // Bundle the people edit into the same create/update body (reviewers/watchers are @NotExport,
-            // so add them explicitly) — one round-trip, not separate /reviewers and /watchers calls. Only
-            // include a set when it actually changed, so a non-people edit doesn't churn reviewers.
+            // reviewers/watchers are @NotExport, so add them to the body explicitly — and only when
+            // changed, so a non-people edit doesn't churn them.
             switch mode {
             case .create:
                 if !capturedReviewerIDs.isEmpty { body["reviewer_ids"] = capturedReviewerIDs }

--- a/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
+++ b/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
@@ -368,57 +368,35 @@ public final class TaskFormSheetMachine {
 
             guard saveMachine.send(.submit) else { return }
 
-            let body = syncContainer.export(draft)
+            var body = syncContainer.export(draft)
             let capturedReviewerIDs = draft.reviewers.map(\.id).sorted()
             let capturedWatcherIDs = draft.watchers.map(\.id).sorted()
 
-            var reviewersChanged = false
-            var watchersChanged = false
-            if case .edit(let originalTask) = mode {
-                let originalReviewerIDs = Set(originalTask.reviewers.map(\.id))
-                let originalWatcherIDs = Set(originalTask.watchers.map(\.id))
-                reviewersChanged = Set(capturedReviewerIDs) != originalReviewerIDs
-                watchersChanged = Set(capturedWatcherIDs) != originalWatcherIDs
+            // Bundle the people edit into the same create/update body (reviewers/watchers are @NotExport,
+            // so add them explicitly) — one round-trip, not separate /reviewers and /watchers calls. Only
+            // include a set when it actually changed, so a non-people edit doesn't churn reviewers.
+            switch mode {
+            case .create:
+                if !capturedReviewerIDs.isEmpty { body["reviewer_ids"] = capturedReviewerIDs }
+                if !capturedWatcherIDs.isEmpty { body["watcher_ids"] = capturedWatcherIDs }
+            case .edit(let originalTask):
+                if Set(capturedReviewerIDs) != Set(originalTask.reviewers.map(\.id)) {
+                    body["reviewer_ids"] = capturedReviewerIDs
+                }
+                if Set(capturedWatcherIDs) != Set(originalTask.watchers.map(\.id)) {
+                    body["watcher_ids"] = capturedWatcherIDs
+                }
             }
+            let requestBody = body
 
             _Concurrency.Task {
                 do {
+                    let payload = try DemoSyncPayload(dictionary: requestBody)
                     switch mode {
                     case .create(let projectID):
-                        let createPayload = try DemoSyncPayload(dictionary: body)
-                        try await syncEngine.createTask(body: createPayload, projectID: projectID)
-                        if !capturedReviewerIDs.isEmpty {
-                            try await syncEngine.replaceTaskReviewers(
-                                taskID: draft.id,
-                                projectID: projectID,
-                                reviewerIDs: capturedReviewerIDs
-                            )
-                        }
-                        if !capturedWatcherIDs.isEmpty {
-                            try await syncEngine.replaceTaskWatchers(
-                                taskID: draft.id,
-                                projectID: projectID,
-                                watcherIDs: capturedWatcherIDs
-                            )
-                        }
-
+                        try await syncEngine.createTask(body: payload, projectID: projectID)
                     case .edit(let task):
-                        let updatePayload = try DemoSyncPayload(dictionary: body)
-                        try await syncEngine.updateTask(taskID: task.id, projectID: task.projectID, body: updatePayload)
-                        if reviewersChanged {
-                            try await syncEngine.replaceTaskReviewers(
-                                taskID: task.id,
-                                projectID: task.projectID,
-                                reviewerIDs: capturedReviewerIDs
-                            )
-                        }
-                        if watchersChanged {
-                            try await syncEngine.replaceTaskWatchers(
-                                taskID: task.id,
-                                projectID: task.projectID,
-                                watcherIDs: capturedWatcherIDs
-                            )
-                        }
+                        try await syncEngine.updateTask(taskID: task.id, projectID: task.projectID, body: payload)
                     }
                     await MainActor.run {
                         _ = saveMachine.send(.success)

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -224,15 +224,23 @@ public final class DemoSyncEngine {
     /// pending change — unlike `syncContainer.sync(item:)`, which stamps writes as inbound (pulled).
     /// Reuses the `@Syncable`-generated `make`/`apply`, so no field mapping is duplicated here.
     private func applyLocalTask(_ body: DemoSyncPayload, project: Project? = nil) throws {
-        let payload = SyncPayload(values: body.toSyncPayloadDictionary(), keyStyle: syncContainer.keyStyle)
+        let values = body.toSyncPayloadDictionary()
+        let payload = SyncPayload(values: values, keyStyle: syncContainer.keyStyle)
         let context = syncContainer.mainContext
-        if let id = payload.value(for: "id", as: String.self), let existing = try task(withID: id) {
+        let task: Task
+        if let id = payload.value(for: "id", as: String.self), let existing = try self.task(withID: id) {
             _ = try existing.apply(payload)
+            task = existing
         } else {
             let created = try Task.make(from: payload)
             context.insert(created)
             if let project { created.project = project }
+            task = created
         }
+        // reviewers/watchers are @NotExport, so apply()/make() won't set them from the body. Apply the
+        // relationships explicitly so an offline people edit shows locally before any server round-trip.
+        if let reviewerIDs = values["reviewer_ids"] as? [String] { task.reviewers = try users(for: reviewerIDs) }
+        if let watcherIDs = values["watcher_ids"] as? [String] { task.watchers = try users(for: watcherIDs) }
         try context.save()
     }
 

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -302,6 +302,41 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertEqual(edited.project?.id, projectID, "the edit must not drop the project link")
     }
 
+    /// The task-form save carries `reviewer_ids` in the `updateTask` body (one round-trip). Offline,
+    /// the local apply must reflect the reviewers immediately even though `reviewers` is `@NotExport`
+    /// (so `Task.apply` won't set it from the body) — otherwise an offline people edit shows nothing
+    /// until a server round-trip that never happens while offline.
+    @MainActor
+    func testOfflineUpdateTaskWithReviewerIDsAppliesLocally() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("offline-update-people-\(UUID().uuidString).sqlite")
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        let backend = try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
+        let apiClient = FakeDemoAPIClient(backend: backend)
+        let syncContainer = try makeSyncContainer()
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+        try await engine.syncTaskDetail(taskID: taskID)
+        try await engine.syncTaskFormMetadata()  // cache the users to assign
+
+        let task = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        let newReviewers = [DemoSeedData.SeedIDs.Users.miaPatel, DemoSeedData.SeedIDs.Users.ethanLee].sorted()
+
+        engine.isOffline = true
+        var body = syncContainer.export(task)
+        body["reviewer_ids"] = newReviewers
+        try await engine.updateTask(
+            taskID: taskID, projectID: projectID, body: try DemoSyncPayload(dictionary: body))
+
+        let offline = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertEqual(
+            offline.reviewers.map(\.id).sorted(), newReviewers,
+            "an offline updateTask with reviewer_ids must apply the reviewers to the local row")
+    }
+
     /// Only `Task` is marked offline, yet a `Task`↔`User` relationship edit made offline (assigning
     /// reviewers) round-trips: assigning a person is a local *Task* update — the linked `User` is
     /// pull-only and never needs to be offline. After reconnect+push the server has the new reviewers,

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -302,10 +302,8 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertEqual(edited.project?.id, projectID, "the edit must not drop the project link")
     }
 
-    /// The task-form save carries `reviewer_ids` in the `updateTask` body (one round-trip). Offline,
-    /// the local apply must reflect the reviewers immediately even though `reviewers` is `@NotExport`
-    /// (so `Task.apply` won't set it from the body) — otherwise an offline people edit shows nothing
-    /// until a server round-trip that never happens while offline.
+    /// Regression: an offline `updateTask` with `reviewer_ids` must apply reviewers locally (`apply()`
+    /// skips the `@NotExport` relationship, so there's no server round-trip to reflect it).
     @MainActor
     func testOfflineUpdateTaskWithReviewerIDsAppliesLocally() async throws {
         let url = FileManager.default.temporaryDirectory

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -126,11 +126,11 @@ is a separate SPM product (↔ Networking items 5–6).
 - [x] **Consolidate the online people-edit save into one round-trip.** Done: `updateTask`/`createTask`
       now honor `reviewer_ids`/`watcher_ids` in the task body (the `.save` handler in `ScreenMachines.swift`
       adds the `@NotExport` people to the body and drops the separate `replaceTaskReviewers`/
-      `replaceTaskWatchers` calls), so a people edit is a single server round-trip. Separately, all the
-      UI save-dismiss waits were unified on a generous `saveDismissTimeout` (10s): the first CI UI run
-      showed a slow shared runner flaking unrelated save tests at the old tight 1s/2s ceilings, and a
-      `waitForNonExistence` ceiling returns the instant the form dismisses, so generous never slows a
-      passing test (the durability rule — pin a behavioral ceiling, not a machine-tuned number).
+      `replaceTaskWatchers` calls), so a people edit is a single server round-trip. The offline local
+      apply (`applyLocalTask`) sets the `@NotExport` reviewers/watchers relationships from the body, since
+      `apply()` won't — so an offline people edit shows before any round-trip. UI save-dismiss waits were
+      unified on one `saveDismissTimeout` (3s — sized for a one-round-trip save plus CI jitter, not a
+      bloated ceiling: `waitForNonExistence` returns on dismiss, so a real failure still fails fast).
 
 ### Offline / two-id identity model — follow-ups (PR #632)
 

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -123,25 +123,12 @@ is a separate SPM product (↔ Networking items 5–6).
 
 ### Demo app — follow-ups
 
-- [ ] **Consolidate the online people-edit save into one round-trip.** Editing a task's assignee +
-      reviewers + watchers and saving currently fires **three serial server round-trips** —
-      `DemoSyncEngine.updateTask` → `replaceTaskReviewers` → `replaceTaskWatchers` (driven from the
-      task-form save in `ScreenMachines.swift`, the `_Concurrency.Task` that awaits all three) — and each
-      one calls `syncTaskAfterMutation` (a project-tasks pull + a task-detail pull). So one save ≈ 3
-      mutations + ~6 pulls, all serial. Measured cost with the UI-test network delay disabled is only
-      ~41ms (vs ~18ms for a single update), so it's invisible in tests — but against a **real network**
-      it's 3× serial latency for one save, and it's why the people-edit UI tests needed a looser
-      save-dismiss budget (PR #631 set `saveDismissTimeout` to 1s as a band-aid).
-      **Fix:** carry `reviewer_ids`/`watcher_ids` in the single `updateTask` upsert body (the offline
-      `DemoSyncEngine.taskData` upload path already does exactly this — `export` omits the `@NotExport`
-      reviewers/watchers, so it adds them explicitly), then do **one** `syncTaskAfterMutation`. Drop the
-      separate online `replaceTaskReviewers`/`replaceTaskWatchers` round-trips (or make them local-apply
-      + a single push).
-      **Prerequisite:** the demo backend's task-update endpoint (`DemoServerSimulator`) must honor
-      `reviewer_ids`/`watcher_ids` in the task body (today only the `/sync/upload` upsert path does).
-      **Done when:** a people-edit save is one server round-trip, and the people-edit UI tests pass at the
-      original tight `0.5s` save-dismiss timeout (the right reason), letting `saveDismissTimeout` shrink.
-      Demo-only — no SwiftSync library change.
+- [x] **Consolidate the online people-edit save into one round-trip.** Done: `updateTask`/`createTask`
+      now honor `reviewer_ids`/`watcher_ids` in the task body (the `.save` handler in `ScreenMachines.swift`
+      adds the `@NotExport` people to the body and drops the separate `replaceTaskReviewers`/
+      `replaceTaskWatchers` calls), so a people edit is a single server round-trip. `saveDismissTimeout`
+      stays at `1s` rather than shrinking to `0.5s`: a generous behavioral ceiling is the right call for
+      the noisy CI simulator (the durability rule), and one round-trip clears it comfortably.
 
 ### Offline / two-id identity model — follow-ups (PR #632)
 

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -126,9 +126,11 @@ is a separate SPM product (↔ Networking items 5–6).
 - [x] **Consolidate the online people-edit save into one round-trip.** Done: `updateTask`/`createTask`
       now honor `reviewer_ids`/`watcher_ids` in the task body (the `.save` handler in `ScreenMachines.swift`
       adds the `@NotExport` people to the body and drops the separate `replaceTaskReviewers`/
-      `replaceTaskWatchers` calls), so a people edit is a single server round-trip. `saveDismissTimeout`
-      stays at `1s` rather than shrinking to `0.5s`: a generous behavioral ceiling is the right call for
-      the noisy CI simulator (the durability rule), and one round-trip clears it comfortably.
+      `replaceTaskWatchers` calls), so a people edit is a single server round-trip. Separately, all the
+      UI save-dismiss waits were unified on a generous `saveDismissTimeout` (10s): the first CI UI run
+      showed a slow shared runner flaking unrelated save tests at the old tight 1s/2s ceilings, and a
+      `waitForNonExistence` ceiling returns the instant the form dismisses, so generous never slows a
+      passing test (the durability rule — pin a behavioral ceiling, not a machine-tuned number).
 
 ### Offline / two-id identity model — follow-ups (PR #632)
 


### PR DESCRIPTION
## What

Splits CI by the **draft ↔ ready** signal.

- **Fast tier (`ci.yml`)** — unchanged: swift-format, macOS `swift test` ×3, warnings ×3, doc-links, perf subset. Runs on **every push** (draft included) + master push.
- **Slow simulator tier (`ios-regression.yml`)** — now runs **only when a PR is marked ready for review**:
  - Triggers on `ready_for_review` (plus opened/synchronize/reopened); each job has `if: github.event.pull_request.draft == false`, so it **skips on drafts** (a skipped check still reports success → drafts stay mergeable-clean).
  - Dropped the `push: master` trigger — this tier is **pre-merge only**.
  - **New `UI Tests` job**: runs the `DemoUITests` target via the `Demo` scheme on a dynamically-selected simulator (previously these 15 UI tests ran *nowhere* in CI). `-retry-tests-on-failure` absorbs first-launch/timing flake without masking real breakage.

## Why

- The iOS regression was paying the slow simulator cost on **every draft push** during iteration.
- UI tests gated nothing — they only ran locally via `scripts/run_ui_test.sh`.
- `AGENTS.md` claimed a *post-merge* gate that didn't match the workflow (which ran pre-merge). Updated the iOS Test Policy to describe the new split.

## Verification

- Both workflow YAMLs parse.
- Fast tier runs on this draft; the simulator tier is verified by marking this PR ready (see checks).

## Note

`master` currently has **no branch protection**, so no check is a hard gate — they're informational and merges succeed regardless of red. Making the simulator tier an enforced gate needs branch protection with those checks marked required (a repo setting, separate from this PR).