### PR TITLE
Phase 5: document the public API surface + mark macro-support publics

### DIFF
--- a/SwiftSync/Sources/SwiftSync/Core.swift
+++ b/SwiftSync/Sources/SwiftSync/Core.swift
@@ -47,6 +47,8 @@ private func toSnakeCaseString(_ value: String) -> String {
 
 public enum SwiftSync {}
 
+// PUBLIC BY CONTRACT — @Syncable's generated extension conforms to this in the consumer's module;
+// demoting it or its members breaks consumers. See docs/planning/public-api-surface.md.
 public protocol SyncModelable: PersistentModel {
     associatedtype SyncID: Hashable & Codable & Sendable
     static var syncIdentity: KeyPath<Self, SyncID> { get }
@@ -96,6 +98,8 @@ extension SyncModelable {
     public static var syncRelationshipSchemaDescriptors: [SyncRelationshipSchemaDescriptor] { [] }
 }
 
+// PUBLIC BY CONTRACT — @Syncable builds these in the consumer's module (syncRelationshipSchemaDescriptors);
+// demoting it breaks consumers. See docs/planning/public-api-surface.md.
 public struct SyncRelationshipSchemaDescriptor: Sendable {
     public let propertyName: String
     public let relatedTypeName: String
@@ -115,6 +119,8 @@ public struct SyncRelationshipSchemaDescriptor: Sendable {
     }
 }
 
+// PUBLIC BY CONTRACT — @Syncable's generated extension conforms to this in the consumer's module
+// (make/apply/applyRelationships/export/syncMarkChanged); demoting it breaks consumers. See docs/planning/public-api-surface.md.
 public protocol SyncUpdatableModel: SyncModelable {
     static func make(from payload: SyncPayload) throws -> Self
     func apply(_ payload: SyncPayload) throws -> Bool
@@ -261,6 +267,9 @@ enum SyncRelationshipLookupState {
     @TaskLocal static var current: SyncRelationshipLookupCache?
 }
 
+// PUBLIC BY CONTRACT — every syncApplyTo{One,Many}{ForeignKey,NestedObject} helper below (all overloads)
+// is emitted into the consumer's module by @Syncable's generated relationship apply; demoting any breaks
+// consumers. See docs/planning/public-api-surface.md.
 @discardableResult
 public func syncApplyToOneForeignKey<Owner, Related: PersistentModel>(
     _ owner: Owner,
@@ -791,6 +800,8 @@ public protocol ParentScopedModel: SyncUpdatableModel {
     static var parentRelationship: ReferenceWritableKeyPath<Self, SyncParent?> { get }
 }
 
+// PUBLIC BY CONTRACT — named in @Syncable's generated applyRelationships(...) in the consumer's module;
+// demoting it breaks consumers. See docs/planning/public-api-surface.md.
 public struct SyncRelationshipOperations: OptionSet, Sendable {
     public let rawValue: Int
 
@@ -833,6 +844,8 @@ func defaultExportDateFormatter() -> DateFormatter {
 /// Cycle-detection state for recursive relationship export.
 /// This type is an implementation detail of `@Syncable`-generated code.
 /// Do not instantiate or reference it directly.
+// PUBLIC BY CONTRACT — generated export(...) calls enter/leave in the consumer's module; demoting it
+// breaks consumers. See docs/planning/public-api-surface.md.
 public enum ExportState {
     private static let threadDictionaryKey = "SwiftSync.ExportState"
 
@@ -868,6 +881,8 @@ private final class ExportStateBox {
     init(_ visiting: Set<String>) { self.visiting = visiting }
 }
 
+// PUBLIC BY CONTRACT — @Syncable's generated export(...) calls this in the consumer's module; demoting
+// it breaks consumers. See docs/planning/public-api-surface.md.
 public func exportEncodeValue(_ raw: Any, dateFormatter: DateFormatter) -> Any? {
     switch raw {
     case let value as String:
@@ -923,6 +938,8 @@ public func exportEncodeValue(_ raw: Any, dateFormatter: DateFormatter) -> Any? 
     }
 }
 
+// PUBLIC BY CONTRACT — @Syncable's generated export(...) calls this in the consumer's module; demoting
+// it breaks consumers. See docs/planning/public-api-surface.md.
 public func exportSetValue(_ value: Any, for keyPath: String, into target: inout [String: Any]) {
     let parts = keyPath.split(separator: ".").map(String.init)
     guard !parts.isEmpty else { return }

--- a/docs/planning/public-api-surface.md
+++ b/docs/planning/public-api-surface.md
@@ -1,0 +1,64 @@
+# Public API Surface — the contract
+
+The authoritative map of what `SwiftSync` (the library target, `SwiftSync/Sources/SwiftSync`) exposes,
+and **why**. Its companion [`api-surface-review.md`](api-surface-review.md) tracks *shrinking* the
+surface; this doc records the surface that should *stay*, so nothing is demoted by accident.
+
+The surface is **sacred and minimal**: a pure `@Syncable` model needs the consumer to hand-write zero
+sync code. Every `public` symbol falls into one of the buckets below. Before adding a `public`, it must
+fit one — otherwise it's accidental and should be `internal`.
+
+## 1. Consumer API — what a consumer calls directly
+
+- `SwiftSync` — root namespace for the top-level static API.
+- `SyncContainer` — the entry point: both inits, `modelContainer` / `mainContext` / `keyStyle` /
+  `dateFormatter`, the `sync(payload:…)` / `sync(item:…)` overloads (incl. parent-scoped), `export(_:)`.
+- `SwiftSync.pendingChanges(for:in:)`, `SwiftSync.push(for:in:upload:)`, `SwiftSync.inboundAuthor` —
+  the offline push entry points.
+- `KeyStyle`, `SyncError` — configuration + the single error currency.
+- `SyncPayload`, `SyncPayloadConvertible` — payload wrapper + the opt-in "convert my type to a payload".
+- Macro attributes: `@Syncable`, `@PrimaryKey`, `@RemoteKey`, `@NotExport` (declared in the macro module).
+
+## 2. Macro-support — PUBLIC BY CONTRACT (must never be demoted)
+
+These are `public` **only** because the `@Syncable` macro's generated code calls or conforms to them, and
+that generated code lives in the **consumer's** module. Demoting any of them is a source break for *every*
+consumer, even though nothing in this repo outside the macro calls them. They are marked at their
+declaration in `Core.swift` with a `PUBLIC BY CONTRACT` comment — do not remove the marker or the `public`.
+
+| Symbol | Kind | Why public |
+|---|---|---|
+| `SyncModelable` | protocol | generated extension conforms to it; all members are implemented in the consumer module |
+| `SyncUpdatableModel` | protocol | generated extension conforms to it (`make`/`apply`/`applyRelationships`/`export`/`syncMarkChanged`) |
+| `SyncRelationshipSchemaDescriptor` | struct | the macro builds an array of these for `syncRelationshipSchemaDescriptors` |
+| `SyncRelationshipOperations` | struct (OptionSet) | named in the generated `applyRelationships(...)` signature/body |
+| `ExportState` | enum | generated `export(...)` calls `enter`/`leave` for cycle detection |
+| `exportEncodeValue(_:dateFormatter:)` | func | generated `export(...)` encodes each scalar through it |
+| `exportSetValue(_:for:into:)` | func | generated `export(...)` writes (nested) keys through it |
+| `syncApplyToOneForeignKey` | func (overloads) | generated relationship-apply emits calls (to-one FK) |
+| `syncApplyToManyForeignKeys` | func (overloads) | generated relationship-apply emits calls (to-many FK) |
+| `syncApplyToOneNestedObject` | func (overloads) | generated relationship-apply emits calls (to-one nested) |
+| `syncApplyToManyNestedObjects` | func (overloads) | generated relationship-apply emits calls (to-many nested) |
+
+Verification: each name appears in the emitted code in `SwiftSync/Sources/MacrosImplementation/SyncableMacro.swift`
+(grep the macro for the symbol). Keep that true — if the macro stops emitting one, *then* it can be demoted.
+
+## 3. Reactive reads (SwiftUI) — consumer-facing
+
+- `@SyncQuery` / `@SyncModel` — the property wrappers consumers use in SwiftUI.
+- `SyncQueryPublisher` / `SyncModelPublisher` — `@Observable` non-property-wrapper equivalents.
+
+(Whether the two publishers stay public or collapse behind the wrappers is open as
+`api-surface-review.md` item 7 — a deliberate decision, not an accidental-public question.)
+
+## 4. Offline push seam — consumer constructs / reads
+
+`SyncPendingChanges` (read), `SyncPushBatch` (read in the upload closure), `SyncPushResponse` +
+`SyncPushFailure` (consumer constructs in its upload closure), `SyncPushSummary` (read from `push()`).
+Tightening these five is open as `api-surface-review.md` item 5.
+
+## Enforcement
+
+- **Now (human):** the `PUBLIC BY CONTRACT` markers in `Core.swift` + this doc.
+- **At first tag (automated):** the release-time `swift package diagnose-api-breaking-changes` gate
+  (roadmap Phase 6) will flag any accidental demotion of these symbols against the published baseline.

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -42,12 +42,15 @@ API minimal (macros + convention over configuration), worked one item at a time.
 
 ## Open items
 
-### Phase 5 — Tighten the public API surface (deferred to first release / tag time)
+### Phase 5 — Tighten the public API surface
 
-- [ ] **Not now — do this when we cut the first tag.** Document the intended public surface and the
-      macro-support extension points (the helpers that must stay public) so they aren't mistakenly
-      demoted later. Lands alongside the release-time API-breakage gate (Phase 6); there's nothing to
-      protect until there's a tag to diff against.
+- [x] **Document the intended public surface + the macro-support extension points so nothing is demoted by
+      accident** — done: [`public-api-surface.md`](public-api-surface.md) is the contract (consumer API,
+      the PUBLIC-BY-CONTRACT macro-support set, reactive, push seam), and every macro-support symbol in
+      `Core.swift` carries a `PUBLIC BY CONTRACT` marker at its declaration. The release-time API-breakage
+      gate (Phase 6) enforces it automatically once there's a tag.
+- [ ] Further *shrinking* of the surface stays tracked in [`api-surface-review.md`](api-surface-review.md)
+      — items 5 (push-response seam) and 7 (reactive publishers); separate decisions, not this item.
 
 ### Phase 6 — CI gates for world-class hygiene
 


### PR DESCRIPTION
Phase 5 — document the intended public surface and the macro-support extension points so nothing gets demoted by accident.

## What
- **`docs/planning/public-api-surface.md`** — the contract: every `public` symbol bucketed into consumer API, the **PUBLIC-BY-CONTRACT macro-support set** (must never demote), reactive (`@SyncQuery`/publishers), and the push seam.
- **`Core.swift` markers** — each macro-support symbol now carries a one-line `PUBLIC BY CONTRACT` comment at its declaration: `SyncModelable`, `SyncUpdatableModel`, `SyncRelationshipSchemaDescriptor`, `SyncRelationshipOperations`, `ExportState`, `exportEncodeValue`, `exportSetValue`, and the four `syncApplyTo*` families. The `@Syncable` macro emits calls to these **in the consumer's module**, so demoting any is a break for every consumer (verified against `MacrosImplementation/SyncableMacro.swift`).

## Scope
- **Comment + docs only — the public surface is unchanged** (the survey's two 'accidental publics' turned out to already be `internal`; nothing to demote).
- Further *shrinking* (push-response seam, reactive publishers) stays tracked in `api-surface-review.md` items 5 & 7 — separate decisions.
- Enforcement becomes automatic via the release-time API-breakage gate (Phase 6) once there's a tag.

Verified: swift-format clean, SwiftSync tests green (171 + 48).