### PR TITLE
ci: make core coverage informational, not a gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,10 @@ jobs:
             --filter FetchStrategyBenchmarkTests/testGlobalBatchSyncBenchmarks \
             --filter FetchStrategyBenchmarkTests/testSingleItemSyncBenchmarks
 
+  # Informational report, not a gate: surfaces SwiftSync core coverage (table + new-uncovered-line
+  # annotations + delta) in the step summary, but never fails CI and is intentionally not a required check.
   core-coverage:
-    name: Core coverage gate (SwiftSync)
+    name: Core coverage (SwiftSync)
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
@@ -143,22 +145,22 @@ jobs:
         run: swift --version
 
       # `swift test --show-codecov-path` only prints the path — it does NOT re-run tests. Run coverage
-      # for real first, then read the path, or the gate scores stale data.
+      # for real first, then read the path, or the report scores stale data.
       - name: Coverage (HEAD)
         run: |
           swift test --enable-code-coverage
           echo "HEAD_JSON=$(swift test --show-codecov-path)" >> "$GITHUB_ENV"
 
-      - name: Evaluate core coverage (informational)
+      - name: Evaluate core coverage
         run: python3 scripts/core_coverage.py evaluate --head "$HEAD_JSON"
 
-      - name: Patch gate — new SwiftSync core lines must be covered
+      - name: Patch coverage report (new core lines)
         if: github.event_name == 'pull_request'
         run: |
           python3 scripts/core_coverage.py patch \
             --head "$HEAD_JSON" --diff-base "origin/${{ github.base_ref }}...HEAD"
 
-      - name: No-decrease gate — core coverage must not drop vs base
+      - name: Core coverage delta vs base
         if: github.event_name == 'pull_request'
         run: |
           cp scripts/core_coverage.py "$RUNNER_TEMP/cc.py"

--- a/scripts/core_coverage.py
+++ b/scripts/core_coverage.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python3
-"""Self-hosted code-coverage evaluation + regression gate for the SwiftSync library.
+"""Self-hosted code-coverage *report* for the SwiftSync library — informational, never a blocker.
 
 Reads the llvm-cov JSON that `swift test --enable-code-coverage --show-codecov-path` produces and acts
 only on the public library at SwiftSync/Sources/SwiftSync — the demo packages are out of scope. No
-third-party service: it's the toolchain's own coverage data plus this script, mirroring how the warnings,
-perf, and format gates are in-repo too.
+third-party service: it's the toolchain's own coverage data plus this script. Every subcommand exits 0;
+findings surface as a GitHub step summary + PR annotations, so coverage is visible without ever failing
+CI (deliberately not a required check).
 
 Subcommands:
   evaluate --head H.json
-      Print a per-file + total line-coverage table (and a GitHub step summary). Never fails.
+      Print a per-file + total line-coverage table (and a GitHub step summary).
   patch --head H.json --diff-base <ref>
-      Fail if any line *added* in this diff (under SwiftSync/Sources/SwiftSync) is an executable line
-      that no test covers. The gate that bites: you can't add untested core code. Escape hatch: a
-      trailing `// coverage:ignore` on the line.
+      Report any line *added* in this diff (under SwiftSync/Sources/SwiftSync) that is an executable line
+      no test covers — as warning annotations + a summary. Escape hatch: a trailing `// coverage:ignore`.
   compare --head H.json --base B.json
-      Fail if core total line coverage dropped vs base by more than EPSILON (a no-decrease ratchet, not
-      an absolute target).
+      Report the core total line-coverage delta vs base (a warning if it dropped past EPSILON).
 """
 
 import argparse
@@ -111,17 +110,22 @@ def cmd_patch(args):
         for ln in sorted(lines):
             if ln not in covered or covered[ln]:
                 continue  # not executable, or already covered
-            text = source[ln - 1] if ln - 1 < len(source) else ""
-            if "coverage:ignore" in text:
+            raw = source[ln - 1] if ln - 1 < len(source) else ""
+            if "coverage:ignore" in raw:
                 continue
-            violations.append(f"{path}:{ln}: {text.strip()}")
-    if violations:
-        print("::error::New SwiftSync core lines are not covered by any test:")
-        for v in violations:
-            print(f"  {v}")
-        print("Add a test, or annotate the line with `// coverage:ignore` if intentionally untestable.")
-        return 1
-    print("Patch coverage OK: every added SwiftSync core line is tested.")
+            violations.append((path, ln, raw.strip()))
+    # Informational, not blocking: surface findings as PR annotations + a summary, but never fail.
+    if not violations:
+        print("Patch coverage: every added SwiftSync core line is covered.")
+        emit_summary("### Patch coverage\n\n✅ Every added `SwiftSync/Sources` line is covered by a test.")
+        return 0
+    for path, ln, _text in violations:
+        print(f"::warning file={path},line={ln}::Added SwiftSync core line not covered by a test")
+    body = "\n".join(f"- `{p}:{ln}` — {t}" for p, ln, t in violations)
+    emit_summary(
+        "### ⚠️ Patch coverage — new core lines not covered\n\n" + body
+        + "\n\n_Informational only. Add a test, or `// coverage:ignore` if intentionally untestable._")
+    print(f"{len(violations)} added SwiftSync core line(s) not covered (informational, not blocking).")
     return 0
 
 
@@ -129,11 +133,12 @@ def cmd_compare(args):
     _, _, head_pct = core_total(core_files(args.head))
     _, _, base_pct = core_total(core_files(args.base))
     delta = head_pct - base_pct
-    print(f"core coverage: base {base_pct:.1f}% -> head {head_pct:.1f}% ({delta:+.1f}pp)")
+    line = f"core coverage: base {base_pct:.1f}% → head {head_pct:.1f}% ({delta:+.1f}pp)"
+    print(line)
+    emit_summary("### Core coverage delta\n\n" + line)
+    # Informational, not blocking.
     if delta < -EPSILON:
-        print(f"::error::SwiftSync core coverage dropped {-delta:.1f}pp (> {EPSILON}pp). "
-              "Add tests for the code that lost coverage.")
-        return 1
+        print(f"::warning::SwiftSync core coverage dropped {-delta:.1f}pp (informational, not blocking).")
     return 0
 
 


### PR DESCRIPTION
Per request: keep core coverage **informative, not a blocker**.

- `patch` and `compare` now emit GitHub **warning annotations + a step-summary message** and **always exit 0** (were failing the check on a violation).
- Renamed the job `Core coverage gate (SwiftSync)` → `Core coverage (SwiftSync)` and the steps from 'gate … must …' to reports.
- Still runs on every PR (surfaces the per-file table, new-uncovered-line annotations, and the coverage delta); intentionally **not** a required check, so it never blocks.

Verified locally: an uncovered added line now produces `::warning::` + exit 0 (was exit 1).

Touches a workflow file, so it runs full CI and needs the `workflow` token scope (or a browser merge).