### PR TITLE
ci: skip heavy workflows for doc-only changes (paths-ignore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ name: CI
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -8,6 +8,9 @@ name: iOS Simulator
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds `paths-ignore: ['**.md', 'docs/**']` to `ci.yml` and `ios-regression.yml`. A PR whose **only** changes are markdown/docs no longer triggers the heavy jobs. Mixed doc+code PRs still run everything (paths-ignore skips only when every changed file matches).

⚠️ **Step 1 of 2.** With the current branch protection (10 required checks + `enforce_admins: true`), a doc-only PR will now *skip* CI **and therefore be un-mergeable** — the required checks never report, and admins can't override. To make doc changes actually fast we still need step 2 (relax `enforce_admins`, or a docs-OK shim). This PR alone is the experiment to confirm the skip behavior.

Minor known tradeoff: doc-only PRs also skip the `Doc link check` job (it lives in `ci.yml`). Worth splitting out later if that matters.

This PR changes workflow files (not doc-only), so it runs full CI as normal.