### PR TITLE
Push seam: upload returns only failures; confirm by complement

### DIFF
--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -621,7 +621,7 @@ public final class DemoServerSimulator {
 
     // MARK: - POST /sync/upload (offline batch push)
     // See docs/project/upload-endpoint-contract.md. A flat, op-tagged operation list; per-operation
-    // results (no all-or-nothing). Operations are keyed by the client's stable `localId`, which is the
+    // results (no all-or-nothing). Operations are keyed by the client's stable `id`, which is the
     // row's public_id. The internal int id never leaves the server. `upsert` is find-by-public_id →
     // update-else-create, `delete` tombstones by public_id. Both are idempotent.
 
@@ -647,23 +647,23 @@ public final class DemoServerSimulator {
         }
     }
 
-    /// Insert-or-update keyed by the client's stable `localId` (the row's public_id). Found ⇒ update
+    /// Insert-or-update keyed by the client's stable `id` (the row's public_id). Found ⇒ update
     /// (last-writer-wins); absent ⇒ create, adopting that public_id. The internal int id never leaves
     /// the server. Idempotent: re-sending converges, no duplicate row.
     private func uploadUpsert(_ payload: [String: Any]) throws -> [String: Any] {
         try requireTasksType(payload)
-        let localID = try requireLocalID(payload)
+        let id = try requireID(payload)
         let incoming = try requireUpdatedAt(payload)
         guard let data = payload["data"] as? [String: Any] else {
             throw DemoBackendError.validation(message: "data is required for upsert")
         }
         var body = data
-        body["id"] = localID
+        body["id"] = id
 
-        if let existingID = try taskRowID(forPublicID: localID, includeTombstoned: true) {
+        if let existingID = try taskRowID(forPublicID: id, includeTombstoned: true) {
             if try isStale(rowID: existingID, incoming: incoming) {
                 return [
-                    "operation": "upsert", "localId": localID, "status": "stale",
+                    "operation": "upsert", "id": id, "status": "stale",
                     "server": try taskDetailPayload(rowID: existingID) ?? NSNull(),
                 ]
             }
@@ -677,21 +677,21 @@ public final class DemoServerSimulator {
         } else {
             _ = try createTask(body: body)
         }
-        return ["operation": "upsert", "localId": localID, "status": "applied"]
+        return ["operation": "upsert", "id": id, "status": "applied"]
     }
 
     private func uploadDelete(_ payload: [String: Any]) throws -> [String: Any] {
         try requireTasksType(payload)
-        let localID = try requireLocalID(payload)
+        let id = try requireID(payload)
         let incoming = try requireUpdatedAt(payload)
-        guard let rowID = try taskRowID(forPublicID: localID, includeTombstoned: true) else {
+        guard let rowID = try taskRowID(forPublicID: id, includeTombstoned: true) else {
             // Already absent (or never synced) ⇒ idempotent success.
-            return ["operation": "delete", "localId": localID, "status": "applied"]
+            return ["operation": "delete", "id": id, "status": "applied"]
         }
         // Last-writer-wins applies to deletes too: an older delete must not erase a newer server edit.
         if try isStale(rowID: rowID, incoming: incoming) {
             return [
-                "operation": "delete", "localId": localID, "status": "stale",
+                "operation": "delete", "id": id, "status": "stale",
                 "server": try taskDetailPayload(rowID: rowID) ?? NSNull(),
             ]
         }
@@ -706,7 +706,7 @@ public final class DemoServerSimulator {
                 self.sqlite.bind(int: rowID, at: 3, in: stmt)
             }
         )
-        return ["operation": "delete", "localId": localID, "status": "applied"]
+        return ["operation": "delete", "id": id, "status": "applied"]
     }
 
     private func requireTasksType(_ payload: [String: Any]) throws {
@@ -715,11 +715,11 @@ public final class DemoServerSimulator {
         }
     }
 
-    private func requireLocalID(_ payload: [String: Any]) throws -> String {
-        guard let localID = payload["localId"] as? String, !localID.isEmpty else {
-            throw DemoBackendError.validation(message: "localId is required")
+    private func requireID(_ payload: [String: Any]) throws -> String {
+        guard let id = payload["id"] as? String, !id.isEmpty else {
+            throw DemoBackendError.validation(message: "id is required")
         }
-        return localID
+        return id
     }
 
     private func requireUpdatedAt(_ payload: [String: Any]) throws -> Date {
@@ -754,7 +754,7 @@ public final class DemoServerSimulator {
     private func rejected(_ payload: [String: Any], code: String, message: String) -> [String: Any] {
         var result: [String: Any] = ["status": "rejected", "code": code, "message": message]
         if let operation = payload["operation"] as? String { result["operation"] = operation }
-        if let localID = payload["localId"] as? String { result["localId"] = localID }
+        if let id = payload["id"] as? String { result["id"] = id }
         return result
     }
 

--- a/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
@@ -9,24 +9,24 @@ final class UploadEndpointTests: XCTestCase {
 
     func testUploadUpsertAdoptsPublicIDAndIsIdempotent() throws {
         let backend = try makeBackend()
-        let localID = "11111111-1111-1111-1111-111111111111"
+        let id = "11111111-1111-1111-1111-111111111111"
         let before = try backend.getProjectTasksPayload(projectID: projectID).count
 
-        let first = try result(of: backend.upload(operations: [upsertOp(localID: localID, title: "Offline task")]))
+        let first = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
         XCTAssertEqual(first["status"] as? String, "applied")
-        XCTAssertEqual(first["localId"] as? String, localID)
+        XCTAssertEqual(first["id"] as? String, id)
         // The internal int id never leaves the server — no remoteId in the response.
         XCTAssertNil(first["remoteId"])
 
         let tasks = try backend.getProjectTasksPayload(projectID: projectID)
         XCTAssertEqual(tasks.count, before + 1)
-        // The client's localId is adopted as the row's public_id (its sole identity).
-        let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == localID })
+        // The client's id is adopted as the row's public_id (its sole identity).
+        let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == id })
         XCTAssertNil(inserted["local_id"])
 
         // Re-upsert the same public_id (lost-response retry): no duplicate row. The identical updatedAt
         // loses the LWW tie, so it's a converged no-op — not a failure.
-        let retry = try result(of: backend.upload(operations: [upsertOp(localID: localID, title: "Offline task")]))
+        let retry = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
         XCTAssertNotEqual(retry["status"] as? String, "rejected")
         XCTAssertNil(retry["remoteId"])
         XCTAssertEqual(try backend.getProjectTasksPayload(projectID: projectID).count, before + 1)
@@ -34,131 +34,131 @@ final class UploadEndpointTests: XCTestCase {
 
     func testUploadUpsertIsLastWriterWins() throws {
         let backend = try makeBackend()
-        let localID = "22222222-2222-2222-2222-222222222222"
+        let id = "22222222-2222-2222-2222-222222222222"
         let created = try result(
             of: backend.upload(operations: [
-                upsertOp(localID: localID, title: "Original", updatedAt: "2026-01-01T00:00:00.000Z")
+                upsertOp(id: id, title: "Original", updatedAt: "2026-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(created["status"] as? String, "applied")
 
         // Older write loses: kept server state returned, title unchanged.
         let stale = try result(
             of: backend.upload(operations: [
-                upsertOp(localID: localID, title: "Stale edit", updatedAt: "2020-01-01T00:00:00.000Z")
+                upsertOp(id: id, title: "Stale edit", updatedAt: "2020-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(stale["status"] as? String, "stale")
         XCTAssertNil(stale["remoteId"])
         let server = try XCTUnwrap(stale["server"] as? [String: Any])
         XCTAssertEqual(server["title"] as? String, "Original")
-        XCTAssertEqual(server["id"] as? String, localID)
+        XCTAssertEqual(server["id"] as? String, id)
 
         // Newer write wins.
         let applied = try result(
             of: backend.upload(operations: [
-                upsertOp(localID: localID, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
+                upsertOp(id: id, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(applied["status"] as? String, "applied")
-        let detail = try XCTUnwrap(backend.getTaskDetailPayload(publicID: localID))
+        let detail = try XCTUnwrap(backend.getTaskDetailPayload(publicID: id))
         XCTAssertEqual(detail["title"] as? String, "Fresh edit")
     }
 
     func testUploadDeleteTombstonesAndHidesFromReads() throws {
         let backend = try makeBackend()
-        let localID = "33333333-3333-3333-3333-333333333333"
-        _ = try result(of: backend.upload(operations: [upsertOp(localID: localID, title: "Doomed")]))
+        let id = "33333333-3333-3333-3333-333333333333"
+        _ = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Doomed")]))
 
         let deleted = try result(
             of: backend.upload(operations: [
-                deleteOp(localID: localID, updatedAt: "2030-01-01T00:00:00.000Z")
+                deleteOp(id: id, updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(deleted["status"] as? String, "applied")
 
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: localID), "tombstoned row is hidden from detail")
+        XCTAssertNil(try backend.getTaskDetailPayload(publicID: id), "tombstoned row is hidden from detail")
         XCTAssertFalse(
             try backend.getProjectTasksPayload(projectID: projectID).contains {
-                ($0["id"] as? String) == localID
+                ($0["id"] as? String) == id
             },
             "tombstoned row is hidden from the list")
     }
 
     func testUploadDeleteIsLastWriterWins() throws {
         let backend = try makeBackend()
-        let localID = "44444444-4444-4444-4444-444444444444"
+        let id = "44444444-4444-4444-4444-444444444444"
         _ = try result(
             of: backend.upload(operations: [
-                upsertOp(localID: localID, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
+                upsertOp(id: id, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
 
         // A delete older than the server's version must lose: stale + server state, not a tombstone.
         let stale = try result(
             of: backend.upload(operations: [
-                deleteOp(localID: localID, updatedAt: "2020-01-01T00:00:00.000Z")
+                deleteOp(id: id, updatedAt: "2020-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(stale["status"] as? String, "stale")
         XCTAssertNotNil(stale["server"] as? [String: Any])
         XCTAssertNotNil(
-            try backend.getTaskDetailPayload(publicID: localID), "a stale delete must not tombstone the row")
+            try backend.getTaskDetailPayload(publicID: id), "a stale delete must not tombstone the row")
 
         // A newer delete wins.
         let applied = try result(
             of: backend.upload(operations: [
-                deleteOp(localID: localID, updatedAt: "2040-01-01T00:00:00.000Z")
+                deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(applied["status"] as? String, "applied")
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: localID))
+        XCTAssertNil(try backend.getTaskDetailPayload(publicID: id))
     }
 
     func testUploadUpsertRevivesTombstonedRowWhenEditIsNewer() throws {
         let backend = try makeBackend()
-        let localID = "55555555-5555-5555-5555-555555555555"
+        let id = "55555555-5555-5555-5555-555555555555"
         _ = try result(
             of: backend.upload(operations: [
-                upsertOp(localID: localID, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
+                upsertOp(id: id, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
         _ = try result(
             of: backend.upload(operations: [
-                deleteOp(localID: localID, updatedAt: "2040-01-01T00:00:00.000Z")
+                deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
             ]))
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: localID), "precondition: tombstoned")
+        XCTAssertNil(try backend.getTaskDetailPayload(publicID: id), "precondition: tombstoned")
 
         // An edit newer than the delete wins LWW: it revives the row, not a phantom "applied".
         let revived = try result(
             of: backend.upload(operations: [
-                upsertOp(localID: localID, title: "Revived", updatedAt: "2050-01-01T00:00:00.000Z")
+                upsertOp(id: id, title: "Revived", updatedAt: "2050-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(revived["status"] as? String, "applied")
         let detail = try XCTUnwrap(
-            backend.getTaskDetailPayload(publicID: localID), "a newer edit must resurrect the tombstoned row")
+            backend.getTaskDetailPayload(publicID: id), "a newer edit must resurrect the tombstoned row")
         XCTAssertEqual(detail["title"] as? String, "Revived")
-        XCTAssertEqual(detail["id"] as? String, localID, "revival keeps the same public_id")
+        XCTAssertEqual(detail["id"] as? String, id, "revival keeps the same public_id")
     }
 
     func testUploadUpsertOnTombstonedRowStaysDeletedWhenEditIsOlder() throws {
         let backend = try makeBackend()
-        let localID = "66666666-6666-6666-6666-666666666666"
+        let id = "66666666-6666-6666-6666-666666666666"
         _ = try result(
             of: backend.upload(operations: [
-                upsertOp(localID: localID, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
+                upsertOp(id: id, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
         _ = try result(
             of: backend.upload(operations: [
-                deleteOp(localID: localID, updatedAt: "2040-01-01T00:00:00.000Z")
+                deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
             ]))
 
         // An edit older than the delete loses LWW: stale, and the row stays deleted (no phantom apply).
         let stale = try result(
             of: backend.upload(operations: [
-                upsertOp(localID: localID, title: "Too late", updatedAt: "2035-01-01T00:00:00.000Z")
+                upsertOp(id: id, title: "Too late", updatedAt: "2035-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(stale["status"] as? String, "stale")
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: localID), "the row stays deleted")
+        XCTAssertNil(try backend.getTaskDetailPayload(publicID: id), "the row stays deleted")
     }
 
     func testUploadFailsClosedOnMissingOrUnknownOperation() throws {
         let backend = try makeBackend()
         let response = try backend.upload(operations: [
-            ["type": "tasks", "localId": "x", "data": [:]],  // no operation
-            ["operation": "destroy", "type": "tasks", "localId": "y"],  // unknown
+            ["type": "tasks", "id": "x", "data": [:]],  // no operation
+            ["operation": "destroy", "type": "tasks", "id": "y"],  // unknown
         ])
         let results = try XCTUnwrap(response["results"] as? [[String: Any]])
         XCTAssertEqual(results.allSatisfy { ($0["status"] as? String) == "rejected" }, true)
@@ -175,21 +175,21 @@ final class UploadEndpointTests: XCTestCase {
         return try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
     }
 
-    private func upsertOp(localID: String, title: String, updatedAt: String = "2026-06-16T20:00:00.000Z")
+    private func upsertOp(id: String, title: String, updatedAt: String = "2026-06-16T20:00:00.000Z")
         -> [String: Any]
     {
         [
-            "operation": "upsert", "type": "tasks", "localId": localID, "updatedAt": updatedAt,
+            "operation": "upsert", "type": "tasks", "id": id, "updatedAt": updatedAt,
             "data": [
-                "id": localID, "project_id": projectID, "author_id": authorID, "title": title,
+                "id": id, "project_id": projectID, "author_id": authorID, "title": title,
                 "description": "from offline", "state": ["id": "todo"],
                 "created_at": updatedAt, "updated_at": updatedAt,
             ],
         ]
     }
 
-    private func deleteOp(localID: String, updatedAt: String) -> [String: Any] {
-        ["operation": "delete", "type": "tasks", "localId": localID, "updatedAt": updatedAt]
+    private func deleteOp(id: String, updatedAt: String) -> [String: Any] {
+        ["operation": "delete", "type": "tasks", "id": id, "updatedAt": updatedAt]
     }
 
     private func result(of response: [String: Any]) throws -> [String: Any] {

--- a/DemoCore/Sources/DemoCore/Models/DemoModels.swift
+++ b/DemoCore/Sources/DemoCore/Models/DemoModels.swift
@@ -87,8 +87,8 @@ public final class Task {
     public var createdAt: Date
     public var updatedAt: Date
 
-    // Demo-owned (not a SwiftSync concept): the engine stamps this from `summary.failures` after a
-    // push and clears it on a later success, so the failures inbox is a query for rows where it's set.
+    // Demo-owned (not a SwiftSync concept): the engine stamps this from the failures `push` returns and
+    // clears it on a later success, so the failures inbox is a query for rows where it's set.
     @NotExport
     public var syncFailureReason: String?
 

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -198,7 +198,7 @@ public final class DemoSyncEngine {
     /// Push every locally-pending task change to the server and apply the result. Returns `nil` while
     /// offline (no network) or if a push is already in flight.
     @discardableResult
-    public func pushPendingChanges() async throws -> SyncPushSummary? {
+    public func pushPendingChanges() async throws -> [SyncPushFailure]? {
         guard !isOffline else { return nil }
         let key = "push"
         guard !inFlightOperations.contains(key) else { return nil }
@@ -210,14 +210,14 @@ public final class DemoSyncEngine {
             isSyncing = !inFlightOperations.isEmpty
         }
 
-        let summary = try await SwiftSync.push(
+        let failures = try await SwiftSync.push(
             for: Task.self,
             in: syncContainer.mainContext,
             upload: { pending in try await self.upload(pending) }
         )
-        try annotateFailures(from: summary)
+        try annotateFailures(failures)
         refreshPendingCount()
-        return summary
+        return failures
     }
 
     /// Apply a payload to the local store as a *local* edit (default author), so it's tracked as a
@@ -253,9 +253,9 @@ public final class DemoSyncEngine {
     /// Reflect a push's outcome onto the inbox: stamp `syncFailureReason` on each rejected row and
     /// clear it from any row that no longer fails (it succeeded, or its corrected edit went through).
     /// SwiftSync persists nothing — the failures inbox is entirely this app's concern.
-    private func annotateFailures(from summary: SyncPushSummary) throws {
+    private func annotateFailures(_ failures: [SyncPushFailure]) throws {
         let reasonsByLocalID = Dictionary(
-            summary.failures.map { ($0.localID, $0.error.localizedDescription) },
+            failures.map { ($0.localID, $0.error.localizedDescription) },
             uniquingKeysWith: { first, _ in first })
         for task in failedTasks() where reasonsByLocalID[task.id] == nil {
             task.syncFailureReason = nil
@@ -310,9 +310,9 @@ public final class DemoSyncEngine {
             case ("upsert", "applied"), ("delete", "applied"):
                 break
             default:
-                // Bubble the backend's rejection up as this app's own error. SwiftSync carries it
-                // verbatim in `summary.failures` without interpreting it; the engine reads it back to
-                // annotate the inbox.
+                // Bubble the backend's rejection up as this app's own error. SwiftSync returns the
+                // failures verbatim without interpreting them; the engine reads them back to annotate
+                // the inbox.
                 failures.append(
                     SyncPushFailure(
                         localID: localID ?? "",

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -255,40 +255,40 @@ public final class DemoSyncEngine {
     /// clear it from any row that no longer fails (it succeeded, or its corrected edit went through).
     /// SwiftSync persists nothing — the failures inbox is entirely this app's concern.
     private func annotateFailures(_ failures: [SyncPushFailure]) throws {
-        let reasonsByLocalID = Dictionary(
-            failures.map { ($0.localID, $0.error.localizedDescription) },
+        let reasonsByID = Dictionary(
+            failures.map { ($0.id, $0.error.localizedDescription) },
             uniquingKeysWith: { first, _ in first })
-        for task in failedTasks() where reasonsByLocalID[task.id] == nil {
+        for task in failedTasks() where reasonsByID[task.id] == nil {
             task.syncFailureReason = nil
         }
-        for (localID, reason) in reasonsByLocalID {
-            if let task = try task(withID: localID) { task.syncFailureReason = reason }
+        for (id, reason) in reasonsByID {
+            if let task = try task(withID: id) { task.syncFailureReason = reason }
         }
         try syncContainer.mainContext.save()
     }
 
     /// Serialize the pending batch into the `/sync/upload` operation list, POST it once, and return only
     /// the per-row failures — SwiftSync confirms everything else by complement. Every created-or-edited
-    /// row is an `upsert` keyed by its stable `localId` (the server find-by-localId → update-else-creates,
-    /// adopting that `localId` as the row's identity — no distinct server id comes back); tombstones are a
-    /// `delete` by the same `localId`. A `stale` result means the server won last-writer-wins — adopt its
-    /// state locally and treat the row as resolved (not a failure) so it isn't re-sent.
+    /// row is an `upsert` keyed by its stable `id` (the server find-by-id → update-else-creates, adopting
+    /// that `id` as the row's `public_id` — no distinct server id comes back); tombstones are a `delete`
+    /// by the same `id`. A `stale` result means the server won last-writer-wins — adopt its state locally
+    /// and treat the row as resolved (not a failure) so it isn't re-sent.
     private func upload(_ pending: SyncPendingChanges) async throws -> [SyncPushFailure] {
         var operations: [[String: Any]] = []
 
-        for localID in pending.inserts + pending.updates {
-            guard let task = try task(withID: localID) else { continue }
+        for id in pending.inserts + pending.updates {
+            guard let task = try task(withID: id) else { continue }
             let data = taskData(task)
             operations.append([
-                "operation": "upsert", "type": "tasks", "localId": localID,
+                "operation": "upsert", "type": "tasks", "id": id,
                 "updatedAt": data["updated_at"] ?? "", "data": data,
             ])
         }
-        for localID in pending.deletes {
+        for id in pending.deletes {
             // The row is already hard-deleted locally — its id is recovered from store history — so the
             // delete can't fetch the gone task. Stamp the deletion time now for the server's LWW check.
             operations.append([
-                "operation": "delete", "type": "tasks", "localId": localID,
+                "operation": "delete", "type": "tasks", "id": id,
                 "updatedAt": syncContainer.dateFormatter.string(from: Date()),
             ])
         }
@@ -299,7 +299,7 @@ public final class DemoSyncEngine {
         for result in results {
             let operation = result["operation"] as? String
             let status = result["status"] as? String
-            let localID = result["localId"] as? String
+            let id = result["id"] as? String
             switch (operation, status) {
             case ("upsert", "stale"), ("delete", "stale"):
                 // The server won last-writer-wins — adopt its state locally (the inbound sync re-creates a
@@ -316,7 +316,7 @@ public final class DemoSyncEngine {
                 // the inbox.
                 failures.append(
                     SyncPushFailure(
-                        localID: localID ?? "",
+                        id: id ?? "",
                         error: DemoUploadRejection(
                             message: (result["message"] as? String) ?? "rejected")))
             }

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -210,11 +210,12 @@ public final class DemoSyncEngine {
             isSyncing = !inFlightOperations.isEmpty
         }
 
-        let failures = try await SwiftSync.push(
+        let failures = try await SwiftSync.withPendingChanges(
             for: Task.self,
-            in: syncContainer.mainContext,
-            upload: { pending in try await self.upload(pending) }
-        )
+            in: syncContainer.mainContext
+        ) { pending in
+            try await self.upload(pending)
+        }
         try annotateFailures(failures)
         refreshPendingCount()
         return failures

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -213,7 +213,7 @@ public final class DemoSyncEngine {
         let summary = try await SwiftSync.push(
             for: Task.self,
             in: syncContainer.mainContext,
-            upload: { batch in try await self.upload(batch) }
+            upload: { pending in try await self.upload(pending) }
         )
         try annotateFailures(from: summary)
         refreshPendingCount()
@@ -266,16 +266,16 @@ public final class DemoSyncEngine {
         try syncContainer.mainContext.save()
     }
 
-    /// Serialize the pending batch into the `/sync/upload` operation list, POST it once, and map the
-    /// per-operation results back into a `SyncPushResponse`. Every created-or-edited row is an `upsert`
-    /// keyed by its stable `localId` (the server find-by-localId → update-else-creates, adopting that
-    /// `localId` as the row's identity — no distinct server id comes back); tombstones are a `delete` by
-    /// the same `localId`. A `stale` result means the server won last-writer-wins — adopt its state
-    /// locally and treat the row as resolved so it isn't re-sent.
-    private func upload(_ batch: SyncPushBatch) async throws -> SyncPushResponse {
+    /// Serialize the pending batch into the `/sync/upload` operation list, POST it once, and return only
+    /// the per-row failures — SwiftSync confirms everything else by complement. Every created-or-edited
+    /// row is an `upsert` keyed by its stable `localId` (the server find-by-localId → update-else-creates,
+    /// adopting that `localId` as the row's identity — no distinct server id comes back); tombstones are a
+    /// `delete` by the same `localId`. A `stale` result means the server won last-writer-wins — adopt its
+    /// state locally and treat the row as resolved (not a failure) so it isn't re-sent.
+    private func upload(_ pending: SyncPendingChanges) async throws -> [SyncPushFailure] {
         var operations: [[String: Any]] = []
 
-        for localID in batch.inserts + batch.updates {
+        for localID in pending.inserts + pending.updates {
             guard let task = try task(withID: localID) else { continue }
             let data = taskData(task)
             operations.append([
@@ -283,7 +283,7 @@ public final class DemoSyncEngine {
                 "updatedAt": data["updated_at"] ?? "", "data": data,
             ])
         }
-        for localID in batch.deletes {
+        for localID in pending.deletes {
             // The row is already hard-deleted locally — its id is recovered from store history — so the
             // delete can't fetch the gone task. Stamp the deletion time now for the server's LWW check.
             operations.append([
@@ -294,46 +294,33 @@ public final class DemoSyncEngine {
 
         let results = try await apiClient.upload(operations: operations)
 
-        var response = SyncPushResponse()
+        var failures: [SyncPushFailure] = []
         for result in results {
             let operation = result["operation"] as? String
             let status = result["status"] as? String
             let localID = result["localId"] as? String
             switch (operation, status) {
-            case ("upsert", "applied"), ("upsert", "stale"):
-                // The localId is the identity the server adopts, so an applied upsert just acknowledges
-                // the row — there's no server id to map home.
-                if let localID { response.confirmedLocalIDs.insert(localID) }
-                if status == "stale", let server = result["server"] as? [String: Any] {
+            case ("upsert", "stale"), ("delete", "stale"):
+                // The server won last-writer-wins — adopt its state locally (the inbound sync re-creates a
+                // hard-deleted row when a delete loses) and treat the row as resolved, not a failure.
+                if let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(
                         item: DemoSyncPayload(dictionary: server), as: Task.self)
                 }
-            case ("delete", "applied"):
-                if let localID { response.confirmedLocalIDs.insert(localID) }
-            case ("delete", "stale"):
-                // The server has a newer edit — the delete lost LWW. Adopt the server's state so the
-                // row reappears with the winning version (the inbound sync re-creates the hard-deleted
-                // row); acknowledge the tombstone so it isn't re-sent.
-                if let localID {
-                    if let server = result["server"] as? [String: Any] {
-                        try? await syncContainer.sync(
-                            item: DemoSyncPayload(dictionary: server), as: Task.self)
-                    }
-                    response.confirmedLocalIDs.insert(localID)
-                }
+            case ("upsert", "applied"), ("delete", "applied"):
+                break
             default:
                 // Bubble the backend's rejection up as this app's own error. SwiftSync carries it
                 // verbatim in `summary.failures` without interpreting it; the engine reads it back to
                 // annotate the inbox.
-                response.failures.append(
+                failures.append(
                     SyncPushFailure(
                         localID: localID ?? "",
-                        operation: operation == "delete" ? .delete : .update,
                         error: DemoUploadRejection(
                             message: (result["message"] as? String) ?? "rejected")))
             }
         }
-        return response
+        return failures
     }
 
     /// The task's upload payload: its exported scalars plus `reviewer_ids`/`watcher_ids` (which are

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -34,10 +34,9 @@ final class OfflinePushTests: XCTestCase {
 
         engine.isOffline = false
         let pushResult = try await engine.pushPendingChanges()
-        let summary = try XCTUnwrap(pushResult)
+        let failures = try XCTUnwrap(pushResult)
 
-        XCTAssertEqual(summary.insertedCount, 1)
-        XCTAssertTrue(summary.failures.isEmpty)
+        XCTAssertTrue(failures.isEmpty)
         XCTAssertEqual(engine.pendingChangeCount, 0)
 
         XCTAssertNotNil(
@@ -145,10 +144,9 @@ final class OfflinePushTests: XCTestCase {
 
         engine.isOffline = false
         let pushResult = try await engine.pushPendingChanges()
-        let summary = try XCTUnwrap(pushResult)
+        let failures = try XCTUnwrap(pushResult)
 
-        XCTAssertEqual(summary.deletedCount, 1)
-        XCTAssertTrue(summary.failures.isEmpty)
+        XCTAssertTrue(failures.isEmpty)
         let remaining = try fetchTask(id: taskID, in: syncContainer.mainContext)
         XCTAssertNil(remaining, "confirmed delete is hard-deleted")
         let detail = try await apiClient.getTaskDetail(taskID: taskID)
@@ -177,8 +175,8 @@ final class OfflinePushTests: XCTestCase {
         // Reconnect + push: the server rejects, and the failure is recorded on the row.
         engine.isOffline = false
         let pushResult = try await engine.pushPendingChanges()
-        let summary = try XCTUnwrap(pushResult)
-        XCTAssertEqual(summary.failures.count, 1)
+        let failures = try XCTUnwrap(pushResult)
+        XCTAssertEqual(failures.count, 1)
 
         let failed = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
         let reason = try XCTUnwrap(
@@ -416,8 +414,8 @@ final class OfflinePushTests: XCTestCase {
 
         engine.isOffline = false
         let pushResult = try await engine.pushPendingChanges()
-        let summary = try XCTUnwrap(pushResult)
-        XCTAssertTrue(summary.failures.isEmpty)
+        let failures = try XCTUnwrap(pushResult)
+        XCTAssertTrue(failures.isEmpty)
 
         // A fresh pull (server is authoritative) brings the same reviewers back.
         try await engine.syncTaskDetail(taskID: taskID)
@@ -458,8 +456,8 @@ final class OfflinePushTests: XCTestCase {
         // Reconnect + push: reviewer_ids travel in the upsert and the server accepts it.
         engine.isOffline = false
         let pushResult = try await engine.pushPendingChanges()
-        let summary = try XCTUnwrap(pushResult)
-        XCTAssertTrue(summary.failures.isEmpty)
+        let failures = try XCTUnwrap(pushResult)
+        XCTAssertTrue(failures.isEmpty)
         XCTAssertEqual(engine.pendingChangeCount, 0, "the assignment was acknowledged")
 
         // Prove the server stored it: a fresh pull (which overwrites local reviewers from the server)
@@ -562,8 +560,8 @@ final class OfflinePushTests: XCTestCase {
         try await engine.createTask(body: body, projectID: projectID)
         engine.isOffline = false
         let pushResult = try await engine.pushPendingChanges()
-        let summary = try XCTUnwrap(pushResult)
-        XCTAssertEqual(summary.failures.count, 1)
+        let failures = try XCTUnwrap(pushResult)
+        XCTAssertEqual(failures.count, 1)
         let failed = try XCTUnwrap(fetchTask(id: "OFFLINE-REJECT-1", in: syncContainer.mainContext))
         XCTAssertNotNil(failed.syncFailureReason, "the rejected create is flagged")
 

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -42,7 +42,7 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertNotNil(
             try fetchTask(id: "OFFLINE-CREATE-1", in: syncContainer.mainContext), "the row remains, now synced")
         let backendDetail = try await apiClient.getTaskDetail(taskID: "OFFLINE-CREATE-1")
-        XCTAssertNotNil(backendDetail, "the row reached the backend, keyed by its localId")
+        XCTAssertNotNil(backendDetail, "the row reached the backend, keyed by its id")
     }
 
     @MainActor
@@ -228,7 +228,7 @@ final class OfflinePushTests: XCTestCase {
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
-        let localID = "FAILED-INSERT-1"
+        let id = "FAILED-INSERT-1"
         try await engine.syncProjectTasks(projectID: projectID)
 
         // Offline create with an over-long title → the insert is rejected on push.
@@ -236,7 +236,7 @@ final class OfflinePushTests: XCTestCase {
         let template = try XCTUnwrap(
             fetchTask(id: DemoSeedData.SeedIDs.Tasks.sessionTimeout, in: syncContainer.mainContext))
         var createDictionary = syncContainer.export(template)
-        createDictionary["id"] = localID
+        createDictionary["id"] = id
         createDictionary["title"] = String(repeating: "A", count: 100)
         createDictionary.removeValue(forKey: "items")
         try await engine.createTask(
@@ -244,7 +244,7 @@ final class OfflinePushTests: XCTestCase {
 
         engine.isOffline = false
         _ = try await engine.pushPendingChanges()
-        let failed = try XCTUnwrap(fetchTask(id: localID, in: syncContainer.mainContext))
+        let failed = try XCTUnwrap(fetchTask(id: id, in: syncContainer.mainContext))
         XCTAssertNotNil(failed.syncFailureReason, "the rejected insert is flagged")
         XCTAssertEqual(engine.failedChangeCount, 1, "it never reached the server")
 
@@ -253,12 +253,12 @@ final class OfflinePushTests: XCTestCase {
         fixDictionary["title"] = "Fixed"
         fixDictionary.removeValue(forKey: "items")
         try await engine.updateTask(
-            taskID: localID, projectID: projectID, body: try DemoSyncPayload(dictionary: fixDictionary))
+            taskID: id, projectID: projectID, body: try DemoSyncPayload(dictionary: fixDictionary))
 
-        let fixed = try XCTUnwrap(fetchTask(id: localID, in: syncContainer.mainContext))
+        let fixed = try XCTUnwrap(fetchTask(id: id, in: syncContainer.mainContext))
         XCTAssertNil(fixed.syncFailureReason, "the failure is resolved")
         XCTAssertEqual(fixed.title, "Fixed")
-        let backendDetail = try await apiClient.getTaskDetail(taskID: localID)
+        let backendDetail = try await apiClient.getTaskDetail(taskID: id)
         XCTAssertNotNil(backendDetail, "it now exists on the server")
     }
 
@@ -335,7 +335,7 @@ final class OfflinePushTests: XCTestCase {
         serverData.removeValue(forKey: "items")
         _ = try backend.upload(operations: [
             [
-                "operation": "upsert", "type": "tasks", "localId": taskID,
+                "operation": "upsert", "type": "tasks", "id": taskID,
                 "updatedAt": "2099-01-01T00:00:00.000Z", "data": serverData,
             ]
         ])
@@ -518,7 +518,7 @@ final class OfflinePushTests: XCTestCase {
         // A task appears on the server that this client has never seen.
         _ = try backend.upload(operations: [
             [
-                "operation": "upsert", "type": "tasks", "localId": "SERVER-ONLY-1",
+                "operation": "upsert", "type": "tasks", "id": "SERVER-ONLY-1",
                 "updatedAt": "2026-06-16T20:00:00.000Z",
                 "data": [
                     "id": "SERVER-ONLY-1",

--- a/README.md
+++ b/README.md
@@ -631,10 +631,10 @@ The identity is the only id: it's client-generated and the backend adopts it, so
 
 `pendingChanges` partitions the un-pushed local changes (history authored by you, since SwiftSync's internal per-type history token) into inserts, updates, and deletes. A row inserted *and* deleted before it was ever pushed is dropped (the server never saw it).
 
-`push` drives one pass. It hands the pending changes to your `upload` closure as a `Sendable` `SyncPendingChanges` (so SwiftData objects never cross into a network call — you own the request); your closure does the network work and returns **only the failures** (`[SyncPushFailure]`). Everything else is confirmed by complement — the client id *is* the identity the server adopts, so a push is an idempotent upsert with no acknowledgements to echo back. Only when the closure reports **no** failures does `push` advance its internal history token and trim the redundant history. It writes no per-row state; a failed (or otherwise un-pushed) change stays pending and is re-detected next push. The failures also come back in `summary.failures` for you to surface (discard / edit / retry).
+`push` drives one pass. It hands the pending changes to your `upload` closure as a `Sendable` `SyncPendingChanges` (so SwiftData objects never cross into a network call — you own the request); your closure does the network work and **returns the failures** (`[SyncPushFailure]`), which `push` returns straight back to you. Everything else is confirmed by complement — the client id *is* the identity the server adopts, so a push is an idempotent upsert with no acknowledgements to echo back. Only when the closure reports **no** failures does `push` advance its internal history token and trim the redundant history. It writes no per-row state; a failed (or otherwise un-pushed) change stays pending and is re-detected next push. Surface the returned failures however you like (discard / edit / retry).
 
 ```swift
-let summary = try await SwiftSync.push(
+let failures = try await SwiftSync.push(
   for: Task.self,
   in: syncContainer.mainContext,
   upload: { pending in
@@ -643,7 +643,7 @@ let summary = try await SwiftSync.push(
     try await api.push(pending)
   }
 )
-// No history token to persist — SwiftSync owns it. Inspect summary.failures / counts.
+// No history token to persist — SwiftSync owns it. `failures` is empty on a fully clean push.
 ```
 
 Inbound pulls are tagged internally so a freshly-pulled row is never mistaken for a local edit; an un-pushed local insert survives a pull that omits it, and a newer local edit isn't clobbered by an older server version (last-writer-wins). Offline requires a persistent store (history is unavailable to ephemeral stores).

--- a/README.md
+++ b/README.md
@@ -631,16 +631,16 @@ The identity is the only id: it's client-generated and the backend adopts it, so
 
 `pendingChanges` partitions the un-pushed local changes (history authored by you, since SwiftSync's internal per-type history token) into inserts, updates, and deletes. A row inserted *and* deleted before it was ever pushed is dropped (the server never saw it).
 
-`push` drives one pass. It hands the pending ids to your `upload` closure as a `Sendable` `SyncPushBatch` (so SwiftData objects never cross into a network call — you own the request), then — only when every change is acknowledged — advances its internal history token and trims the redundant history. It writes no per-row state; an unacknowledged change stays pending and is re-detected next push. Per-item failures come back in `summary.failures` for you to surface (discard / edit / retry).
+`push` drives one pass. It hands the pending changes to your `upload` closure as a `Sendable` `SyncPendingChanges` (so SwiftData objects never cross into a network call — you own the request); your closure does the network work and returns **only the failures** (`[SyncPushFailure]`). Everything else is confirmed by complement — the client id *is* the identity the server adopts, so a push is an idempotent upsert with no acknowledgements to echo back. Only when the closure reports **no** failures does `push` advance its internal history token and trim the redundant history. It writes no per-row state; a failed (or otherwise un-pushed) change stays pending and is re-detected next push. The failures also come back in `summary.failures` for you to surface (discard / edit / retry).
 
 ```swift
 let summary = try await SwiftSync.push(
   for: Task.self,
   in: syncContainer.mainContext,
-  upload: { batch in
-    // map batch.inserts / batch.updates / batch.deletes (the localIDs) to upsert/delete
-    // requests, call your API, and report back which localIDs the server acknowledged
-    try await api.push(batch)
+  upload: { pending in
+    // map pending.inserts / pending.updates / pending.deletes (the localIDs) to upsert/delete
+    // requests, call your API, and return a SyncPushFailure for each rejected localID
+    try await api.push(pending)
   }
 )
 // No history token to persist — SwiftSync owns it. Inspect summary.failures / counts.

--- a/README.md
+++ b/README.md
@@ -631,19 +631,15 @@ The identity is the only id: it's client-generated and the backend adopts it, so
 
 `pendingChanges` partitions the un-pushed local changes (history authored by you, since SwiftSync's internal per-type history token) into inserts, updates, and deletes. A row inserted *and* deleted before it was ever pushed is dropped (the server never saw it).
 
-`push` drives one pass. It hands the pending changes to your `upload` closure as a `Sendable` `SyncPendingChanges` (so SwiftData objects never cross into a network call — you own the request); your closure does the network work and **returns the failures** (`[SyncPushFailure]`), which `push` returns straight back to you. Everything else is confirmed by complement — the client id *is* the identity the server adopts, so a push is an idempotent upsert with no acknowledgements to echo back. Only when the closure reports **no** failures does `push` advance its internal history token and trim the redundant history. It writes no per-row state; a failed (or otherwise un-pushed) change stays pending and is re-detected next push. Surface the returned failures however you like (discard / edit / retry).
+`withPendingChanges` runs one pass inside a scope SwiftSync manages (the `with…` idiom: it sets up the pending changes, your closure does the work, it commits the bookmark on the way out). It hands your closure a `Sendable` `SyncPendingChanges` (so SwiftData objects never cross into a network call — you own the request); the closure does the network work and **returns the failures** (`[SyncPushFailure]`), which the method returns straight back to you. Everything else is confirmed by complement — the client id *is* the identity the server adopts, so a push is an idempotent upsert with no acknowledgements to echo back. Only when the closure reports **no** failures does it advance its internal history token and trim the redundant history. It writes no per-row state; a failed (or otherwise un-pushed) change stays pending and is re-detected next call. Surface the returned failures however you like (discard / edit / retry).
 
 ```swift
-let failures = try await SwiftSync.push(
-  for: Task.self,
-  in: syncContainer.mainContext,
-  upload: { pending in
-    // map pending.inserts / pending.updates / pending.deletes (the localIDs) to upsert/delete
-    // requests, call your API, and return a SyncPushFailure for each rejected localID
-    try await api.push(pending)
-  }
-)
-// No history token to persist — SwiftSync owns it. `failures` is empty on a fully clean push.
+let failures = try await SwiftSync.withPendingChanges(for: Task.self, in: syncContainer.mainContext) { pending in
+  // map pending.inserts / pending.updates / pending.deletes (the localIDs) to upsert/delete
+  // requests, call your API, and return a SyncPushFailure for each rejected localID
+  try await api.push(pending)
+}
+// No history token to persist — SwiftSync owns it. `failures` is empty on a fully clean pass.
 ```
 
 Inbound pulls are tagged internally so a freshly-pulled row is never mistaken for a local edit; an un-pushed local insert survives a pull that omits it, and a newer local edit isn't clobbered by an older server version (last-writer-wins). Offline requires a persistent store (history is unavailable to ephemeral stores).

--- a/README.md
+++ b/README.md
@@ -635,8 +635,8 @@ The identity is the only id: it's client-generated and the backend adopts it, so
 
 ```swift
 let failures = try await SwiftSync.withPendingChanges(for: Task.self, in: syncContainer.mainContext) { pending in
-  // map pending.inserts / pending.updates / pending.deletes (the localIDs) to upsert/delete
-  // requests, call your API, and return a SyncPushFailure for each rejected localID
+  // map pending.inserts / pending.updates / pending.deletes (the ids) to upsert/delete
+  // requests, call your API, and return a SyncPushFailure for each rejected id
   try await api.push(pending)
 }
 // No history token to persist — SwiftSync owns it. `failures` is empty on a fully clean pass.

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -9,9 +9,9 @@ extension SwiftSync {
     static let inboundAuthor = "swiftsync.inbound"
 }
 
-/// The local `localID`s pending a push, partitioned by operation, derived from store history. Both the
-/// return of `pendingChanges(...)` and the value `push(...)` hands the `upload` closure — the app maps each
-/// id to its own request payload, so SwiftData objects never cross into a network call.
+/// The local rows with un-pushed changes, split by operation. Each array holds `localID`s (the rows'
+/// string ids), not objects — `push` hands this to your `upload` closure and you map each id to your own
+/// request payload, so SwiftData objects never cross into the network call.
 public struct SyncPendingChanges: Sendable {
     public let inserts: [String]
     public let updates: [String]
@@ -57,8 +57,8 @@ extension SwiftSync {
         try pendingChanges(from: localTransactions(since: token, in: context), for: Model.self, in: context)
     }
 
-    /// Separate from the token-driven overload so `push` derives the batch and its pre-upload boundary
-    /// token from a single history read (see the boundary capture in `push`).
+    /// Separate from the token-driven overload so `push` derives the batch and its `uploadedThrough` token
+    /// from a single history read (see the capture in `push`).
     static func pendingChanges<Model: SyncUpdatableModel>(
         from transactions: [DefaultHistoryTransaction],
         for _: Model.Type,
@@ -130,12 +130,13 @@ extension SwiftSync {
         return SyncPendingChanges(inserts: inserts, updates: updates, deletes: deletes)
     }
 
-    /// Drive one push: read pending changes from history (since the model type's last-pushed token),
-    /// hand them to the app's `upload` closure (the app owns the network call) which returns only the
-    /// failures, then — only when there are **no** failures — advance the last-pushed token to the
-    /// pre-upload history boundary and trim the now-redundant inbound history. SwiftSync writes no per-row
-    /// state on push; a failed (or any un-acknowledged) change simply stays past the token and is
-    /// re-detected next push.
+    /// Drive one push pass. Reads what changed locally since this model type's last-pushed token, hands it
+    /// to your `upload` closure (you own the network call), and gets back the rejected rows. Everything you
+    /// *don't* return as a failure is treated as confirmed — the client id is the identity the server
+    /// adopts, so a push is an idempotent upsert with nothing to acknowledge. Only on a fully clean push
+    /// (no failures) does it advance the token and trim the now-redundant inbound history. SwiftSync stores
+    /// no per-row state: a failed — or any un-pushed — change stays past the token and is re-detected next
+    /// push. Returns the same failures your closure returned (empty == clean).
     @discardableResult
     public static func push<Model: SyncUpdatableModel>(
         for _: Model.Type,
@@ -149,14 +150,15 @@ extension SwiftSync {
         let transactions = try localTransactions(since: token, in: context)
         let pending = try pendingChanges(from: transactions, for: Model.self, in: context)
         guard !pending.isEmpty else { return [] }
-        // The history head observed *before* the upload. Advancing only to here leaves any write that
-        // lands during the upload await past the token, so it's re-detected next push, not swallowed.
-        let boundary = transactions.last?.token
+        // The newest history token in this batch, captured *before* the upload. On success we advance the
+        // token only to here — never to the live head — so any local write that lands during the upload
+        // await stays past the token and is re-detected next push, instead of being silently skipped.
+        let uploadedThrough = transactions.last?.token
 
         let failures = try await upload(pending)
-        if failures.isEmpty, let boundary {
-            try setLastPushedHistoryToken(boundary, for: Model.self, in: context)
-            try? trimInboundHistory(throughInclusive: boundary, in: context)
+        if failures.isEmpty, let uploadedThrough {
+            try setLastPushedHistoryToken(uploadedThrough, for: Model.self, in: context)
+            try? trimInboundHistory(through: uploadedThrough, in: context)
         }
         return failures
     }
@@ -197,7 +199,7 @@ extension SwiftSync {
     /// Trim inbound (pull-authored) history up to and including `token`. Only inbound transactions are
     /// removed — local-authored history is the un-pushed-changes signal and a different model type may
     /// still need its own un-pushed local changes, so those are never trimmed here.
-    static func trimInboundHistory(throughInclusive token: DefaultHistoryToken, in context: ModelContext) throws {
+    static func trimInboundHistory(through token: DefaultHistoryToken, in context: ModelContext) throws {
         let inbound = inboundAuthor
         try context.deleteHistory(
             HistoryDescriptor<DefaultHistoryTransaction>(

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -10,8 +10,8 @@ extension SwiftSync {
 }
 
 /// The local rows with un-pushed changes, split by operation. Each array holds `localID`s (the rows'
-/// string ids), not objects — `push` hands this to your `upload` closure and you map each id to your own
-/// request payload, so SwiftData objects never cross into the network call.
+/// string ids), not objects — `withPendingChanges` hands this to your `process` closure and you map each
+/// id to your own request payload, so SwiftData objects never cross into the network call.
 public struct SyncPendingChanges: Sendable {
     public let inserts: [String]
     public let updates: [String]
@@ -21,7 +21,7 @@ public struct SyncPendingChanges: Sendable {
 }
 
 /// One pushed row the server rejected: the `localID` to keep pending, and the consumer's own `error`
-/// bubbled up verbatim. The `upload` closure returns only these — everything else in the batch is treated
+/// bubbled up verbatim. Your `process` closure returns only these — everything else in the batch is treated
 /// as confirmed (the client `localID` is the identity the backend adopts, so a push is an idempotent
 /// upsert with no server-assigned ids to map home). The operation is the library's to know, not yours.
 public struct SyncPushFailure: Sendable {
@@ -130,19 +130,20 @@ extension SwiftSync {
         return SyncPendingChanges(inserts: inserts, updates: updates, deletes: deletes)
     }
 
-    /// Drive one push pass. Reads what changed locally since this model type's last-pushed token, hands it
-    /// to your `upload` closure (you own the network call), and gets back the rejected rows. Everything you
-    /// *don't* return as a failure is treated as confirmed — the client id is the identity the server
-    /// adopts, so a push is an idempotent upsert with nothing to acknowledge. Only on a fully clean push
-    /// (no failures) does it advance the token and trim the now-redundant inbound history. SwiftSync stores
-    /// no per-row state: a failed — or any un-pushed — change stays past the token and is re-detected next
-    /// push. Returns the same failures your closure returned (empty == clean).
+    /// Process this model type's locally-changed rows inside a scope SwiftSync manages. Reads what changed
+    /// since the last-pushed token, hands it to your `process` closure (you own the network call), and gets
+    /// back the rejected rows. Everything you *don't* return as a failure is treated as confirmed — the
+    /// client id is the identity the server adopts, so it's an idempotent upsert with nothing to
+    /// acknowledge. Only on a fully clean pass (no failures) does it advance the token and trim the
+    /// now-redundant inbound history. SwiftSync stores no per-row state: a failed — or any un-pushed —
+    /// change stays past the token and is re-detected next call. Returns the same failures your closure
+    /// returned (empty == clean).
     @discardableResult
-    public static func push<Model: SyncUpdatableModel>(
+    public static func withPendingChanges<Model: SyncUpdatableModel>(
         for _: Model.Type,
         in context: ModelContext,
         isolation: isolated (any Actor)? = #isolation,
-        upload: (SyncPendingChanges) async throws -> [SyncPushFailure]
+        process: (SyncPendingChanges) async throws -> [SyncPushFailure]
     ) async throws -> [SyncPushFailure] where Model.SyncID == String {
         try requireOfflineCapable(Model.self, in: context)
         try requireOfflinePushBookkeeping(in: context)
@@ -155,7 +156,7 @@ extension SwiftSync {
         // await stays past the token and is re-detected next push, instead of being silently skipped.
         let uploadedThrough = transactions.last?.token
 
-        let failures = try await upload(pending)
+        let failures = try await process(pending)
         if failures.isEmpty, let uploadedThrough {
             try setLastPushedHistoryToken(uploadedThrough, for: Model.self, in: context)
             try? trimInboundHistory(through: uploadedThrough, in: context)

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -34,15 +34,6 @@ public struct SyncPushFailure: Sendable {
     }
 }
 
-/// Result of a push pass. SwiftSync advances its own per-type token internally on a fully-acknowledged
-/// push, so there is no token for the caller to persist — just the counts and any per-row failures.
-public struct SyncPushSummary: Sendable {
-    public let insertedCount: Int
-    public let updatedCount: Int
-    public let deletedCount: Int
-    public let failures: [SyncPushFailure]
-}
-
 extension SwiftSync {
     /// The local changes pending a push, read straight from SwiftData history since SwiftSync's stored
     /// per-type token: transactions authored by anyone other than the inbound (pull) author. A row
@@ -151,34 +142,23 @@ extension SwiftSync {
         in context: ModelContext,
         isolation: isolated (any Actor)? = #isolation,
         upload: (SyncPendingChanges) async throws -> [SyncPushFailure]
-    ) async throws -> SyncPushSummary where Model.SyncID == String {
+    ) async throws -> [SyncPushFailure] where Model.SyncID == String {
         try requireOfflineCapable(Model.self, in: context)
         try requireOfflinePushBookkeeping(in: context)
         let token = lastPushedHistoryToken(for: Model.self, in: context)
         let transactions = try localTransactions(since: token, in: context)
         let pending = try pendingChanges(from: transactions, for: Model.self, in: context)
-        guard !pending.isEmpty else {
-            return SyncPushSummary(insertedCount: 0, updatedCount: 0, deletedCount: 0, failures: [])
-        }
+        guard !pending.isEmpty else { return [] }
         // The history head observed *before* the upload. Advancing only to here leaves any write that
         // lands during the upload await past the token, so it's re-detected next push, not swallowed.
         let boundary = transactions.last?.token
 
-        // The uploader reports only failures; everything else in the batch is confirmed by complement.
         let failures = try await upload(pending)
-        let failedIDs = Set(failures.map(\.localID))
-
         if failures.isEmpty, let boundary {
             try setLastPushedHistoryToken(boundary, for: Model.self, in: context)
             try? trimInboundHistory(throughInclusive: boundary, in: context)
         }
-
-        func confirmed(_ ids: [String]) -> Int { ids.filter { !failedIDs.contains($0) }.count }
-        return SyncPushSummary(
-            insertedCount: confirmed(pending.inserts),
-            updatedCount: confirmed(pending.updates),
-            deletedCount: confirmed(pending.deletes),
-            failures: failures)
+        return failures
     }
 
     /// Dirty persistent ids for the pull, but only for models that opted into offline round-trip by

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -5,10 +5,13 @@ extension SwiftSync {
     /// The transaction author SwiftSync stamps on inbound (pull) writes, so the push side can tell
     /// server-applied changes from genuine local edits and never push pulled rows back. Local edits
     /// use the store's default author; pull writes use this one and are filtered out of `pendingChanges`.
-    public static let inboundAuthor = "swiftsync.inbound"
+    /// Internal — the consumer never references it (`SyncContainer` stamps it on inbound saves).
+    static let inboundAuthor = "swiftsync.inbound"
 }
 
-/// The local `localID`s pending a push, partitioned by operation, derived from store history.
+/// The local `localID`s pending a push, partitioned by operation, derived from store history. Both the
+/// return of `pendingChanges(...)` and the value `push(...)` hands the `upload` closure — the app maps each
+/// id to its own request payload, so SwiftData objects never cross into a network call.
 public struct SyncPendingChanges: Sendable {
     public let inserts: [String]
     public let updates: [String]
@@ -17,40 +20,17 @@ public struct SyncPendingChanges: Sendable {
     public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
-/// The `localID`s to push, partitioned by operation. Sendable; the app maps each id to its payload,
-/// so SwiftData objects never cross into a network call.
-public struct SyncPushBatch: Sendable {
-    public let inserts: [String]
-    public let updates: [String]
-    public let deletes: [String]
-
-    public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
-}
-
-/// One pushed item the server rejected. `error` is the consumer's own error, bubbled up verbatim.
+/// One pushed row the server rejected: the `localID` to keep pending, and the consumer's own `error`
+/// bubbled up verbatim. The `upload` closure returns only these — everything else in the batch is treated
+/// as confirmed (the client `localID` is the identity the backend adopts, so a push is an idempotent
+/// upsert with no server-assigned ids to map home). The operation is the library's to know, not yours.
 public struct SyncPushFailure: Sendable {
-    public enum Operation: String, Equatable, Sendable { case insert, update, delete }
     public let localID: String
-    public let operation: Operation
     public let error: any Error & Sendable
 
-    public init(localID: String, operation: Operation, error: any Error & Sendable) {
+    public init(localID: String, error: any Error & Sendable) {
         self.localID = localID
-        self.operation = operation
         self.error = error
-    }
-}
-
-/// What the app's uploader reports back. The client `localID` is the identity the backend adopts, so a
-/// push is an idempotent upsert — there are no server-assigned ids to map home — and the response is
-/// just the set of acknowledged `localID`s plus any failures.
-public struct SyncPushResponse: Sendable {
-    public var confirmedLocalIDs: Set<String>
-    public var failures: [SyncPushFailure]
-
-    public init(confirmedLocalIDs: Set<String> = [], failures: [SyncPushFailure] = []) {
-        self.confirmedLocalIDs = confirmedLocalIDs
-        self.failures = failures
     }
 }
 
@@ -160,16 +140,17 @@ extension SwiftSync {
     }
 
     /// Drive one push: read pending changes from history (since the model type's last-pushed token),
-    /// hand their ids to the app's `upload` closure (the app owns the network call), then — only when
-    /// *every* pending change was acknowledged — advance the last-pushed token to the pre-upload history
-    /// boundary and trim the now-redundant inbound history. SwiftSync writes no per-row state on push; an
-    /// unacknowledged change simply stays past the token and is re-detected next push.
+    /// hand them to the app's `upload` closure (the app owns the network call) which returns only the
+    /// failures, then — only when there are **no** failures — advance the last-pushed token to the
+    /// pre-upload history boundary and trim the now-redundant inbound history. SwiftSync writes no per-row
+    /// state on push; a failed (or any un-acknowledged) change simply stays past the token and is
+    /// re-detected next push.
     @discardableResult
     public static func push<Model: SyncUpdatableModel>(
         for _: Model.Type,
         in context: ModelContext,
         isolation: isolated (any Actor)? = #isolation,
-        upload: (SyncPushBatch) async throws -> SyncPushResponse
+        upload: (SyncPendingChanges) async throws -> [SyncPushFailure]
     ) async throws -> SyncPushSummary where Model.SyncID == String {
         try requireOfflineCapable(Model.self, in: context)
         try requireOfflinePushBookkeeping(in: context)
@@ -183,23 +164,21 @@ extension SwiftSync {
         // lands during the upload await past the token, so it's re-detected next push, not swallowed.
         let boundary = transactions.last?.token
 
-        let batch = SyncPushBatch(inserts: pending.inserts, updates: pending.updates, deletes: pending.deletes)
-        let response = try await upload(batch)
+        // The uploader reports only failures; everything else in the batch is confirmed by complement.
+        let failures = try await upload(pending)
+        let failedIDs = Set(failures.map(\.localID))
 
-        let allIDs = Set(pending.inserts + pending.updates + pending.deletes)
-        let acknowledgedEverything = response.failures.isEmpty && allIDs.isSubset(of: response.confirmedLocalIDs)
-
-        if acknowledgedEverything, let boundary {
+        if failures.isEmpty, let boundary {
             try setLastPushedHistoryToken(boundary, for: Model.self, in: context)
             try? trimInboundHistory(throughInclusive: boundary, in: context)
         }
 
-        func confirmed(_ ids: [String]) -> Int { ids.filter { response.confirmedLocalIDs.contains($0) }.count }
+        func confirmed(_ ids: [String]) -> Int { ids.filter { !failedIDs.contains($0) }.count }
         return SyncPushSummary(
             insertedCount: confirmed(pending.inserts),
             updatedCount: confirmed(pending.updates),
             deletedCount: confirmed(pending.deletes),
-            failures: response.failures)
+            failures: failures)
     }
 
     /// Dirty persistent ids for the pull, but only for models that opted into offline round-trip by

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -9,9 +9,9 @@ extension SwiftSync {
     static let inboundAuthor = "swiftsync.inbound"
 }
 
-/// The local rows with un-pushed changes, split by operation. Each array holds `localID`s (the rows'
-/// string ids), not objects — `withPendingChanges` hands this to your `process` closure and you map each
-/// id to your own request payload, so SwiftData objects never cross into the network call.
+/// The local rows with un-pushed changes, split by operation. Each array holds the rows' `id`s (strings),
+/// not objects — `withPendingChanges` hands this to your `process` closure and you map each id to your own
+/// request payload, so SwiftData objects never cross into the network call.
 public struct SyncPendingChanges: Sendable {
     public let inserts: [String]
     public let updates: [String]
@@ -20,16 +20,16 @@ public struct SyncPendingChanges: Sendable {
     public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
-/// One pushed row the server rejected: the `localID` to keep pending, and the consumer's own `error`
+/// One pushed row the server rejected: the row `id` to keep pending, and the consumer's own `error`
 /// bubbled up verbatim. Your `process` closure returns only these — everything else in the batch is treated
-/// as confirmed (the client `localID` is the identity the backend adopts, so a push is an idempotent
-/// upsert with no server-assigned ids to map home). The operation is the library's to know, not yours.
+/// as confirmed (the client id is the identity the backend adopts, so a push is an idempotent upsert with
+/// no server-assigned ids to map home). The operation is the library's to know, not yours.
 public struct SyncPushFailure: Sendable {
-    public let localID: String
+    public let id: String
     public let error: any Error & Sendable
 
-    public init(localID: String, error: any Error & Sendable) {
-        self.localID = localID
+    public init(id: String, error: any Error & Sendable) {
+        self.id = id
         self.error = error
     }
 }
@@ -38,7 +38,7 @@ extension SwiftSync {
     /// The local changes pending a push, read straight from SwiftData history since SwiftSync's stored
     /// per-type token: transactions authored by anyone other than the inbound (pull) author. A row
     /// inserted then edited collapses to a single insert; a row deleted after editing collapses to a
-    /// delete (its `localID` recovered from the history tombstone — mark the identity
+    /// delete (its `id` recovered from the history tombstone — mark the identity
     /// `.preserveValueOnDeletion`).
     public static func pendingChanges<Model: SyncUpdatableModel>(
         for _: Model.Type,
@@ -70,7 +70,7 @@ extension SwiftSync {
             return SyncPendingChanges(inserts: [], updates: [], deletes: [])
         }
 
-        // Resolve every changed persistent id to its localID. Live rows come from a fetch; deleted
+        // Resolve every changed persistent id to its id. Live rows come from a fetch; deleted
         // rows are gone from the store, so their (now-invalidated) insert/update changes can't be read
         // — their id comes from the delete tombstone instead (mark the identity `.preserveValueOnDeletion`).
         // Resolving deleted rows lets us recognise an insert-then-delete that never reached the server.
@@ -178,7 +178,7 @@ extension SwiftSync {
     /// The persistent identifiers of rows with **un-pushed local changes** for `Model` — local-authored
     /// history since the stored token. The pull uses this to preserve never-pushed local inserts from
     /// delete-missing and to keep a newer local edit from being clobbered (last-writer-wins). Reads
-    /// persistent ids (not localIDs), so it needs no `SyncID == String` constraint.
+    /// persistent ids (not row ids), so it needs no `SyncID == String` constraint.
     static func locallyDirtyPersistentIDs<Model: SyncUpdatableModel>(
         for _: Model.Type, in context: ModelContext
     ) throws -> Set<PersistentIdentifier> {

--- a/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
@@ -49,7 +49,7 @@ final class OfflineHistoryTests: XCTestCase {
 
         // Push it so it's "synced" (token advances past its insert); now a later delete is a genuine
         // pending deletion rather than an insert-then-delete the server never saw.
-        _ = try await SwiftSync.push(for: HistoryRow.self, in: local) { _ in [] }
+        _ = try await SwiftSync.withPendingChanges(for: HistoryRow.self, in: local) { _ in [] }
 
         // Delete the synced row with a plain context.delete — the tombstone must yield its id.
         let row = try XCTUnwrap(

--- a/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
@@ -49,9 +49,7 @@ final class OfflineHistoryTests: XCTestCase {
 
         // Push it so it's "synced" (token advances past its insert); now a later delete is a genuine
         // pending deletion rather than an insert-then-delete the server never saw.
-        _ = try await SwiftSync.push(for: HistoryRow.self, in: local) { batch in
-            SyncPushResponse(confirmedLocalIDs: Set(batch.inserts))
-        }
+        _ = try await SwiftSync.push(for: HistoryRow.self, in: local) { _ in [] }
 
         // Delete the synced row with a plain context.delete — the tombstone must yield its id.
         let row = try XCTUnwrap(

--- a/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
@@ -29,9 +29,7 @@ final class OfflinePushTests: XCTestCase {
             configurations: ModelConfiguration(url: directory.appendingPathComponent("store.sqlite")))
     }
 
-    private func confirmAll(_ batch: SyncPushBatch) -> SyncPushResponse {
-        SyncPushResponse(confirmedLocalIDs: Set(batch.inserts + batch.updates + batch.deletes))
-    }
+    private func noFailures(_ pending: SyncPendingChanges) -> [SyncPushFailure] { [] }
 
     /// History-derived partitioning: after a baseline push makes some rows "synced" (behind the
     /// token), a fresh round of local edits partitions into insert/update/delete — and a row inserted
@@ -43,7 +41,7 @@ final class OfflinePushTests: XCTestCase {
         for id in ["a", "b", "d"] { context.insert(PushNote(id: id, title: id)) }
         try context.save()
         // Baseline push: a, b, d become synced (token advances past their inserts).
-        _ = try await SwiftSync.push(for: PushNote.self, in: context, upload: confirmAll)
+        _ = try await SwiftSync.push(for: PushNote.self, in: context, upload: noFailures)
 
         try mutate(context) { $0.first { $0.id == "b" }?.title = "edited" }  // update
         try delete("d", in: context)  // delete
@@ -67,9 +65,9 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "c1", title: "insert"))
         try context.save()
 
-        let summary = try await SwiftSync.push(for: PushNote.self, in: context) { batch in
-            XCTAssertEqual(batch.inserts, ["c1"])
-            return self.confirmAll(batch)
+        let summary = try await SwiftSync.push(for: PushNote.self, in: context) { pending in
+            XCTAssertEqual(pending.inserts, ["c1"])
+            return []
         }
 
         XCTAssertEqual(summary.insertedCount, 1)
@@ -86,9 +84,7 @@ final class OfflinePushTests: XCTestCase {
         try context.save()
 
         let summary = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
-            SyncPushResponse(failures: [
-                SyncPushFailure(localID: "c1", operation: .insert, error: PushTestError(message: "422"))
-            ])
+            [SyncPushFailure(localID: "c1", error: PushTestError(message: "422"))]
         }
 
         XCTAssertEqual(summary.failures.first?.localID, "c1")
@@ -102,35 +98,37 @@ final class OfflinePushTests: XCTestCase {
         let context = container.mainContext
         context.insert(PushNote(id: "u1", title: "v1"))
         try context.save()
-        _ = try await SwiftSync.push(for: PushNote.self, in: context, upload: confirmAll)  // synced
+        _ = try await SwiftSync.push(for: PushNote.self, in: context, upload: noFailures)  // synced
 
         try mutate(context) { $0.first { $0.id == "u1" }?.title = "v2" }
         try context.save()
 
         _ = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
-            SyncPushResponse(failures: [
-                SyncPushFailure(localID: "u1", operation: .update, error: PushTestError(message: "500"))
-            ])
+            [SyncPushFailure(localID: "u1", error: PushTestError(message: "500"))]
         }
         XCTAssertEqual(
             try SwiftSync.pendingChanges(for: PushNote.self, in: context).updates, ["u1"],
             "an unacknowledged update stays pending")
     }
 
-    /// `updatedCount` reflects only rows actually in this batch, not extra ids the server echoes.
-    func testUpdatedCountIgnoresIDsOutsideTheBatch() async throws {
+    /// Counts are the batch minus the reported failures: a partial rejection confirms the rest by
+    /// complement. Because *any* failure freezes the token, even the confirmed rows stay pending and are
+    /// re-detected next push (at-least-once).
+    func testCountsAreBatchMinusFailures() async throws {
         let container = try makeContainer()
         let context = container.mainContext
-        context.insert(PushNote(id: "u1", title: "v1"))
-        try context.save()
-        _ = try await SwiftSync.push(for: PushNote.self, in: context, upload: confirmAll)  // synced
-        try mutate(context) { $0.first { $0.id == "u1" }?.title = "v2" }
+        context.insert(PushNote(id: "c1", title: "ok"))
+        context.insert(PushNote(id: "c2", title: "rejected"))
         try context.save()
 
         let summary = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
-            SyncPushResponse(confirmedLocalIDs: ["u1", "ghost-not-in-batch"])
+            [SyncPushFailure(localID: "c2", error: PushTestError(message: "422"))]
         }
-        XCTAssertEqual(summary.updatedCount, 1, "only the in-batch update counts, not server echoes")
+        XCTAssertEqual(summary.insertedCount, 1, "c1 confirmed by complement; c2 failed")
+        XCTAssertEqual(summary.failures.map(\.localID), ["c2"])
+        XCTAssertEqual(
+            try SwiftSync.pendingChanges(for: PushNote.self, in: context).inserts.sorted(), ["c1", "c2"],
+            "a failure freezes the token, so even the confirmed row is re-detected")
     }
 
     /// A local write during the upload await wasn't in the batch, so the token must not advance past it:
@@ -141,12 +139,12 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "p1", title: "first"))
         try context.save()
 
-        let summary = try await SwiftSync.push(for: PushNote.self, in: context) { batch in
-            XCTAssertEqual(batch.inserts, ["p1"])
+        let summary = try await SwiftSync.push(for: PushNote.self, in: context) { pending in
+            XCTAssertEqual(pending.inserts, ["p1"])
             // A new local row appears after the batch was captured, while "uploading".
             context.insert(PushNote(id: "p2", title: "during upload"))
             try context.save()
-            return self.confirmAll(batch)
+            return []
         }
 
         XCTAssertEqual(summary.insertedCount, 1)
@@ -172,9 +170,9 @@ final class OfflinePushTests: XCTestCase {
 
         var uploadCalled = false
         do {
-            _ = try await SwiftSync.push(for: PushNote.self, in: context) { batch in
+            _ = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
                 uploadCalled = true
-                return self.confirmAll(batch)
+                return []
             }
             XCTFail("expected push to throw when the bookkeeping model is not registered")
         } catch {

--- a/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
@@ -83,10 +83,10 @@ final class OfflinePushTests: XCTestCase {
         try context.save()
 
         let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
-            [SyncPushFailure(localID: "c1", error: PushTestError(message: "422"))]
+            [SyncPushFailure(id: "c1", error: PushTestError(message: "422"))]
         }
 
-        XCTAssertEqual(failures.first?.localID, "c1")
+        XCTAssertEqual(failures.first?.id, "c1")
         XCTAssertEqual(failures.first?.error as? PushTestError, PushTestError(message: "422"))
         XCTAssertEqual(try SwiftSync.pendingChanges(for: PushNote.self, in: context).inserts, ["c1"])
     }
@@ -103,7 +103,7 @@ final class OfflinePushTests: XCTestCase {
         try context.save()
 
         _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
-            [SyncPushFailure(localID: "u1", error: PushTestError(message: "500"))]
+            [SyncPushFailure(id: "u1", error: PushTestError(message: "500"))]
         }
         XCTAssertEqual(
             try SwiftSync.pendingChanges(for: PushNote.self, in: context).updates, ["u1"],
@@ -121,9 +121,9 @@ final class OfflinePushTests: XCTestCase {
         try context.save()
 
         let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
-            [SyncPushFailure(localID: "c2", error: PushTestError(message: "422"))]
+            [SyncPushFailure(id: "c2", error: PushTestError(message: "422"))]
         }
-        XCTAssertEqual(failures.map(\.localID), ["c2"])
+        XCTAssertEqual(failures.map(\.id), ["c2"])
         XCTAssertEqual(
             try SwiftSync.pendingChanges(for: PushNote.self, in: context).inserts.sorted(), ["c1", "c2"],
             "a failure freezes the token, so even the accepted row is re-detected")

--- a/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
@@ -65,13 +65,12 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "c1", title: "insert"))
         try context.save()
 
-        let summary = try await SwiftSync.push(for: PushNote.self, in: context) { pending in
+        let failures = try await SwiftSync.push(for: PushNote.self, in: context) { pending in
             XCTAssertEqual(pending.inserts, ["c1"])
             return []
         }
 
-        XCTAssertEqual(summary.insertedCount, 1)
-        XCTAssertTrue(summary.failures.isEmpty)
+        XCTAssertTrue(failures.isEmpty)
         XCTAssertTrue(try SwiftSync.pendingChanges(for: PushNote.self, in: context).isEmpty)
     }
 
@@ -83,12 +82,12 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "c1", title: "rejected"))
         try context.save()
 
-        let summary = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
+        let failures = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
             [SyncPushFailure(localID: "c1", error: PushTestError(message: "422"))]
         }
 
-        XCTAssertEqual(summary.failures.first?.localID, "c1")
-        XCTAssertEqual(summary.failures.first?.error as? PushTestError, PushTestError(message: "422"))
+        XCTAssertEqual(failures.first?.localID, "c1")
+        XCTAssertEqual(failures.first?.error as? PushTestError, PushTestError(message: "422"))
         XCTAssertEqual(try SwiftSync.pendingChanges(for: PushNote.self, in: context).inserts, ["c1"])
     }
 
@@ -113,22 +112,23 @@ final class OfflinePushTests: XCTestCase {
 
     /// Counts are the batch minus the reported failures: a partial rejection confirms the rest by
     /// complement. Because *any* failure freezes the token, even the confirmed rows stay pending and are
-    /// re-detected next push (at-least-once).
-    func testCountsAreBatchMinusFailures() async throws {
+    /// Any failure freezes the token (all-or-nothing): the rejected row comes back in the returned
+    /// failures, and even the row the server accepted stays pending and is re-detected next push
+    /// (at-least-once).
+    func testPartialFailureFreezesTheTokenForTheWholeBatch() async throws {
         let container = try makeContainer()
         let context = container.mainContext
         context.insert(PushNote(id: "c1", title: "ok"))
         context.insert(PushNote(id: "c2", title: "rejected"))
         try context.save()
 
-        let summary = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
+        let failures = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
             [SyncPushFailure(localID: "c2", error: PushTestError(message: "422"))]
         }
-        XCTAssertEqual(summary.insertedCount, 1, "c1 confirmed by complement; c2 failed")
-        XCTAssertEqual(summary.failures.map(\.localID), ["c2"])
+        XCTAssertEqual(failures.map(\.localID), ["c2"])
         XCTAssertEqual(
             try SwiftSync.pendingChanges(for: PushNote.self, in: context).inserts.sorted(), ["c1", "c2"],
-            "a failure freezes the token, so even the confirmed row is re-detected")
+            "a failure freezes the token, so even the accepted row is re-detected")
     }
 
     /// A local write during the upload await wasn't in the batch, so the token must not advance past it:
@@ -139,7 +139,7 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "p1", title: "first"))
         try context.save()
 
-        let summary = try await SwiftSync.push(for: PushNote.self, in: context) { pending in
+        let failures = try await SwiftSync.push(for: PushNote.self, in: context) { pending in
             XCTAssertEqual(pending.inserts, ["p1"])
             // A new local row appears after the batch was captured, while "uploading".
             context.insert(PushNote(id: "p2", title: "during upload"))
@@ -147,7 +147,7 @@ final class OfflinePushTests: XCTestCase {
             return []
         }
 
-        XCTAssertEqual(summary.insertedCount, 1)
+        XCTAssertTrue(failures.isEmpty)
         XCTAssertEqual(
             try SwiftSync.pendingChanges(for: PushNote.self, in: context).inserts, ["p2"],
             "a local write during upload must survive the token advance")

--- a/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
@@ -41,7 +41,7 @@ final class OfflinePushTests: XCTestCase {
         for id in ["a", "b", "d"] { context.insert(PushNote(id: id, title: id)) }
         try context.save()
         // Baseline push: a, b, d become synced (token advances past their inserts).
-        _ = try await SwiftSync.push(for: PushNote.self, in: context, upload: noFailures)
+        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: noFailures)
 
         try mutate(context) { $0.first { $0.id == "b" }?.title = "edited" }  // update
         try delete("d", in: context)  // delete
@@ -65,7 +65,7 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "c1", title: "insert"))
         try context.save()
 
-        let failures = try await SwiftSync.push(for: PushNote.self, in: context) { pending in
+        let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { pending in
             XCTAssertEqual(pending.inserts, ["c1"])
             return []
         }
@@ -82,7 +82,7 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "c1", title: "rejected"))
         try context.save()
 
-        let failures = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
+        let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
             [SyncPushFailure(localID: "c1", error: PushTestError(message: "422"))]
         }
 
@@ -97,12 +97,12 @@ final class OfflinePushTests: XCTestCase {
         let context = container.mainContext
         context.insert(PushNote(id: "u1", title: "v1"))
         try context.save()
-        _ = try await SwiftSync.push(for: PushNote.self, in: context, upload: noFailures)  // synced
+        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: noFailures)  // synced
 
         try mutate(context) { $0.first { $0.id == "u1" }?.title = "v2" }
         try context.save()
 
-        _ = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
+        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
             [SyncPushFailure(localID: "u1", error: PushTestError(message: "500"))]
         }
         XCTAssertEqual(
@@ -110,8 +110,6 @@ final class OfflinePushTests: XCTestCase {
             "an unacknowledged update stays pending")
     }
 
-    /// Counts are the batch minus the reported failures: a partial rejection confirms the rest by
-    /// complement. Because *any* failure freezes the token, even the confirmed rows stay pending and are
     /// Any failure freezes the token (all-or-nothing): the rejected row comes back in the returned
     /// failures, and even the row the server accepted stays pending and is re-detected next push
     /// (at-least-once).
@@ -122,7 +120,7 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "c2", title: "rejected"))
         try context.save()
 
-        let failures = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
+        let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
             [SyncPushFailure(localID: "c2", error: PushTestError(message: "422"))]
         }
         XCTAssertEqual(failures.map(\.localID), ["c2"])
@@ -139,7 +137,7 @@ final class OfflinePushTests: XCTestCase {
         context.insert(PushNote(id: "p1", title: "first"))
         try context.save()
 
-        let failures = try await SwiftSync.push(for: PushNote.self, in: context) { pending in
+        let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { pending in
             XCTAssertEqual(pending.inserts, ["p1"])
             // A new local row appears after the batch was captured, while "uploading".
             context.insert(PushNote(id: "p2", title: "during upload"))
@@ -170,7 +168,7 @@ final class OfflinePushTests: XCTestCase {
 
         var uploadCalled = false
         do {
-            _ = try await SwiftSync.push(for: PushNote.self, in: context) { _ in
+            _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
                 uploadCalled = true
                 return []
             }

--- a/docs/planning/api-surface-review.md
+++ b/docs/planning/api-surface-review.md
@@ -31,7 +31,7 @@ git history is the memory.
 2. [x] ~~Macro-generate `SyncOfflineModel`~~ — **superseded**: offline now rides SwiftData History, so there is no `SyncOfflineModel` to generate. Models carry zero offline fields; offline is opted in by marking the identity `@Attribute(.preserveValueOnDeletion)`. See `docs/planning/offline-history-design.md`.
 3. [x] ~~Drop `syncFailureReason` from the protocol~~ — **done** (#624: removed from `SyncOfflineModel`)
 4. [x] ~~Generalize the inbound LWW timestamp key~~ — **stale**: superseded by the history dirty-set (see §4)
-5. [x] ~~Tighten the push response seam~~ — **done**: 5 push structs → 2 (`SyncPendingChanges`, `SyncPushFailure`); both `upload` and `push` deal only in `[SyncPushFailure]` (see §5)
+5. [x] ~~Tighten the push response seam~~ — **done**: 5 push structs → 2 (`SyncPendingChanges`, `SyncPushFailure`); `push`→`withPendingChanges` (a `with…` scope) with a `process` closure that returns only `[SyncPushFailure]` (see §5)
 6. [x] ~~Unify the three error types into `SyncError`~~ — **done** (#624: `SchemaValidationError` + `ObjectiveCInitializationExceptionError` folded into `SyncError`)
 7. [ ] Demote the reactive publishers to `internal`
 
@@ -103,7 +103,7 @@ coordination with #3 (don't generate a field that's being removed).
 ## 3. Drop `syncFailureReason` from `SyncOfflineModel` — ✅ done (#624)
 
 Pure-bubble (#624) removed `syncFailureReason` from `SyncOfflineModel`: the library persists no per-row
-failure state — failures bubble up as `push`'s `[SyncPushFailure]` return and the consumer owns any inbox (the
+failure state — failures bubble up as `withPendingChanges`'s `[SyncPushFailure]` return and the consumer owns any inbox (the
 demo annotates its own `@NotExport` field). One fewer hand-written protocol requirement. **Note for #2:**
 the macro must not generate this field — it's gone.
 
@@ -138,18 +138,23 @@ redundant; only the **failures** carry information the library can't derive.
 
 **Now (5 structs → 2).**
 - `SyncPushBatch` merged into `SyncPendingChanges` — one type is both the return of `pendingChanges(...)`
-  and the value `push(...)` hands `upload`.
+  and the value `withPendingChanges(...)` hands the `process` closure.
 - `SyncPushResponse` **deleted** — `upload` now returns `[SyncPushFailure]` directly.
 - `SyncPushFailure` shrank to `{ localID, error }` — the `Operation` enum/field went (the operation is
   the library's to know from the batch, not the consumer's to report).
-- `SyncPushSummary` **deleted** — `push` returns `[SyncPushFailure]` (the same value `upload` returns). Its
-  three counts (`insertedCount`/`updatedCount`/`deletedCount`) had no consumer; the demo only ever read
-  `.failures`. Counts are derivable by complement if a consumer ever needs them.
+- `SyncPushSummary` **deleted** — the method returns `[SyncPushFailure]` (the same value the closure
+  returns). Its three counts (`insertedCount`/`updatedCount`/`deletedCount`) had no consumer; the demo only
+  ever read `.failures`. Counts are derivable by complement if a consumer ever needs them.
+- `push(for:in:upload:)` renamed `withPendingChanges(for:in:process:)` — `push` was dishonest (the library
+  does no network; unlike `sync`, which *does* the write). The `with…` idiom names what it is: a scope that
+  hands you the pending changes, lets your `process` closure do the transport, and commits the token on the
+  way out. Pairs with the `pendingChanges` getter (peek vs. process). The `upload` label (a networking
+  term) became a trailing closure.
 - `inboundAuthor` demoted `public` → `internal` (consumer never referenced it).
 
 Surviving public push surface: `SyncPendingChanges` (in) and `SyncPushFailure` (out). The token still
-advances (and inbound history is trimmed) only when `upload` reports **no** failures — same at-least-once
-semantics, smaller seam.
+advances (and inbound history is trimmed) only when the `process` closure reports **no** failures — same
+at-least-once semantics, smaller seam.
 
 ---
 

--- a/docs/planning/api-surface-review.md
+++ b/docs/planning/api-surface-review.md
@@ -31,7 +31,7 @@ git history is the memory.
 2. [x] ~~Macro-generate `SyncOfflineModel`~~ — **superseded**: offline now rides SwiftData History, so there is no `SyncOfflineModel` to generate. Models carry zero offline fields; offline is opted in by marking the identity `@Attribute(.preserveValueOnDeletion)`. See `docs/planning/offline-history-design.md`.
 3. [x] ~~Drop `syncFailureReason` from the protocol~~ — **done** (#624: removed from `SyncOfflineModel`)
 4. [x] ~~Generalize the inbound LWW timestamp key~~ — **stale**: superseded by the history dirty-set (see §4)
-5. [x] ~~Tighten the push response seam~~ — **done**: 5 push structs → 3 (`SyncPendingChanges`, `SyncPushFailure`, `SyncPushSummary`); `upload` returns only `[SyncPushFailure]` (see §5)
+5. [x] ~~Tighten the push response seam~~ — **done**: 5 push structs → 2 (`SyncPendingChanges`, `SyncPushFailure`); both `upload` and `push` deal only in `[SyncPushFailure]` (see §5)
 6. [x] ~~Unify the three error types into `SyncError`~~ — **done** (#624: `SchemaValidationError` + `ObjectiveCInitializationExceptionError` folded into `SyncError`)
 7. [ ] Demote the reactive publishers to `internal`
 
@@ -103,7 +103,7 @@ coordination with #3 (don't generate a field that's being removed).
 ## 3. Drop `syncFailureReason` from `SyncOfflineModel` — ✅ done (#624)
 
 Pure-bubble (#624) removed `syncFailureReason` from `SyncOfflineModel`: the library persists no per-row
-failure state — failures bubble up via `SyncPushSummary.failures` and the consumer owns any inbox (the
+failure state — failures bubble up as `push`'s `[SyncPushFailure]` return and the consumer owns any inbox (the
 demo annotates its own `@NotExport` field). One fewer hand-written protocol requirement. **Note for #2:**
 the macro must not generate this field — it's gone.
 
@@ -136,17 +136,18 @@ identity the server adopts (an idempotent upsert — no server-assigned ids to m
 are derivable: `confirmed = batch − failures`. Asking the consumer to echo back which ids succeeded was
 redundant; only the **failures** carry information the library can't derive.
 
-**Now (5 structs → 3).**
+**Now (5 structs → 2).**
 - `SyncPushBatch` merged into `SyncPendingChanges` — one type is both the return of `pendingChanges(...)`
   and the value `push(...)` hands `upload`.
 - `SyncPushResponse` **deleted** — `upload` now returns `[SyncPushFailure]` directly.
 - `SyncPushFailure` shrank to `{ localID, error }` — the `Operation` enum/field went (the operation is
   the library's to know from the batch, not the consumer's to report).
-- `SyncPushSummary` unchanged (`insertedCount` / `updatedCount` / `deletedCount` / `failures`); counts are
-  now computed by complement.
+- `SyncPushSummary` **deleted** — `push` returns `[SyncPushFailure]` (the same value `upload` returns). Its
+  three counts (`insertedCount`/`updatedCount`/`deletedCount`) had no consumer; the demo only ever read
+  `.failures`. Counts are derivable by complement if a consumer ever needs them.
 - `inboundAuthor` demoted `public` → `internal` (consumer never referenced it).
 
-Surviving public push surface: `SyncPendingChanges`, `SyncPushFailure`, `SyncPushSummary`. The token still
+Surviving public push surface: `SyncPendingChanges` (in) and `SyncPushFailure` (out). The token still
 advances (and inbound history is trimmed) only when `upload` reports **no** failures — same at-least-once
 semantics, smaller seam.
 

--- a/docs/planning/api-surface-review.md
+++ b/docs/planning/api-surface-review.md
@@ -140,8 +140,11 @@ redundant; only the **failures** carry information the library can't derive.
 - `SyncPushBatch` merged into `SyncPendingChanges` — one type is both the return of `pendingChanges(...)`
   and the value `withPendingChanges(...)` hands the `process` closure.
 - `SyncPushResponse` **deleted** — `upload` now returns `[SyncPushFailure]` directly.
-- `SyncPushFailure` shrank to `{ localID, error }` — the `Operation` enum/field went (the operation is
-  the library's to know from the batch, not the consumer's to report).
+- `SyncPushFailure` shrank to `{ id, error }` — the `Operation` enum/field went (the operation is
+  the library's to know from the batch, not the consumer's to report). Its `id` field was renamed from
+  `localID` (a vestige of the deleted two-id `localId`+`remoteId` model); the library deals in one `id`,
+  matching the model's `@Attribute(.unique) var id`. The demo's `/sync/upload` wire key followed suit
+  (`"localId"` → `"id"`); the backend keeps `public_id` internally, where the int-PK contrast is real.
 - `SyncPushSummary` **deleted** — the method returns `[SyncPushFailure]` (the same value the closure
   returns). Its three counts (`insertedCount`/`updatedCount`/`deletedCount`) had no consumer; the demo only
   ever read `.failures`. Counts are derivable by complement if a consumer ever needs them.

--- a/docs/planning/api-surface-review.md
+++ b/docs/planning/api-surface-review.md
@@ -31,7 +31,7 @@ git history is the memory.
 2. [x] ~~Macro-generate `SyncOfflineModel`~~ — **superseded**: offline now rides SwiftData History, so there is no `SyncOfflineModel` to generate. Models carry zero offline fields; offline is opted in by marking the identity `@Attribute(.preserveValueOnDeletion)`. See `docs/planning/offline-history-design.md`.
 3. [x] ~~Drop `syncFailureReason` from the protocol~~ — **done** (#624: removed from `SyncOfflineModel`)
 4. [x] ~~Generalize the inbound LWW timestamp key~~ — **stale**: superseded by the history dirty-set (see §4)
-5. [ ] Tighten the push response seam (5 public structs)
+5. [x] ~~Tighten the push response seam~~ — **done**: 5 push structs → 3 (`SyncPendingChanges`, `SyncPushFailure`, `SyncPushSummary`); `upload` returns only `[SyncPushFailure]` (see §5)
 6. [x] ~~Unify the three error types into `SyncError`~~ — **done** (#624: `SchemaValidationError` + `ObjectiveCInitializationExceptionError` folded into `SyncError`)
 7. [ ] Demote the reactive publishers to `internal`
 
@@ -124,21 +124,31 @@ generalize. Same fate as #2 (`SyncOfflineModel`), superseded by the same rework.
 
 ---
 
-## 5. Tighten the push response seam
+## 5. Tighten the push response seam — ✅ done
 
-**Context.** The push feature exposes five public structs — `SyncPushBatch`, `SyncPushFailure`
-(+`Operation`), `SyncPushResponse`, `SyncPushSummary`, `SyncPendingChanges`. The consumer hand-maps its
-server's JSON into a `SyncPushResponse` (three id sets — `assignedRemoteIDs` / `confirmedUpdateLocalIDs`
-/ `confirmedDeleteLocalIDs` — plus `failures`). Some mapping is inherent (server shapes vary), but the
-return shape of the `upload` closure deserves a first-principles pass.
+**Was.** The push feature exposed **five** public structs — `SyncPushBatch`, `SyncPushFailure`
+(+ an `Operation` enum), `SyncPushResponse`, `SyncPushSummary`, `SyncPendingChanges` — and the `upload`
+closure took a `SyncPushBatch` and returned a `SyncPushResponse` the consumer assembled by enumerating
+*confirmed* ids (a `confirmedLocalIDs` set) plus failures.
 
-**Target.** Review whether the closure's return can be smaller or library-derived (e.g. derive
-confirmations from the batch + assigned ids rather than asking the consumer to enumerate three sets).
+**First principle.** The library already hands the consumer the batch, and the client id *is* the
+identity the server adopts (an idempotent upsert — no server-assigned ids to map home). So confirmations
+are derivable: `confirmed = batch − failures`. Asking the consumer to echo back which ids succeeded was
+redundant; only the **failures** carry information the library can't derive.
 
-**Decision needed.** Needs a design pass; lower leverage than #1–#2 — don't churn the seam without a
-clear reduction.
+**Now (5 structs → 3).**
+- `SyncPushBatch` merged into `SyncPendingChanges` — one type is both the return of `pendingChanges(...)`
+  and the value `push(...)` hands `upload`.
+- `SyncPushResponse` **deleted** — `upload` now returns `[SyncPushFailure]` directly.
+- `SyncPushFailure` shrank to `{ localID, error }` — the `Operation` enum/field went (the operation is
+  the library's to know from the batch, not the consumer's to report).
+- `SyncPushSummary` unchanged (`insertedCount` / `updatedCount` / `deletedCount` / `failures`); counts are
+  now computed by complement.
+- `inboundAuthor` demoted `public` → `internal` (consumer never referenced it).
 
-**Scope/risk.** Public API change to the push seam; medium.
+Surviving public push surface: `SyncPendingChanges`, `SyncPushFailure`, `SyncPushSummary`. The token still
+advances (and inbound history is trimmed) only when `upload` reports **no** failures — same at-least-once
+semantics, smaller seam.
 
 ---
 

--- a/docs/planning/offline-history-design.md
+++ b/docs/planning/offline-history-design.md
@@ -27,7 +27,7 @@ each tagged with an **author** and ordered by a **token**. So:
   pulled row is never mistaken for a local insert and pushed back.
 - **"Deleted"** = a delete transaction. Marking the identity `@Attribute(.preserveValueOnDeletion)`
   keeps the id readable in the tombstone, so a plain `context.delete(row)` is enough to recover the
-  deleted `localID` at push time.
+  deleted `id` at push time.
 
 **Opt-in = `.preserveValueOnDeletion` on the identity.** That attribute is genuinely *required* for
 offline (to recover deleted ids) and is a harmless no-op otherwise, so its presence is the honest
@@ -52,7 +52,7 @@ cursor and trims the now-redundant inbound history.
 - **Near-zero consumer surface.** One attribute option (`.preserveValueOnDeletion`) on the identity —
   no `syncRemoteID`/tombstone/`updatedAt` sync fields, no `SwiftSync.delete` ceremony. The consumer
   uses plain SwiftData inserts/edits/`context.delete`.
-- **Collapsed id model** (decided with the user): the client `localID` *is* the identity the backend
+- **Collapsed id model** (decided with the user): the client `id` *is* the identity the backend
   adopts; there is no separate server-assigned id to map home. Push is an idempotent **upsert**, so
   insert vs update need not be distinguished on the wire — and confirmations need not be echoed: the
   `process` closure returns only `[SyncPushFailure]`, and the library confirms everything else by complement.

--- a/docs/planning/offline-history-design.md
+++ b/docs/planning/offline-history-design.md
@@ -54,16 +54,17 @@ cursor and trims the now-redundant inbound history.
   uses plain SwiftData inserts/edits/`context.delete`.
 - **Collapsed id model** (decided with the user): the client `localID` *is* the identity the backend
   adopts; there is no separate server-assigned id to map home. Push is an idempotent **upsert**, so
-  insert vs update need not be distinguished on the wire — and confirmations need not be echoed: `upload`
-  returns only `[SyncPushFailure]`, and the library confirms everything else by complement.
+  insert vs update need not be distinguished on the wire — and confirmations need not be echoed: the
+  `process` closure returns only `[SyncPushFailure]`, and the library confirms everything else by complement.
 
 ## What changed in code
 
 - `Push.swift`: `SyncCursor` (= `DefaultHistoryToken`), `SwiftSync.inboundAuthor`, history-based
-  `pendingChanges(for:in:)` / `push(for:in:upload:)` (cursor internal, no `changedSince`/return cursor),
-  `locallyDirtyPersistentIDs`, `trimInboundHistory`, `localTransactions`, `latestToken`. The
-  insert-then-delete-before-push case is dropped (server never saw it). Both `upload` and `push` return
-  `[SyncPushFailure]` (confirmations derived by complement; no summary/cursor for the caller to handle).
+  `pendingChanges(for:in:)` / `withPendingChanges(for:in:process:)` (cursor internal, no
+  `changedSince`/return cursor), `locallyDirtyPersistentIDs`, `trimInboundHistory`, `localTransactions`,
+  `latestToken`. The insert-then-delete-before-push case is dropped (server never saw it). Both the
+  `process` closure and `withPendingChanges` return `[SyncPushFailure]` (confirmations derived by
+  complement; no summary/cursor for the caller to handle).
 - `SyncCursorStore.swift`: internal `SyncCursorRecord` (per-type token) + read/write helpers.
 - `OfflineDetection.swift`: `identityPreservesValueOnDeletion` (the opt-in check) + `requireOfflineCapable`
   (push/pending throw a clear diagnostic if the identity isn't `.preserveValueOnDeletion`).

--- a/docs/planning/offline-history-design.md
+++ b/docs/planning/offline-history-design.md
@@ -62,8 +62,8 @@ cursor and trims the now-redundant inbound history.
 - `Push.swift`: `SyncCursor` (= `DefaultHistoryToken`), `SwiftSync.inboundAuthor`, history-based
   `pendingChanges(for:in:)` / `push(for:in:upload:)` (cursor internal, no `changedSince`/return cursor),
   `locallyDirtyPersistentIDs`, `trimInboundHistory`, `localTransactions`, `latestToken`. The
-  insert-then-delete-before-push case is dropped (server never saw it). `upload` returns
-  `[SyncPushFailure]` (confirmations derived by complement); `SyncPushSummary` drops `cursor`.
+  insert-then-delete-before-push case is dropped (server never saw it). Both `upload` and `push` return
+  `[SyncPushFailure]` (confirmations derived by complement; no summary/cursor for the caller to handle).
 - `SyncCursorStore.swift`: internal `SyncCursorRecord` (per-type token) + read/write helpers.
 - `OfflineDetection.swift`: `identityPreservesValueOnDeletion` (the opt-in check) + `requireOfflineCapable`
   (push/pending throw a clear diagnostic if the identity isn't `.preserveValueOnDeletion`).

--- a/docs/planning/offline-history-design.md
+++ b/docs/planning/offline-history-design.md
@@ -54,16 +54,16 @@ cursor and trims the now-redundant inbound history.
   uses plain SwiftData inserts/edits/`context.delete`.
 - **Collapsed id model** (decided with the user): the client `localID` *is* the identity the backend
   adopts; there is no separate server-assigned id to map home. Push is an idempotent **upsert**, so
-  insert vs update need not be distinguished on the wire — `SyncPushResponse` is just
-  `confirmedLocalIDs` + `failures`.
+  insert vs update need not be distinguished on the wire — and confirmations need not be echoed: `upload`
+  returns only `[SyncPushFailure]`, and the library confirms everything else by complement.
 
 ## What changed in code
 
 - `Push.swift`: `SyncCursor` (= `DefaultHistoryToken`), `SwiftSync.inboundAuthor`, history-based
   `pendingChanges(for:in:)` / `push(for:in:upload:)` (cursor internal, no `changedSince`/return cursor),
   `locallyDirtyPersistentIDs`, `trimInboundHistory`, `localTransactions`, `latestToken`. The
-  insert-then-delete-before-push case is dropped (server never saw it). `SyncPushResponse` =
-  `confirmedLocalIDs` + `failures`; `SyncPushSummary` drops `cursor`.
+  insert-then-delete-before-push case is dropped (server never saw it). `upload` returns
+  `[SyncPushFailure]` (confirmations derived by complement); `SyncPushSummary` drops `cursor`.
 - `SyncCursorStore.swift`: internal `SyncCursorRecord` (per-type token) + read/write helpers.
 - `OfflineDetection.swift`: `identityPreservesValueOnDeletion` (the opt-in check) + `requireOfflineCapable`
   (push/pending throw a clear diagnostic if the identity isn't `.preserveValueOnDeletion`).

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -97,10 +97,10 @@ state; failed rows stay pending and retry; surfacing is an event stream; the inb
 
 - [ ] **Represent + report (pure-bubble).** One `SyncError` currency for everything SwiftSync throws
       (`.invalidPayload` / `.cancelled` / `.schemaValidation` / `.containerInitialization`). For per-row
-      *partial* push rejections, `push()` returns the rejected rows (`[SyncPushFailure]` of `{localID, error}`)
-      and marks succeeded rows synced / leaves failed rows pending — it persists **nothing** on models
-      (no `syncFailureReason`/`syncFailureCode` on `SyncOfflineModel`). The consumer owns any inbox
-      persistence and reads the backend's own error in its `upload` closure. *Demo:* the engine annotates
+      *partial* push rejections, `withPendingChanges()` returns the rejected rows (`[SyncPushFailure]` of
+      `{localID, error}`) and marks succeeded rows synced / leaves failed rows pending — it persists
+      **nothing** on models (no `syncFailureReason`/`syncFailureCode` on `SyncOfflineModel`). The consumer
+      owns any inbox persistence and reads the backend's own error in its `process` closure. *Demo:* the engine annotates
       its own `Task` field from the returned failures and clears it on a later successful push.
 
 - [ ] **Surface (observability).** A multi-consumer `events()` `AsyncStream` emitting per-sync outcomes
@@ -109,7 +109,7 @@ state; failed rows stay pending and retry; surfacing is an event stream; the inb
       Same concern as the bubble above; lands with or right after it. (↔ Networking roadmap item 3.)
 
 **Out of SwiftSync — resilience.** Retry/backoff/`Retry-After`/auth-refresh are the *networking layer's*
-job (the `code/3lvis/ios/Networking` interceptors, wired into the consumer's `upload` closure), by the
+job (the `code/3lvis/ios/Networking` interceptors, wired into the consumer's `process` closure), by the
 same "a sync library doesn't own the network" principle that keeps it from categorizing errors. Not a
 SwiftSync feature.
 

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -98,7 +98,7 @@ state; failed rows stay pending and retry; surfacing is an event stream; the inb
 - [ ] **Represent + report (pure-bubble).** One `SyncError` currency for everything SwiftSync throws
       (`.invalidPayload` / `.cancelled` / `.schemaValidation` / `.containerInitialization`). For per-row
       *partial* push rejections, `withPendingChanges()` returns the rejected rows (`[SyncPushFailure]` of
-      `{localID, error}`) and marks succeeded rows synced / leaves failed rows pending — it persists
+      `{id, error}`) and marks succeeded rows synced / leaves failed rows pending — it persists
       **nothing** on models (no `syncFailureReason`/`syncFailureCode` on `SyncOfflineModel`). The consumer
       owns any inbox persistence and reads the backend's own error in its `process` closure. *Demo:* the engine annotates
       its own `Task` field from the returned failures and clears it on a later successful push.
@@ -182,3 +182,7 @@ server-origin rows get a server-minted UUID. The client deals only in `public_id
       `public_id` as the sole external identity, the dual-minting + adopt rule, and the rationale
       (idempotency on lost-response retry, shareable URL id, reach over existing backends). The doc still
       describes the superseded #630 collapsed-id / `SyncOffline`-marker model — refresh it.
+- [ ] **Rewrite `upload-endpoint-contract.md`** to the collapsed-id model. It still documents the original
+      two-id (`localId` + server-minted `remoteId`) wire protocol; the shipped reality is one id (client id
+      adopted as `public_id`, no `remoteId`) and the demo's wire key is now `"id"`. Currently carries a
+      staleness banner pointing at `offline-history-design.md`.

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -97,11 +97,11 @@ state; failed rows stay pending and retry; surfacing is an event stream; the inb
 
 - [ ] **Represent + report (pure-bubble).** One `SyncError` currency for everything SwiftSync throws
       (`.invalidPayload` / `.cancelled` / `.schemaValidation` / `.containerInitialization`). For per-row
-      *partial* push rejections, `push()` returns the outcomes (`failures: [{localID, error}]`)
+      *partial* push rejections, `push()` returns the rejected rows (`[SyncPushFailure]` of `{localID, error}`)
       and marks succeeded rows synced / leaves failed rows pending — it persists **nothing** on models
       (no `syncFailureReason`/`syncFailureCode` on `SyncOfflineModel`). The consumer owns any inbox
       persistence and reads the backend's own error in its `upload` closure. *Demo:* the engine annotates
-      its own `Task` field from `summary.failures` and clears it on a later successful push.
+      its own `Task` field from the returned failures and clears it on a later successful push.
 
 - [ ] **Surface (observability).** A multi-consumer `events()` `AsyncStream` emitting per-sync outcomes
       (started/completed, applied/stale/rejected, counts, duration) — the prior-art surfacing channel

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -97,7 +97,7 @@ state; failed rows stay pending and retry; surfacing is an event stream; the inb
 
 - [ ] **Represent + report (pure-bubble).** One `SyncError` currency for everything SwiftSync throws
       (`.invalidPayload` / `.cancelled` / `.schemaValidation` / `.containerInitialization`). For per-row
-      *partial* push rejections, `push()` returns the outcomes (`failures: [{localID, operation, error}]`)
+      *partial* push rejections, `push()` returns the outcomes (`failures: [{localID, error}]`)
       and marks succeeded rows synced / leaves failed rows pending — it persists **nothing** on models
       (no `syncFailureReason`/`syncFailureCode` on `SyncOfflineModel`). The consumer owns any inbox
       persistence and reads the backend's own error in its `upload` closure. *Demo:* the engine annotates

--- a/docs/project/upload-endpoint-contract.md
+++ b/docs/project/upload-endpoint-contract.md
@@ -1,5 +1,11 @@
 # Upload Endpoint Contract
 
+> ⚠️ **Stale — pending rewrite.** This describes the original two-id (`localId` + server-minted
+> `remoteId`) protocol. The shipped model **collapsed to one id**: the client id *is* the row's identity
+> and the backend adopts it as its `public_id` (no `remoteId`), and the demo's `/sync/upload` wire key is
+> now `"id"`, not `"localId"`. See `docs/planning/offline-history-design.md` for the current model. This
+> doc is tracked for a refresh in the roadmap's docs follow-ups.
+
 The wire contract for SwiftSync's **push** (local → server). A general-purpose backend
 (Django/Rails/Laravel/Spring) adds this as one thin "offline layer" endpoint *beside* its normal
 per-resource routes — backed by the framework's bulk-upsert primitive (`upsert_all` / `upsert()` /


### PR DESCRIPTION
## What

Collapses the offline-push public surface from **5 structs to 3**, the next item (§5) in `docs/planning/api-surface-review.md`. Same spirit as the offline/History reworks: less to construct, less to misuse.

## Why

The library already hands the consumer the batch, and the client id *is* the identity the server adopts (idempotent upsert — no server-assigned id to map home). So confirmations are derivable: `confirmed = batch − failures`. Asking the consumer to enumerate which ids succeeded was redundant; only the **failures** carry information the library can't derive.

## Changes

- `SyncPushBatch` merged into `SyncPendingChanges` — one type is both the return of `pendingChanges(...)` and the value `push(...)` hands `upload`.
- `SyncPushResponse` **deleted** — `upload` now returns `[SyncPushFailure]` directly.
- `SyncPushFailure` shrinks to `{ localID, error }` — the `Operation` enum/field is gone (the operation is the library's to know from the batch).
- `SyncPushSummary` unchanged; its counts are now computed by complement.
- `inboundAuthor` demoted `public` → `internal` (consumer never referenced it).

Token still advances (and inbound history is trimmed) only when `upload` reports **no** failures — same at-least-once semantics, smaller seam.

## Verification

- SwiftSync: 171 XCTest + 48 swift-testing, 0 failures (incl. the repurposed `testCountsAreBatchMinusFailures`).
- DemoCore: 42 tests, 0 failures — full offline push round-trip via the failures-only seam.
- README, `api-surface-review.md` §5, `offline-history-design.md`, and the roadmap updated in the same PR.