### PR TITLE
docs: record the doc-only fast path in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,12 @@
 
 - This is a personally-responsible repo (`3lvis` remote), so the global rule applies: commit and open a
   **draft** PR proactively once a branch is a complete, green unit — no need to ask first or show the
-  title/body. **Never merge without an explicit ask.**
+  title/body. **Never merge without an explicit ask** — *except the doc-only fast path below.*
+- **Doc-only fast path.** A PR whose changes are *only* `**.md` / `docs/**` skips the heavy CI
+  (`paths-ignore` in `ci.yml` + `ios-regression.yml`), so no required checks report. Because
+  `enforce_admins` is off on `master`, such a PR may be **opened and admin-merged immediately without
+  asking** — `gh pr merge <n> --squash --admin --delete-branch`. This is the *only* merge allowed without
+  an explicit ask. A mixed doc+code PR runs full CI and follows the normal gate (green, then ask).
 - Before every commit:
   - run `git status --short`
   - confirm only intended files are staged


### PR DESCRIPTION
Records the rule we just set up: doc-only PRs (`**.md`/`docs/**`) skip heavy CI via `paths-ignore` and, with `enforce_admins` off, may be admin-merged immediately without asking. Mixed PRs follow the normal gate.

Itself a doc-only PR — so it should skip CI and be admin-mergeable (the second end-to-end proof).