### PR TITLE
docs: roadmap — record CI gates shipped (paths-ignore test)

### DIFF
--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -70,6 +70,9 @@ API minimal (macros + convention over configuration), worked one item at a time.
       on-brand than a coverage %. Canonical implementation: the reusable `swiftlang/github-workflows`
       `soundness.yml` (`api_breakage_check`). It only becomes meaningful with a baseline tag, so it's
       gated on the first release, not now.
+- [x] Self-hosted core-coverage evaluation + regression gate for `SwiftSync/Sources` (per-file
+      evaluation, patch gate on new core lines, no-decrease gate) — shipped in #636. Doc-only PRs skip the
+      heavy CI via `paths-ignore` — shipped in #637.
 
 ### Phase 7 — Production-sync story (foundation shipped)
 


### PR DESCRIPTION
Doc-only PR (single roadmap line). Purpose: also the live test of the `paths-ignore` doc fast-path from #637 — the heavy CI workflows should **not** trigger here.

Expected, given current branch protection: CI skips, but the PR then shows the 10 required checks as missing and is un-mergeable until step 2 (relax `enforce_admins`).