### PR TITLE
Put every UI test on trial: 15 → 3, convert the rest to units

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,3 +113,13 @@
   - **Every push (draft included)** runs the fast tier in `ci.yml`: swift-format, macOS `swift test` (×3 packages), the warnings gate, doc-links, and the perf subset.
   - **Only when a PR is marked ready for review** does the slow simulator tier in `ios-regression.yml` run — one `iOS Simulator Tests` job that runs both the `DemoUITests` UI suite and the iOS-specific dirty-tracking regression (`DirtyTrackingGapTests`) on a simulator. It skips on drafts (a skipped check still reports success) and there is no master-push run — this tier is pre-merge only.
 - So mark a PR **ready** to trigger the `iOS Simulator Tests` gate, then verify it green before merging. If a task touches `Core.swift`, `MacrosImplementation/`, or `SyncableMacro.swift`, note in the plan that marking the PR ready will run that simulator tier.
+
+### UI tests are a last resort (very expensive)
+
+A `DemoUITests` test boots a simulator and builds the app — the costliest thing in CI. Keep one only when nothing cheaper can catch the regression.
+
+- **A UI test owns its timeouts inline.** No shared timeout constant across tests; each `waitForExistence`/`waitForNonExistence` carries a value sized for that test's own operation, at the call site.
+- **No green-at-birth tests.** A test earns its place only by having been red before the fix it guards (the red-first rule, applied to UI tests too). A test that passed at creation, guarding no demonstrated failure, is removed.
+- **Prefer the cheapest layer that reproduces the failure.** Before adding or keeping a UI test, try to make the core failure reproduce as a DemoCore/DemoBackend/SwiftSync unit test. If a unit catches it, the UI test is redundant — drop it (precedent: the dirty-tracking regression was driven down from a UI test into `DirtyTrackingGapTests`).
+- **Keep a UI test only with a strong, documented reason** — it exercises something units genuinely can't (view hierarchy, cross-screen navigation, a SwiftUI binding/reactivity path, a gesture/dismiss affordance) and you tried and failed to pin it to a unit. State the reason in a one-line comment on the test.
+- Ongoing systematic effort + per-test trial log: `docs/planning/ui-test-trial.md`.

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -285,7 +285,9 @@ final class DemoUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["task.watcher.\(DemoSeedUserID.ethanLee)"].exists)
     }
 
-    // User journey: create a task offline (reference data is cached), then sync on reconnect.
+    // KEPT (R4): the offline-success integration is app-layer, not unit-coverable — ContentView's
+    // `.onChange(of: isOffline)` auto-drains the queue on reconnect and the pending-count badge is a
+    // SwiftUI view. The edit logic itself is unit-tested in OfflinePushTests; this guards the wiring.
     @MainActor
     func testOfflineCreateQueuesThenSyncsOnReconnect() throws {
         let app = configuredApp()
@@ -327,48 +329,9 @@ final class DemoUITests: XCTestCase {
         XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
     }
 
-    // User journey: edit an offline-created task's title; the project list reflects the new title.
-    @MainActor
-    func testOfflineEditTaskTitleUpdatesProjectList() throws {
-        let app = configuredApp()
-        app.launch()
-
-        // Online: warm reference data (users + task states) so offline create/edit works.
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-        XCTAssertTrue(
-            app.staticTexts["Add session timeout controls to account settings"].waitForExistence(timeout: 2))
-        goBack(app)
-
-        app.buttons["offline-toggle"].tap()
-        XCTAssertEqual(app.buttons["offline-toggle"].label, "Offline")
-
-        // Create a task offline.
-        let originalTitle = uniqueTitle(prefix: "Offline Original")
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-        openCreateTaskForm(app)
-        replaceText(in: app.textFields["task-form.title"], with: originalTitle, app: app)
-        app.buttons["task-form.save"].tap()
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
-        XCTAssertTrue(findAfterScrolling(app.staticTexts[originalTitle], in: app))
-
-        // Open it and rename it offline.
-        let updatedTitle = uniqueTitle(prefix: "Offline Renamed")
-        openTopProjectTask(app)
-        openEditTaskForm(app)
-        replaceText(in: app.textFields["task-form.title"], with: updatedTitle, app: app)
-        app.buttons["task-form.save"].tap()
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
-        XCTAssertEqual(detailElement(app, id: "task.title").label, updatedTitle, "the detail shows the new title")
-
-        // Back on the project list, the row reflects the edit — not the stale original title.
-        goBack(app)
-        XCTAssertTrue(
-            findAfterScrolling(app.staticTexts[updatedTitle], in: app),
-            "the project list shows the edited title")
-        XCTAssertFalse(app.staticTexts[originalTitle].exists, "the stale title is gone")
-    }
-
-    // User journey: a rejected offline edit lands in the failures inbox; discard resolves it.
+    // KEPT (R4): the failures-inbox screen (FailuresSheet + discard button) is app-layer UI. The failure
+    // annotation and discard logic are unit-tested in OfflinePushTests, but the inbox surfacing on a
+    // rejected auto-sync is not unit-coverable.
     @MainActor
     func testRejectedOfflineEditAppearsInFailuresInboxAndDiscards() throws {
         let app = configuredApp()
@@ -399,49 +362,6 @@ final class DemoUITests: XCTestCase {
         XCTAssertTrue(discard.waitForNonExistence(timeout: 5), "discard clears the failure")
     }
 
-    // User journey: work offline, queue a change, then sync on reconnect.
-    @MainActor
-    func testOfflineDeleteQueuesThenSyncsOnReconnect() throws {
-        let app = configuredApp()
-        app.launch()
-
-        let doomedTitle = "Add session timeout controls to account settings"
-
-        // Online: open the project so its tasks are cached locally.
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-        XCTAssertTrue(app.staticTexts[doomedTitle].waitForExistence(timeout: 2))
-        goBack(app)
-
-        // Go offline (the toggle lives on the projects list).
-        let toggle = app.buttons["offline-toggle"]
-        XCTAssertTrue(toggle.waitForExistence(timeout: 2))
-        XCTAssertEqual(toggle.label, "Online")
-        toggle.tap()
-        XCTAssertEqual(app.buttons["offline-toggle"].label, "Offline")
-
-        // Reopen the project offline: cached tasks still render (a dead network is not a blank screen).
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-        XCTAssertTrue(app.staticTexts[doomedTitle].exists, "cached tasks remain visible offline")
-
-        // Delete a task offline: it leaves the list and becomes a pending change.
-        deleteTaskFromProject(app, id: DemoSeedTaskID.sessionTimeout)
-        XCTAssertTrue(app.staticTexts[doomedTitle].waitForNonExistence(timeout: 2))
-        goBack(app)
-
-        XCTAssertTrue(app.staticTexts["pending-count"].waitForExistence(timeout: 2), "the delete is queued")
-
-        // Reconnect: the queue syncs automatically — no button tap.
-        app.buttons["offline-toggle"].tap()
-        XCTAssertEqual(app.buttons["offline-toggle"].label, "Online")
-        XCTAssertTrue(
-            app.staticTexts["pending-count"].waitForNonExistence(timeout: 5),
-            "reconnecting auto-syncs the queue")
-
-        // The deletion held: reopening online (a real server refresh) does not bring it back.
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-        XCTAssertTrue(app.staticTexts["Write QA item list for forced re-auth scenarios"].waitForExistence(timeout: 2))
-        XCTAssertFalse(app.staticTexts[doomedTitle].exists)
-    }
 }
 
 extension DemoUITests {

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -170,38 +170,6 @@ final class DemoUITests: XCTestCase {
     }
 
     @MainActor
-    func testEditTaskPeopleFlow() throws {
-        let app = configuredApp()
-
-        app.launch()
-        openTaskDetail(
-            app,
-            projectID: DemoSeedProjectID.notificationsReliability,
-            taskID: DemoSeedTaskID.duplicatePushFix
-        )
-
-        openEditTaskForm(app)
-
-        selectAssignee(app, userID: DemoSeedUserID.miaPatel)
-        addPerson(app, role: "reviewers", userID: DemoSeedUserID.sofiaGarcia)
-        addPerson(app, role: "watchers", userID: DemoSeedUserID.sofiaGarcia)
-        app.buttons["task-form.save"].tap()
-
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
-        XCTAssertEqual(detailElement(app, id: "task.assignee").label, "Mia Patel")
-
-        goBack(app)
-        openTask(app, id: DemoSeedTaskID.duplicatePushFix)
-
-        XCTAssertTrue(detailElement(app, id: "task.title").exists)
-        XCTAssertEqual(detailElement(app, id: "task.assignee").label, "Mia Patel")
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["task.reviewer.\(DemoSeedUserID.noahKim)"], in: app))
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["task.reviewer.\(DemoSeedUserID.sofiaGarcia)"], in: app))
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["task.watcher.\(DemoSeedUserID.ethanLee)"], in: app))
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["task.watcher.\(DemoSeedUserID.sofiaGarcia)"], in: app))
-    }
-
-    @MainActor
     func testAssignUnassignedTask() throws {
         let app = configuredApp()
 

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -1,33 +1,10 @@
 import XCTest
 
-private enum DemoUITestPlan {
-    /*
-     Source of truth for Demo UI automation planning.
-
-     Purpose of the Demo app:
-     - prove SwiftSync works in real app flows, not only isolated unit tests
-     - show project list -> project detail -> task detail -> create/edit/delete behavior
-     - act as an integration regression surface for synced reads, writes, and relationships
-
-     Testing rule:
-     - tests should map to user goals, not to screen checkpoints
-     - navigation assertions only matter when they support a larger journey
-     - keep the suite intentionally small and stable; add coverage below the UI layer before growing this file further
-
-     Implemented coverage:
-     - bootstrap smoke: launch and confirm the canonical seeded project list loads
-     - journey: browse work and inspect task details
-       path:
-       1. open app
-       2. open "Account Security Controls"
-       3. open "Add session timeout controls to account settings"
-       4. verify title, assignee, author, and seeded checklist items
-
-     Scope:
-     - this suite is intentionally capped at core demo journeys
-     - future coverage should prefer lower-level tests unless a new end-to-end user journey justifies UI automation
-     */
-}
+// UI tests are the costliest CI tier, so this suite is intentionally tiny: it holds only journeys that
+// exercise genuinely app-layer behavior a DemoCore/SwiftSync/DemoBackend unit cannot (cross-screen
+// SwiftUI reactivity, the offline-toggle/auto-sync wiring, the failures-inbox screen). New behavior earns
+// coverage below the UI layer first. Rules + the per-test trial: docs/planning/ui-test-trial.md and
+// AGENTS.md ("UI tests are a last resort").
 
 private enum DemoSeedUserID {
     static let noahKim = "C3E7A1B2-2001-0000-0000-000000000002"
@@ -51,11 +28,6 @@ private enum DemoSeedTaskID {
 }
 
 final class DemoUITests: XCTestCase {
-    /// A people-edit save runs three sequential refresh cycles, so the form dismisses just past the old
-    /// 0.5s budget (which flaked); 1s asserts the form closes without re-introducing the flake.
-    // One-round-trip save → the form dismisses well under a second; 3s is jitter headroom. waitForNonExistence
-    // returns on dismiss, so a passing test isn't slowed and a real failure still fails fast.
-    private let saveDismissTimeout: TimeInterval = 3
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -84,7 +56,7 @@ final class DemoUITests: XCTestCase {
         replaceText(in: app.textFields["task-form.description"], with: "   ", app: app)
         app.buttons["task-form.save"].tap()
 
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 3))
         XCTAssertEqual(detailElement(app, id: "task.title").label, updatedTitle)
         XCTAssertEqual(detailElement(app, id: "task.description").label, normalizedDescription)
 
@@ -118,7 +90,7 @@ final class DemoUITests: XCTestCase {
         replaceText(in: app.textFields["task-form.title"], with: title, app: app)
         XCTAssertTrue(app.buttons["task-form.save"].isEnabled, "offline create works with cached reference data")
         app.buttons["task-form.save"].tap()
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 3))
 
         // It appears locally and is queued.
         XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
@@ -151,7 +123,7 @@ final class DemoUITests: XCTestCase {
         openEditTaskForm(app)
         replaceText(in: app.textFields["task-form.title"], with: String(repeating: "A", count: 100), app: app)
         app.buttons["task-form.save"].tap()
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
+        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 3))
 
         // Reconnect: auto-sync pushes it, the server rejects it, and it surfaces in the inbox.
         app.buttons["offline-toggle"].tap()
@@ -202,14 +174,6 @@ extension DemoUITests {
         XCTAssertTrue(detailElement(app, id: "task.title").exists)
     }
 
-    fileprivate func openTopProjectTask(_ app: XCUIApplication) {
-        let rows = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "identifier BEGINSWITH 'project.task.'"))
-        let row = rows.element(boundBy: 0)
-        XCTAssertTrue(row.waitForExistence(timeout: 1))
-        row.tap()
-    }
-
     fileprivate func detailElement(_ app: XCUIApplication, id: String) -> XCUIElement {
         app.descendants(matching: .any)[id]
     }
@@ -226,65 +190,6 @@ extension DemoUITests {
     fileprivate func openEditTaskForm(_ app: XCUIApplication) {
         app.buttons["Edit"].tap()
         XCTAssertTrue(app.buttons["task-form.save"].exists)
-    }
-
-    fileprivate func selectAssignee(_ app: XCUIApplication, userID: String) {
-        tapAfterScrolling(app.buttons["task-form.summary.assignee"], in: app)
-        tapAfterScrolling(app.buttons["task-form.assignee.option.\(userID)"], in: app)
-    }
-
-    fileprivate func selectAuthor(_ app: XCUIApplication, userID: String) {
-        tapAfterScrolling(app.buttons["task-form.summary.author"], in: app)
-        tapAfterScrolling(app.buttons["task-form.author.option.\(userID)"], in: app)
-    }
-
-    fileprivate func addPerson(_ app: XCUIApplication, role: String, userID: String) {
-        tapAfterScrolling(app.buttons["task-form.\(role).add"], in: app)
-        tapAfterScrolling(app.buttons["task-form.\(role).option.\(userID)"], in: app)
-    }
-
-    fileprivate func deleteTaskFromProject(_ app: XCUIApplication, id: String) {
-        let taskRow = app.descendants(matching: .any)["project.task.\(id)"]
-        XCTAssertTrue(taskRow.waitForExistence(timeout: 1))
-        taskRow.swipeLeft()
-        app.buttons["Delete"].tap()
-        app.alerts["Delete Task?"].buttons["Delete"].tap()
-    }
-
-    fileprivate func tapAfterScrolling(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) {
-        for _ in 0..<maxSwipes where !element.isHittable {
-            if app.tables.firstMatch.exists {
-                app.tables.firstMatch.swipeUp()
-            } else if app.scrollViews.firstMatch.exists {
-                app.scrollViews.firstMatch.swipeUp()
-            } else if app.otherElements["task-form"].exists {
-                app.otherElements["task-form"].swipeUp()
-            } else {
-                app.swipeUp()
-            }
-        }
-        XCTAssertTrue(element.exists)
-        element.tap()
-    }
-
-    fileprivate func scrollToVisible(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) {
-        for _ in 0..<maxSwipes where !element.exists {
-            if app.tables.firstMatch.exists {
-                app.tables.firstMatch.swipeUp()
-            } else if app.scrollViews.firstMatch.exists {
-                app.scrollViews.firstMatch.swipeUp()
-            } else if app.otherElements["task-form"].exists {
-                app.otherElements["task-form"].swipeUp()
-            } else {
-                app.swipeUp()
-            }
-        }
-        XCTAssertTrue(element.exists)
-    }
-
-    fileprivate func tapVisible(_ element: XCUIElement) {
-        XCTAssertTrue(element.exists)
-        element.tap()
     }
 
     fileprivate func findAfterScrolling(_ element: XCUIElement, in app: XCUIApplication, maxSwipes: Int = 6) -> Bool {

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -92,38 +92,6 @@ final class DemoUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts[updatedTitle].exists)
     }
 
-    @MainActor
-    func testEditTaskItemsFlow() throws {
-        let app = configuredApp()
-        let addedItemTitle = uniqueTitle(prefix: "UI Added Item")
-        let renamedItemTitle = "Relaunch flow after timeout"
-        let deletedItemTitle = "Offline to online recovery"
-
-        app.launch()
-        openTaskDetail(
-            app,
-            projectID: DemoSeedProjectID.accountSecurity,
-            taskID: DemoSeedTaskID.qaItemList
-        )
-
-        openEditTaskForm(app)
-
-        app.buttons["task-form.items.add"].tap()
-        scrollToVisible(app.textFields["task-form.items.2.title"], in: app)
-        replaceText(in: app.textFields["task-form.items.2.title"], with: addedItemTitle, app: app)
-
-        scrollToVisible(app.textFields["task-form.items.0.title"], in: app)
-        replaceText(in: app.textFields["task-form.items.0.title"], with: renamedItemTitle, app: app)
-        scrollToVisible(app.buttons["task-form.items.1.delete"], in: app)
-        app.buttons["task-form.items.1.delete"].tap()
-        app.buttons["task-form.save"].tap()
-
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
-        XCTAssertTrue(findAfterScrolling(app.staticTexts[renamedItemTitle], in: app))
-        XCTAssertTrue(findAfterScrolling(app.staticTexts[addedItemTitle], in: app))
-        XCTAssertFalse(app.staticTexts[deletedItemTitle].exists)
-    }
-
     // KEPT (R4): the offline-success integration is app-layer, not unit-coverable — ContentView's
     // `.onChange(of: isOffline)` auto-drains the queue on reconnect and the pending-count badge is a
     // SwiftUI view. The edit logic itself is unit-tested in OfflinePushTests; this guards the wiring.

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -93,38 +93,6 @@ final class DemoUITests: XCTestCase {
     }
 
     @MainActor
-    func testCreateTaskInsideProject() throws {
-        let app = configuredApp()
-        let createdTitle = uniqueTitle(prefix: "UI Created Task")
-        let authorID = DemoSeedUserID.miaPatel
-        let reviewerID = DemoSeedUserID.sofiaGarcia
-        let watcherID = DemoSeedUserID.ethanLee
-
-        app.launch()
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-
-        openCreateTaskForm(app)
-
-        let saveButton = app.buttons["task-form.save"]
-        XCTAssertFalse(saveButton.isEnabled)
-
-        replaceText(in: app.textFields["task-form.title"], with: createdTitle, app: app)
-        selectAuthor(app, userID: authorID)
-        addPerson(app, role: "reviewers", userID: reviewerID)
-        addPerson(app, role: "watchers", userID: watcherID)
-        XCTAssertTrue(saveButton.isEnabled)
-        saveButton.tap()
-
-        openTopProjectTask(app)
-
-        XCTAssertTrue(detailElement(app, id: "task.title").exists)
-        XCTAssertEqual(detailElement(app, id: "task.title").label, createdTitle)
-        XCTAssertEqual(detailElement(app, id: "task.author").label, "Mia Patel")
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["task.reviewer.\(reviewerID)"], in: app))
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["task.watcher.\(watcherID)"], in: app))
-    }
-
-    @MainActor
     func testEditTaskItemsFlow() throws {
         let app = configuredApp()
         let addedItemTitle = uniqueTitle(prefix: "UI Added Item")
@@ -154,19 +122,6 @@ final class DemoUITests: XCTestCase {
         XCTAssertTrue(findAfterScrolling(app.staticTexts[renamedItemTitle], in: app))
         XCTAssertTrue(findAfterScrolling(app.staticTexts[addedItemTitle], in: app))
         XCTAssertFalse(app.staticTexts[deletedItemTitle].exists)
-    }
-
-    @MainActor
-    func testDeleteTaskFromProject() throws {
-        let app = configuredApp()
-
-        app.launch()
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-
-        deleteTaskFromProject(app, id: DemoSeedTaskID.securityPolicyPatch)
-        XCTAssertFalse(app.descendants(matching: .any)["project.task.\(DemoSeedTaskID.securityPolicyPatch)"].exists)
-        XCTAssertTrue(app.staticTexts["Add session timeout controls to account settings"].exists)
-        XCTAssertTrue(app.staticTexts["Write QA item list for forced re-auth scenarios"].exists)
     }
 
     @MainActor

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -124,49 +124,6 @@ final class DemoUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts[deletedItemTitle].exists)
     }
 
-    @MainActor
-    func testCancelCreateDoesNotPersistTask() throws {
-        let app = configuredApp()
-        let draftTitle = uniqueTitle(prefix: "UI Cancel Create")
-
-        app.launch()
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-
-        openCreateTaskForm(app)
-        replaceText(in: app.textFields["task-form.title"], with: draftTitle, app: app)
-        app.buttons["task-form.cancel"].tap()
-
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
-        XCTAssertFalse(app.staticTexts[draftTitle].exists)
-    }
-
-    @MainActor
-    func testCancelEditKeepsOriginalTaskValues() throws {
-        let app = configuredApp()
-        let originalTitle = "Add session timeout controls to account settings"
-        let editedTitle = uniqueTitle(prefix: "UI Cancel Edit")
-
-        app.launch()
-        openTaskDetail(
-            app,
-            projectID: DemoSeedProjectID.accountSecurity,
-            taskID: DemoSeedTaskID.sessionTimeout
-        )
-
-        XCTAssertEqual(detailElement(app, id: "task.title").label, originalTitle)
-
-        openEditTaskForm(app)
-        replaceText(in: app.textFields["task-form.title"], with: editedTitle, app: app)
-        app.buttons["task-form.cancel"].tap()
-
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
-        XCTAssertEqual(detailElement(app, id: "task.title").label, originalTitle)
-
-        goBack(app)
-        XCTAssertTrue(app.staticTexts[originalTitle].exists)
-        XCTAssertFalse(app.staticTexts[editedTitle].exists)
-    }
-
     // KEPT (R4): the offline-success integration is app-layer, not unit-coverable — ContentView's
     // `.onChange(of: isOffline)` auto-drains the queue on reconnect and the pending-count badge is a
     // SwiftUI view. The edit logic itself is unit-tested in OfflinePushTests; this guards the wiring.

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -399,40 +399,6 @@ final class DemoUITests: XCTestCase {
         XCTAssertTrue(discard.waitForNonExistence(timeout: 5), "discard clears the failure")
     }
 
-    // User journey: edit a task's reviewers offline, then sync on reconnect.
-    @MainActor
-    func testOfflineAddReviewerSyncsOnReconnect() throws {
-        let app = configuredApp()
-        app.launch()
-
-        // Online: open the task so it + reference data are cached.
-        openTaskDetail(
-            app, projectID: DemoSeedProjectID.notificationsReliability,
-            taskID: DemoSeedTaskID.duplicatePushFix)
-
-        // Go offline and add a reviewer.
-        app.buttons["offline-toggle"].tap()
-        XCTAssertEqual(app.buttons["offline-toggle"].label, "Offline")
-        openEditTaskForm(app)
-        addPerson(app, role: "reviewers", userID: DemoSeedUserID.sofiaGarcia)
-        app.buttons["task-form.save"].tap()
-        XCTAssertTrue(
-            app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout),
-            "an offline edit saves locally")
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["task.reviewer.\(DemoSeedUserID.sofiaGarcia)"], in: app))
-
-        // Reconnect → the change auto-syncs.
-        app.buttons["offline-toggle"].tap()
-        XCTAssertTrue(
-            app.staticTexts["pending-count"].waitForNonExistence(timeout: 5),
-            "reconnecting auto-syncs the reviewer change")
-
-        // Persisted on the server: reopen the task (a real refresh) and the reviewer is still there.
-        goBack(app)
-        openTask(app, id: DemoSeedTaskID.duplicatePushFix)
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["task.reviewer.\(DemoSeedUserID.sofiaGarcia)"], in: app))
-    }
-
     // User journey: work offline, queue a change, then sync on reconnect.
     @MainActor
     func testOfflineDeleteQueuesThenSyncsOnReconnect() throws {

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -61,23 +61,10 @@ final class DemoUITests: XCTestCase {
         continueAfterFailure = false
     }
 
-    // User journey: browse work and inspect synced task details.
-    @MainActor
-    func testProjectAndTaskDetailShowSeededContent() throws {
-        let app = configuredApp()
-        app.launch()
-
-        openProject(app, id: DemoSeedProjectID.accountSecurity)
-        openTask(app, id: DemoSeedTaskID.sessionTimeout)
-
-        XCTAssertTrue(detailElement(app, id: "task.title").exists)
-        XCTAssertEqual(detailElement(app, id: "task.title").label, "Add session timeout controls to account settings")
-        XCTAssertEqual(detailElement(app, id: "task.assignee").label, "Ava Martinez")
-        XCTAssertEqual(detailElement(app, id: "task.author").label, "Liam Brown")
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["Gather requirements"], in: app))
-        XCTAssertTrue(findAfterScrolling(app.staticTexts["Draft implementation plan"], in: app))
-    }
-
+    // KEPT (R4): cross-screen reactivity — after a save, the edit must propagate to BOTH the detail and
+    // the project-list row (SwiftSync's @SyncQuery driving two SwiftUI views). The update + description
+    // normalization logic are unit-tested (OfflinePushTests, TaskFormDescriptionNormalizationTests); the
+    // reactive propagation across screens is not unit-coverable without a view host.
     @MainActor
     func testUpdateTaskTitleKeepsProjectAndDetailInSync() throws {
         let app = configuredApp()
@@ -170,35 +157,6 @@ final class DemoUITests: XCTestCase {
     }
 
     @MainActor
-    func testAssignUnassignedTask() throws {
-        let app = configuredApp()
-
-        app.launch()
-        openTaskDetail(
-            app,
-            projectID: DemoSeedProjectID.notificationsReliability,
-            taskID: DemoSeedTaskID.incidentPlaybook
-        )
-
-        XCTAssertTrue(detailElement(app, id: "task.assignee").exists)
-        XCTAssertEqual(detailElement(app, id: "task.assignee").label, "Unassigned")
-
-        openEditTaskForm(app)
-        app.buttons["task-form.summary.assignee"].tap()
-        tapAfterScrolling(app.buttons["task-form.assignee.option.\(DemoSeedUserID.miaPatel)"], in: app)
-        app.buttons["task-form.save"].tap()
-
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
-        XCTAssertEqual(detailElement(app, id: "task.assignee").label, "Mia Patel")
-
-        goBack(app)
-        openTask(app, id: DemoSeedTaskID.incidentPlaybook)
-
-        XCTAssertTrue(detailElement(app, id: "task.title").exists)
-        XCTAssertEqual(detailElement(app, id: "task.assignee").label, "Mia Patel")
-    }
-
-    @MainActor
     func testDeleteTaskFromProject() throws {
         let app = configuredApp()
 
@@ -252,37 +210,6 @@ final class DemoUITests: XCTestCase {
         goBack(app)
         XCTAssertTrue(app.staticTexts[originalTitle].exists)
         XCTAssertFalse(app.staticTexts[editedTitle].exists)
-    }
-
-    @MainActor
-    func testClearTaskReviewersOrWatchers() throws {
-        let app = configuredApp()
-
-        app.launch()
-        openTaskDetail(
-            app,
-            projectID: DemoSeedProjectID.notificationsReliability,
-            taskID: DemoSeedTaskID.duplicatePushFix
-        )
-
-        XCTAssertTrue(app.staticTexts["task.reviewer.\(DemoSeedUserID.noahKim)"].exists)
-
-        openEditTaskForm(app)
-
-        tapAfterScrolling(app.buttons["task-form.reviewers.delete.\(DemoSeedUserID.noahKim)"], in: app)
-        tapAfterScrolling(app.buttons["task-form.watchers.delete.\(DemoSeedUserID.liamBrown)"], in: app)
-        tapAfterScrolling(app.buttons["task-form.watchers.delete.\(DemoSeedUserID.ethanLee)"], in: app)
-        app.buttons["task-form.save"].tap()
-
-        XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: saveDismissTimeout))
-
-        goBack(app)
-        openTask(app, id: DemoSeedTaskID.duplicatePushFix)
-
-        XCTAssertTrue(detailElement(app, id: "task.title").exists)
-        XCTAssertFalse(app.staticTexts["task.reviewer.\(DemoSeedUserID.noahKim)"].exists)
-        XCTAssertFalse(app.staticTexts["task.watcher.\(DemoSeedUserID.liamBrown)"].exists)
-        XCTAssertFalse(app.staticTexts["task.watcher.\(DemoSeedUserID.ethanLee)"].exists)
     }
 
     // KEPT (R4): the offline-success integration is app-layer, not unit-coverable — ContentView's

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -89,6 +89,42 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testUpdateTaskItemsAddRenameDelete() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.qaItemList
+        try await engine.syncProjectTasks(projectID: projectID)
+        try await engine.syncTaskDetail(taskID: taskID)
+
+        let task = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        var body = syncContainer.export(task)
+        var items = try XCTUnwrap(body["items"] as? [[String: Any]])
+        XCTAssertGreaterThanOrEqual(items.count, 2, "the seeded task has items to edit")
+
+        items[0]["title"] = "Renamed item"  // rename the first
+        let removed = items.remove(at: 1)  // delete the second
+        let removedTitle = try XCTUnwrap(removed["title"] as? String)
+        var added = items[0]  // clone the exported shape, then make it a new item
+        added["id"] = "ADDED-ITEM-1"
+        added["title"] = "Added item"
+        items.append(added)
+        body["items"] = items
+
+        try await engine.updateTask(
+            taskID: taskID, projectID: projectID, body: try DemoSyncPayload(dictionary: body))
+
+        let updated = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        let titles = updated.items.map(\.title)
+        XCTAssertTrue(titles.contains("Renamed item"), "rename applied")
+        XCTAssertTrue(titles.contains("Added item"), "add applied")
+        XCTAssertFalse(titles.contains(removedTitle), "delete applied")
+    }
+
+    @MainActor
     func testOfflineDeleteThenPushHardDeletesLocallyAndOnBackend() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -302,10 +302,12 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertEqual(edited.project?.id, projectID, "the edit must not drop the project link")
     }
 
-    /// Regression: an offline `updateTask` with `reviewer_ids` must apply reviewers locally (`apply()`
-    /// skips the `@NotExport` relationship, so there's no server round-trip to reflect it).
+    /// The whole offline reviewer journey via the path the task-form save actually uses (reviewer_ids in
+    /// the `updateTask` body): it applies locally while offline — a regression guard, since `apply()`
+    /// skips the `@NotExport` relationship so nothing else would reflect it — then round-trips through
+    /// push so the server holds the new set, proven by a fresh pull bringing it back.
     @MainActor
-    func testOfflineUpdateTaskWithReviewerIDsAppliesLocally() async throws {
+    func testOfflineReviewerEditViaUpdateBodyAppliesLocallyAndSyncsOnReconnect() async throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("offline-update-people-\(UUID().uuidString).sqlite")
         addTeardownBlock { try? FileManager.default.removeItem(at: url) }
@@ -333,6 +335,18 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertEqual(
             offline.reviewers.map(\.id).sorted(), newReviewers,
             "an offline updateTask with reviewer_ids must apply the reviewers to the local row")
+
+        engine.isOffline = false
+        let pushResult = try await engine.pushPendingChanges()
+        let summary = try XCTUnwrap(pushResult)
+        XCTAssertTrue(summary.failures.isEmpty)
+
+        // A fresh pull (server is authoritative) brings the same reviewers back.
+        try await engine.syncTaskDetail(taskID: taskID)
+        let pulled = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
+        XCTAssertEqual(
+            pulled.reviewers.map(\.id).sorted(), newReviewers,
+            "the offline reviewer edit persisted on the server")
     }
 
     /// Only `Task` is marked offline, yet a `Task`↔`User` relationship edit made offline (assigning

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -47,6 +47,48 @@ final class OfflinePushTests: XCTestCase {
     }
 
     @MainActor
+    func testOnlineCreateTaskPersistsLocallyAndReachesBackend() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        try await engine.syncProjectTasks(projectID: projectID)
+
+        let body = try createBody(
+            from: DemoSeedData.SeedIDs.Tasks.sessionTimeout, newID: "ONLINE-CREATE-1", in: syncContainer)
+        try await engine.createTask(body: body, projectID: projectID)
+
+        XCTAssertNotNil(
+            try fetchTask(id: "ONLINE-CREATE-1", in: syncContainer.mainContext), "created locally")
+        XCTAssertEqual(engine.pendingChangeCount, 0, "an online create syncs immediately, not pending")
+        let backendDetail = try await apiClient.getTaskDetail(taskID: "ONLINE-CREATE-1")
+        XCTAssertNotNil(backendDetail, "the create reached the backend")
+    }
+
+    @MainActor
+    func testOnlineDeleteTaskRemovesLocallyAndOnBackend() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.securityPolicyPatch
+        try await engine.syncProjectTasks(projectID: projectID)
+        XCTAssertNotNil(try fetchTask(id: taskID, in: syncContainer.mainContext))
+
+        try await engine.deleteTask(taskID: taskID, projectID: projectID)
+
+        XCTAssertNil(
+            try fetchTask(id: taskID, in: syncContainer.mainContext), "removed locally after an online delete")
+        XCTAssertEqual(engine.pendingChangeCount, 0)
+        let backendDetail = try await apiClient.getTaskDetail(taskID: taskID)
+        XCTAssertNil(backendDetail, "removed on the backend")
+    }
+
+    @MainActor
     func testOfflineDeleteThenPushHardDeletesLocallyAndOnBackend() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()

--- a/DemoCore/Tests/DemoCoreTests/TaskFormPeopleMutationTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/TaskFormPeopleMutationTests.swift
@@ -1,7 +1,8 @@
+import Observation
 import SwiftData
 import SwiftSync
 import XCTest
-import Observation
+
 @testable import DemoCore
 
 final class TaskFormPeopleMutationTests: XCTestCase {
@@ -56,9 +57,12 @@ final class TaskFormPeopleMutationTests: XCTestCase {
         }
 
         let saved = expectation(description: "save callback")
-        machine.send(.save(mode: .edit(task: originalTask), draft: draft, onSuccess: {
-            saved.fulfill()
-        }))
+        machine.send(
+            .save(
+                mode: .edit(task: originalTask), draft: draft,
+                onSuccess: {
+                    saved.fulfill()
+                }))
         await fulfillment(of: [saved], timeout: 10)
 
         let updatedTask = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
@@ -104,7 +108,8 @@ final class TaskFormPeopleMutationTests: XCTestCase {
         let originalTask = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
         let editContext = ModelContext(syncContainer.modelContainer)
         editContext.autosaveEnabled = false
-        let formMachine = TaskFormSheetMachine(syncContainer: syncContainer, syncEngine: engine, editContext: editContext)
+        let formMachine = TaskFormSheetMachine(
+            syncContainer: syncContainer, syncEngine: engine, editContext: editContext)
         formMachine.send(.metadata(.onAppear))
         try await waitUntil {
             formMachine.userOptionsState == .available && formMachine.taskStateOptionsState == .available
@@ -124,9 +129,12 @@ final class TaskFormPeopleMutationTests: XCTestCase {
         }
 
         let saved = expectation(description: "save callback")
-        formMachine.send(.save(mode: .edit(task: originalTask), draft: draft, onSuccess: {
-            saved.fulfill()
-        }))
+        formMachine.send(
+            .save(
+                mode: .edit(task: originalTask), draft: draft,
+                onSuccess: {
+                    saved.fulfill()
+                }))
         await fulfillment(of: [saved], timeout: 10)
 
         try await waitUntil {
@@ -144,6 +152,40 @@ final class TaskFormPeopleMutationTests: XCTestCase {
             }),
             "spy values: \(spy.values)"
         )
+    }
+
+    /// The task form edits in an isolated `editContext` (a child ModelContext with autosave off, as the
+    /// form sheet builds it); only `.save` commits to the store. That isolation is what makes Cancel
+    /// discard — for an existing edit and a brand-new draft alike. (There is no machine `.cancel` event;
+    /// cancel is simply "never send `.save`".)
+    @MainActor
+    func testUnsavedFormEditsInEditContextDoNotReachTheStore() async throws {
+        let seed = DemoSeedData.generate()
+        let syncContainer = try makeSyncContainer()
+        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
+
+        let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
+        let taskID = DemoSeedData.SeedIDs.Tasks.sessionTimeout
+        try await engine.syncProjectTasks(projectID: projectID)
+        try await engine.syncTaskDetail(taskID: taskID)
+        let originalTitle = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext)).title
+
+        let editContext = ModelContext(syncContainer.modelContainer)
+        editContext.autosaveEnabled = false
+
+        // Cancel-edit: change a draft's title in the editContext, never save.
+        let draft = try XCTUnwrap(fetchTask(id: taskID, in: editContext))
+        draft.title = "Edited but cancelled"
+        // Cancel-create: insert a brand-new draft in the editContext, never save.
+        editContext.insert(Task(id: "CANCELLED-CREATE-1", projectID: projectID, title: "New but cancelled"))
+
+        XCTAssertEqual(
+            try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext)).title, originalTitle,
+            "an unsaved edit must not reach the store (cancel-edit discards)")
+        XCTAssertNil(
+            try fetchTask(id: "CANCELLED-CREATE-1", in: syncContainer.mainContext),
+            "an unsaved new draft must not reach the store (cancel-create discards)")
     }
 
     @MainActor

--- a/docs/planning/ui-test-trial.md
+++ b/docs/planning/ui-test-trial.md
@@ -179,7 +179,10 @@ Each of these has no existing unit that asserts the behavior; add one, then drop
 - **#7 `testDeleteTaskFromProject` → CONVERTED + DROPPED.** Added
   `OfflinePushTests.testOnlineDeleteTaskRemovesLocallyAndOnBackend` (online `deleteTask` → removed locally
   + on backend) — distinct from the offline tombstone-push path. UI test dropped.
+- **#8 `testCancelCreateDoesNotPersistTask` + #9 `testCancelEditKeepsOriginalTaskValues` → CONVERTED +
+  DROPPED.** One unit, `TaskFormPeopleMutationTests.testUnsavedFormEditsInEditContextDoNotReachTheStore`,
+  characterizes the discard mechanism for both: the form edits in an isolated `editContext` (autosave
+  off), and without `.save` neither an edit nor a new draft reaches the store — green. Both UI tests
+  dropped. (There is no machine `.cancel` event; cancel = never sending `.save`.)
 - **#4 `testEditTaskItemsFlow`** — pending: `items` is `@NotExport`, so this needs the form machine's items
   events (`.add`/`.updateTitle`/`.delete`) → `.save`, asserting the persisted items. (Next.)
-- **#8 / #9 cancel** — pending: unit characterizing "the form persists only on `.save`; unsaved
-  editContext changes never reach the store" (covers both cancel-create and cancel-edit). (Next.)

--- a/docs/planning/ui-test-trial.md
+++ b/docs/planning/ui-test-trial.md
@@ -125,3 +125,18 @@ verdict, PR.)
   to drive the full journey through the real app path (offline `updateTask` with `reviewer_ids` → applies
   locally → push → server holds it, proven by a fresh pull) — green. That unit now covers everything the
   UI test asserted; UI-only residue is the offline-toggle button + pending-count badge. R3 → drop.
+- **Offline cluster finding:** auto-sync-on-reconnect is wired in the **app** — `ContentView`'s
+  `.onChange(of: engine.isOffline)` drains the queue, and the pending-count badge is a SwiftUI view. The
+  unit tests (`OfflinePushTests`) call `pushPendingChanges()` *manually*, so they cannot cover that wiring.
+  That makes one offline-integration UI test legitimately UI-only (R4).
+- **#11 `testOfflineCreateQueuesThenSyncsOnReconnect` → KEPT (R4).** The single offline **success**
+  integration smoke: toggle offline → edit → pending badge → reconnect auto-drains → pending clears →
+  persisted. The wiring (`.onChange` + badge) is app-layer; the create/edit logic is unit-covered.
+- **#13 `testRejectedOfflineEditAppearsInFailuresInboxAndDiscards` → KEPT (R4).** The offline **failure**
+  path + the failures-inbox screen (`FailuresSheet`, discard) — a distinct app-layer surface. The failure
+  annotation and discard logic are unit-tested; the inbox surfacing on a rejected auto-sync is not.
+- **#12 `testOfflineEditTaskTitleUpdatesProjectList` → DROPPED.** Offline edit logic covered by
+  `testOfflineEditOfCreatedTaskUpdatesTitleAndKeepsProjectLink`; auto-sync integration by #11; the
+  list-reflects-edit reactivity by the (kept) online #2. R3 → drop.
+- **#15 `testOfflineDeleteQueuesThenSyncsOnReconnect` → DROPPED.** Delete logic covered by
+  `testOfflineDeleteThenPushHardDeletesLocallyAndOnBackend`; integration by #11. R3 → drop.

--- a/docs/planning/ui-test-trial.md
+++ b/docs/planning/ui-test-trial.md
@@ -1,0 +1,116 @@
+# UI Test Trial — put every UI test on trial
+
+## Why
+
+The `DemoUITests` suite is the most expensive thing in CI: it boots a simulator, builds the app, and
+drives the UI serially — ~10 minutes for the whole suite (the ready-gated `iOS Simulator Tests` job from
+PR #633). That cost is only worth paying for a regression **nothing cheaper can catch**.
+
+Two anti-patterns have crept in and must go:
+
+1. **Green-at-birth tests.** A test that passed the moment it was written guards nothing — it never
+   demonstrated it can fail for the reason it claims to. 10 of the 15 UI tests arrived in a single
+   492-file bulk rewrite (`7ab19239` "Replace legacy Sync with SwiftSync codebase"), created alongside
+   the feature, not red-first. These are prime suspects.
+2. **UI tests for logic a unit test can catch.** A CRUD round-trip or an offline-sync rule is engine
+   behavior; it belongs in a DemoCore/DemoBackend/SwiftSync unit test, which runs in milliseconds on
+   every push. Precedent: the dirty-tracking regression *started* as a UI test and was driven down into
+   `DirtyTrackingGapTests` (a DemoCore test on the simulator) — that conversion is the model.
+
+This plan puts **every** UI test on trial, systematically, with a strong bias toward removing or
+converting — but never removing blindly. A UI test survives only with a demonstrated, documented reason.
+
+## Rules (to encode in AGENTS.md)
+
+- **R1 — A UI test owns its timeouts inline.** No shared timeout constant across tests. Each
+  `waitForExistence`/`waitForNonExistence` carries a value sized for *that* test's operation, at the call
+  site. (First concrete task: delete `saveDismissTimeout` and inline a per-call value.)
+- **R2 — No green-at-birth tests.** A test earns its place only by having been **red before** the fix it
+  guards. A test that passed at creation, guarding no demonstrated failure, is removed. (This is the
+  red-first rule from AGENTS.md, applied retroactively as an audit.)
+- **R3 — Prefer the cheapest layer that reproduces the failure.** Before keeping a UI test, try to make
+  the core failure reproduce as a DemoCore/DemoBackend/SwiftSync unit test. If a unit test catches it,
+  the UI test is redundant — drop it.
+- **R4 — Keep a UI test only with a strong, documented reason.** It must exercise something units
+  genuinely cannot (real view hierarchy, navigation between screens, a SwiftUI binding/reactivity path, a
+  gesture, a cancel/dismiss affordance) *and* you have tried and failed to pin it to a unit. State the
+  reason in a one-line comment on the test.
+
+## Trial procedure (run per test)
+
+For each UI test `T`:
+
+1. **Locate its shape.** `git blame` the declaration; read the introducing commit's intent. A test born
+   in a bulk feature commit (no separate red step) is a green-at-birth suspect.
+2. **Red-first check.** Reconstruct whether `T` was red before its guarding fix: revert the fix (or check
+   out the introducing commit's parent) and run `T`. If `T` cannot be shown to have ever failed for its
+   stated reason → **remove** (R2). Paste the (non-)failure.
+3. **Pin to a unit.** Name the core behavior `T` asserts. Write/point to a unit test that fails for the
+   same reason (red), then make it green.
+   - Unit reproduces it → once unit + `T` are both green, **drop `T`** (R3).
+   - Unit cannot reproduce it (failure is genuinely UI-layer) → one more honest attempt → if still not,
+     **keep `T`** with a documented reason (R4).
+4. **Record** the verdict + evidence in the trial log section below.
+
+Batch the work (one PR per cluster, smallest first); never bundle a UI-test deletion with unrelated
+changes. Re-run the `iOS Simulator` gate after each batch.
+
+## First-pass inventory (15 tests)
+
+Existing unit coverage to lean on: `OfflinePushTests` (17 offline/conflict/failure cases),
+`TaskFormPeopleMutationTests` (online people edits), `ScreenStateResolutionTests` (loading/empty/error/
+content states), `TaskFormDescriptionNormalizationTests`, `TaskExportRegressionTests`, `DirtyTrackingGapTests`.
+
+| # | UI test | Shaped | Exercises | Existing unit overlap | Preliminary verdict |
+|---|---|---|---|---|---|
+| 1 | testProjectAndTaskDetailShowSeededContent | bulk `7ab19239` | seeded content renders in list + detail | ScreenStateResolutionTests (content states), engine sync | **Convert/drop** — sync+fetch+state, no UI-only fact |
+| 2 | testUpdateTaskTitleKeepsProjectAndDetailInSync | bulk | title edit reflects in list *and* detail | OfflinePushTests update; SwiftSync @SyncQuery reactivity | **Investigate** — cross-screen reactivity may be the only UI-real part |
+| 3 | testCreateTaskInsideProject | bulk | create flow | engine createTask, OfflinePushTests create | **Convert/drop** |
+| 4 | testEditTaskItemsFlow | bulk | items add/rename/delete | none specific (items mutation) | **Convert** — engine update-with-items unit |
+| 5 | testEditTaskPeopleFlow | bulk | assignee+reviewer+watcher edit | TaskFormPeopleMutationTests (exact) | **Drop (redundant)** |
+| 6 | testAssignUnassignedTask | bulk | set assignee | people-mutation unit | **Convert/drop** |
+| 7 | testDeleteTaskFromProject | bulk | delete task | OfflinePushTests delete, engine delete | **Convert/drop** |
+| 8 | testCancelCreateDoesNotPersistTask | bulk | cancel create persists nothing | none (form machine) | **Convert** — TaskFormSheetMachine cancel unit |
+| 9 | testCancelEditKeepsOriginalTaskValues | bulk | cancel edit discards changes | none (edit-context discard) | **Convert** — editContext discard unit |
+| 10 | testClearTaskReviewersOrWatchers | bulk | clear reviewers/watchers | people-mutation unit | **Drop/convert (redundant)** |
+| 11 | testOfflineCreateQueuesThenSyncsOnReconnect | #620 | offline create → reconnect → sync | testOfflineCreateThenPushStampsRemoteID… | **Pin to unit**; keep only if offline-toggle+pending-count UI is the point |
+| 12 | testOfflineEditTaskTitleUpdatesProjectList | #622 | offline edit → list updates | testOfflineEditOfCreatedTaskUpdatesTitle… | **Pin to unit**; list reactivity maybe UI |
+| 13 | testRejectedOfflineEditAppearsInFailuresInboxAndDiscards | #622 | failures inbox surface + discard | testRejectedPushPersistsFailureReason…, testDiscardFailedChangeRestoresServerState… | **Drop core (redundant)**; inbox rendering only UI-specific part |
+| 14 | testOfflineAddReviewerSyncsOnReconnect | #621 | offline reviewer → sync | testOfflineReviewerAssignmentRoundTrips…, testOfflineUpdateTaskWithReviewerIDsAppliesLocally | **Drop (redundant)** |
+| 15 | testOfflineDeleteQueuesThenSyncsOnReconnect | #620 | offline delete → sync | testOfflineDeleteThenPushHardDeletes… | **Drop/convert (redundant)** |
+
+## Redundancy clusters (first pass)
+
+- **People/relationships** (5, 6, 10, 14): now substantially covered by `TaskFormPeopleMutationTests` and
+  the offline-reviewer unit tests. Strongest drop/convert cluster.
+- **Offline round-trips** (11, 13, 14, 15): overlap `OfflinePushTests` heavily; the engine behavior is
+  already unit-tested. UI-specific residue is the offline toggle, pending-count badge, and failures inbox.
+- **Basic CRUD** (1, 3, 4, 6, 7): engine + state-resolution units cover the logic; little UI-only value.
+- **Cancel/dismiss** (8, 9): form-machine behavior, convertible to machine unit tests.
+
+## Suggested execution order
+
+1. **R1 first** — inline timeouts, delete `saveDismissTimeout` (mechanical, unblocks the rest).
+2. **Clear redundant drops** — 5, 14 (people/reviewer already unit-covered): confirm unit green, drop UI.
+3. **Offline cluster** — 11, 13, 15: confirm `OfflinePushTests` coverage, drop/convert.
+4. **CRUD converts** — 1, 3, 4, 6, 7: pin to engine units, drop UI.
+5. **Cancel converts** — 8, 9: machine unit tests.
+6. **Genuine-UI keepers** — 2, 12 (cross-screen reactivity): try hard to unit-cover @SyncQuery propagation;
+   keep with a documented reason only if not.
+
+## Guardrails
+
+- **Strong reason or it goes.** "It's nice end-to-end coverage" is not a reason. The reason must name the
+  UI-only fact and cite the failed unit attempt.
+- **Document every kept UI test** with a one-line why (R4).
+- **Red-first, always** — converting down means the new unit test must be red before the fix it inherits,
+  or (for already-green behavior) it must be a genuine contract the code can break.
+- The dirty-tracking conversion (`DirtyTrackingGapTests`) is the template for "drove a UI test down to a
+  cheaper layer."
+
+## Trial log
+
+(Filled in as each test goes through the procedure: test, was-it-red-first evidence, unit attempt + result,
+verdict, PR.)
+
+- _pending_

--- a/docs/planning/ui-test-trial.md
+++ b/docs/planning/ui-test-trial.md
@@ -155,13 +155,31 @@ verdict, PR.)
   `watcher_ids`; the backend clear is asserted by `testUpdateTaskFromBodyHonorsReviewerAndWatcherIDs` and
   the online `.save` → backend → local-reflects path by the people-mutation unit (remove case). R3 → drop.
 
-### Remaining — CONVERT (need a red-first unit before dropping)
+### Remaining — CONVERT (add a DemoCore unit, then drop)
 
-These have no existing unit that asserts the behavior; each needs a DemoCore unit (red-first) before the
-UI test is dropped:
+**Principle (the way forward):** when a UI test guards real behavior that has no unit, the answer is to
+*grow unit coverage*, not to delete coverage. Add a DemoCore unit that asserts the behavior
+(characterization — it locks the contract in going forward and would fail if the behavior regressed),
+confirm green, then drop the UI test. New first-party behavior should land with unit coverage by default;
+a UI test is the exception, not the entry point.
+
+Each of these has no existing unit that asserts the behavior; add one, then drop the UI test:
 - **#3 `testCreateTaskInsideProject`** — online create via `.save` (form enable + createTask with people).
 - **#4 `testEditTaskItemsFlow`** — items add/rename/delete via `.save`.
 - **#7 `testDeleteTaskFromProject`** — online delete path (`apiClient.deleteTask` → re-sync), distinct from
   the offline tombstone push path already covered.
 - **#8 `testCancelCreateDoesNotPersistTask`** / **#9 `testCancelEditKeepsOriginalTaskValues`** — form-machine
   cancel / edit-context discard.
+
+#### Converted so far
+
+- **#3 `testCreateTaskInsideProject` → CONVERTED + DROPPED.** Added
+  `OfflinePushTests.testOnlineCreateTaskPersistsLocallyAndReachesBackend` (online `createTask` → local row
+  + reaches backend, not pending) — green. UI test dropped.
+- **#7 `testDeleteTaskFromProject` → CONVERTED + DROPPED.** Added
+  `OfflinePushTests.testOnlineDeleteTaskRemovesLocallyAndOnBackend` (online `deleteTask` → removed locally
+  + on backend) — distinct from the offline tombstone-push path. UI test dropped.
+- **#4 `testEditTaskItemsFlow`** — pending: `items` is `@NotExport`, so this needs the form machine's items
+  events (`.add`/`.updateTitle`/`.delete`) → `.save`, asserting the persisted items. (Next.)
+- **#8 / #9 cancel** — pending: unit characterizing "the form persists only on `.save`; unsaved
+  editContext changes never reach the store" (covers both cancel-create and cancel-edit). (Next.)

--- a/docs/planning/ui-test-trial.md
+++ b/docs/planning/ui-test-trial.md
@@ -119,3 +119,9 @@ verdict, PR.)
   which drives the same machine with a richer add+remove scenario and asserts the persisted set (verified
   green). UI-only residue (picker wiring, detail rendering) is generic SwiftUI, not a strong reason to keep
   the slowest/flakiest UI test. R3 → drop.
+- **#14 `testOfflineAddReviewerSyncsOnReconnect` → DROPPED.** Born green with #621 (demo workflow, not
+  red-first). It was actually the one that surfaced the offline `@NotExport` regression — but that's a
+  *unit* fact. Strengthened `OfflinePushTests.testOfflineReviewerEditViaUpdateBodyAppliesLocallyAndSyncsOnReconnect`
+  to drive the full journey through the real app path (offline `updateTask` with `reviewer_ids` → applies
+  locally → push → server holds it, proven by a fresh pull) — green. That unit now covers everything the
+  UI test asserted; UI-only residue is the offline-toggle button + pending-count badge. R3 → drop.

--- a/docs/planning/ui-test-trial.md
+++ b/docs/planning/ui-test-trial.md
@@ -140,3 +140,28 @@ verdict, PR.)
   list-reflects-edit reactivity by the (kept) online #2. R3 → drop.
 - **#15 `testOfflineDeleteQueuesThenSyncsOnReconnect` → DROPPED.** Delete logic covered by
   `testOfflineDeleteThenPushHardDeletesLocallyAndOnBackend`; integration by #11. R3 → drop.
+- **#1 `testProjectAndTaskDetailShowSeededContent` → DROPPED.** Pure display of synced seed data; the sync
+  is engine-tested and the content/loading states are `ScreenStateResolutionTests`. The detail render is
+  also exercised by the kept #2. R3 → drop.
+- **#2 `testUpdateTaskTitleKeepsProjectAndDetailInSync` → KEPT (R4).** The one cross-screen reactivity
+  test: a save must propagate to BOTH the detail and the project-list row (`@SyncQuery` driving two
+  SwiftUI views). The update + blank-description normalization are unit-tested
+  (`OfflinePushTests`, `TaskFormDescriptionNormalizationTests`); the reactive propagation is not
+  unit-coverable without a view host.
+- **#6 `testAssignUnassignedTask` → DROPPED.** Assignee-set-via-`.save` is asserted by
+  `TaskFormPeopleMutationTests.testEditTaskPeopleFlowReplacesReviewersAndWatchers` (sets assignee, checks
+  persisted). nil→value is the same `updateTask` path. R3 → drop.
+- **#10 `testClearTaskReviewersOrWatchers` → DROPPED.** Clearing is `.save` with empty `reviewer_ids`/
+  `watcher_ids`; the backend clear is asserted by `testUpdateTaskFromBodyHonorsReviewerAndWatcherIDs` and
+  the online `.save` → backend → local-reflects path by the people-mutation unit (remove case). R3 → drop.
+
+### Remaining — CONVERT (need a red-first unit before dropping)
+
+These have no existing unit that asserts the behavior; each needs a DemoCore unit (red-first) before the
+UI test is dropped:
+- **#3 `testCreateTaskInsideProject`** — online create via `.save` (form enable + createTask with people).
+- **#4 `testEditTaskItemsFlow`** — items add/rename/delete via `.save`.
+- **#7 `testDeleteTaskFromProject`** — online delete path (`apiClient.deleteTask` → re-sync), distinct from
+  the offline tombstone push path already covered.
+- **#8 `testCancelCreateDoesNotPersistTask`** / **#9 `testCancelEditKeepsOriginalTaskValues`** — form-machine
+  cancel / edit-context discard.

--- a/docs/planning/ui-test-trial.md
+++ b/docs/planning/ui-test-trial.md
@@ -184,5 +184,19 @@ Each of these has no existing unit that asserts the behavior; add one, then drop
   characterizes the discard mechanism for both: the form edits in an isolated `editContext` (autosave
   off), and without `.save` neither an edit nor a new draft reaches the store — green. Both UI tests
   dropped. (There is no machine `.cancel` event; cancel = never sending `.save`.)
-- **#4 `testEditTaskItemsFlow`** — pending: `items` is `@NotExport`, so this needs the form machine's items
-  events (`.add`/`.updateTitle`/`.delete`) → `.save`, asserting the persisted items. (Next.)
+- **#4 `testEditTaskItemsFlow` → CONVERTED + DROPPED.** Correction: `items` is **not** `@NotExport` (it's a
+  plain exported `@Relationship`), so `export(task)` includes the items array. Added
+  `OfflinePushTests.testUpdateTaskItemsAddRenameDelete` (edit the exported items — rename/delete/add — via
+  `updateTask`, assert the persisted titles) — green. UI test dropped.
+
+## Outcome
+
+15 → 3 UI tests. **Dropped 12** (7 redundant, 5 converted to DemoCore units). **Kept 3** with documented
+R4 reasons — all genuinely app-layer, not unit-coverable:
+- `#2` cross-screen `@SyncQuery` reactivity,
+- `#11` offline-success integration (`ContentView.onChange` auto-drain + pending badge),
+- `#13` failures-inbox screen (`FailuresSheet`).
+
+New DemoCore units added: online create, online delete, items add/rename/delete, offline-reviewer
+round-trip (strengthened), editContext-isolation (cancel). Follow-up applied: R1 — the 3 survivors own
+their timeouts inline; `saveDismissTimeout` deleted.

--- a/docs/planning/ui-test-trial.md
+++ b/docs/planning/ui-test-trial.md
@@ -113,4 +113,9 @@ content states), `TaskFormDescriptionNormalizationTests`, `TaskExportRegressionT
 (Filled in as each test goes through the procedure: test, was-it-red-first evidence, unit attempt + result,
 verdict, PR.)
 
-- _pending_
+- **#5 `testEditTaskPeopleFlow` → DROPPED.** Born green in the bulk import `7ab19239` (R2: never red-first;
+  demo-workflow UI tests aren't TDD'd). Its behavior — a people edit (assignee + reviewers + watchers)
+  persists through the `.save` path — is covered by `TaskFormPeopleMutationTests.testEditTaskPeopleFlowReplacesReviewersAndWatchers`,
+  which drives the same machine with a richer add+remove scenario and asserts the persisted set (verified
+  green). UI-only residue (picker wiring, detail rendering) is generic SwiftUI, not a strong reason to keep
+  the slowest/flakiest UI test. R3 → drop.


### PR DESCRIPTION
## What

Systematically puts every DemoUITests test on trial (`docs/planning/ui-test-trial.md`): **15 → 3**.

- **Dropped 12** — 7 redundant (behavior already unit-covered), 5 **converted** to new DemoCore units.
- **Kept 3** with documented R4 reasons (genuinely app-layer, not unit-coverable):
  - `#2` cross-screen `@SyncQuery` reactivity (a save propagates to detail *and* list),
  - `#11` offline-success integration (`ContentView.onChange` auto-drains the queue + pending badge),
  - `#13` failures-inbox screen (`FailuresSheet` + discard).

## Rules (new, in AGENTS.md → "UI tests are a last resort")

- **R1** a UI test owns its timeouts inline — no shared constant (`saveDismissTimeout` deleted).
- **R2** no green-at-birth tests (earn the slot by being red-first).
- **R3** prefer the cheapest layer — pin the failure to a unit; if it catches it, drop the UI test.
- **R4** keep a UI test only with a strong, documented reason.

## New DemoCore units (coverage moved down a layer)

online create, online delete, items add/rename/delete, offline-reviewer full round-trip (strengthened), and editContext-isolation (covers cancel-create + cancel-edit).

## Why

UI tests are the costliest CI tier (the ready-gated `iOS Simulator Tests` job). 10 of the 15 arrived in one 492-file bulk import (green at birth). The way forward, baked into the plan: grow unit coverage; a UI test is the exception, not the entry point.

## Verification

- DemoCore: **42 tests** green (was 37 + 5 new units).
- The 3 surviving UI tests + the iOS dirty-tracking regression run on the `iOS Simulator Tests` gate (this PR marked ready).