### PR TITLE
Total accounting: process returns a verdict per pending id

### DIFF
--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -267,13 +267,13 @@ public final class DemoSyncEngine {
         try syncContainer.mainContext.save()
     }
 
-    /// Serialize the pending batch into the `/sync/upload` operation list, POST it once, and return only
-    /// the per-row failures — SwiftSync confirms everything else by complement. Every created-or-edited
-    /// row is an `upsert` keyed by its stable `id` (the server find-by-id → update-else-creates, adopting
-    /// that `id` as the row's `public_id` — no distinct server id comes back); tombstones are a `delete`
-    /// by the same `id`. A `stale` result means the server won last-writer-wins — adopt its state locally
-    /// and treat the row as resolved (not a failure) so it isn't re-sent.
-    private func upload(_ pending: SyncPendingChanges) async throws -> [SyncPushFailure] {
+    /// Serialize the pending batch into the `/sync/upload` operation list, POST it once, and return a
+    /// verdict for every row — SwiftSync requires total accounting. Every created-or-edited row is an
+    /// `upsert` keyed by its stable `id` (the server find-by-id → update-else-creates, adopting that `id`
+    /// as the row's `public_id` — no distinct server id comes back); tombstones are a `delete` by the same
+    /// `id`. A `stale` result means the server won last-writer-wins — adopt its state locally and report
+    /// `.confirmed` (resolved, not a failure) so it isn't re-sent.
+    private func upload(_ pending: SyncPendingChanges) async throws -> [String: SyncRowOutcome] {
         var operations: [[String: Any]] = []
 
         for id in pending.inserts + pending.updates {
@@ -295,33 +295,28 @@ public final class DemoSyncEngine {
 
         let results = try await apiClient.upload(operations: operations)
 
-        var failures: [SyncPushFailure] = []
+        var outcomes: [String: SyncRowOutcome] = [:]
         for result in results {
-            let operation = result["operation"] as? String
-            let status = result["status"] as? String
-            let id = result["id"] as? String
-            switch (operation, status) {
+            guard let id = result["id"] as? String else { continue }
+            switch (result["operation"] as? String, result["status"] as? String) {
             case ("upsert", "stale"), ("delete", "stale"):
                 // The server won last-writer-wins — adopt its state locally (the inbound sync re-creates a
-                // hard-deleted row when a delete loses) and treat the row as resolved, not a failure.
+                // hard-deleted row when a delete loses), then report the row resolved (not a failure).
                 if let server = result["server"] as? [String: Any] {
                     try? await syncContainer.sync(
                         item: DemoSyncPayload(dictionary: server), as: Task.self)
                 }
+                outcomes[id] = .confirmed
             case ("upsert", "applied"), ("delete", "applied"):
-                break
+                outcomes[id] = .confirmed
             default:
-                // Bubble the backend's rejection up as this app's own error. SwiftSync returns the
-                // failures verbatim without interpreting them; the engine reads them back to annotate
-                // the inbox.
-                failures.append(
-                    SyncPushFailure(
-                        id: id ?? "",
-                        error: DemoUploadRejection(
-                            message: (result["message"] as? String) ?? "rejected")))
+                // Bubble the backend's rejection up as this app's own error. SwiftSync carries it verbatim
+                // and returns it as a SyncPushFailure; the engine reads it back to annotate the inbox.
+                outcomes[id] = .rejected(
+                    DemoUploadRejection(message: (result["message"] as? String) ?? "rejected"))
             }
         }
-        return failures
+        return outcomes
     }
 
     /// The task's upload payload: its exported scalars plus `reviewer_ids`/`watcher_ids` (which are

--- a/README.md
+++ b/README.md
@@ -631,15 +631,15 @@ The identity is the only id: it's client-generated and the backend adopts it, so
 
 `pendingChanges` partitions the un-pushed local changes (history authored by you, since SwiftSync's internal per-type history token) into inserts, updates, and deletes. A row inserted *and* deleted before it was ever pushed is dropped (the server never saw it).
 
-`withPendingChanges` runs one pass inside a scope SwiftSync manages (the `with…` idiom: it sets up the pending changes, your closure does the work, it commits the bookmark on the way out). It hands your closure a `Sendable` `SyncPendingChanges` (so SwiftData objects never cross into a network call — you own the request); the closure does the network work and **returns the failures** (`[SyncPushFailure]`), which the method returns straight back to you. Everything else is confirmed by complement — the client id *is* the identity the server adopts, so a push is an idempotent upsert with no acknowledgements to echo back. Only when the closure reports **no** failures does it advance its internal history token and trim the redundant history. It writes no per-row state; a failed (or otherwise un-pushed) change stays pending and is re-detected next call. Surface the returned failures however you like (discard / edit / retry).
+`withPendingChanges` runs one pass inside a scope SwiftSync manages (the `with…` idiom: it sets up the pending changes, your closure does the work, it commits the bookmark on the way out). It hands your closure a `Sendable` `SyncPendingChanges` (so SwiftData objects never cross into a network call — you own the request); the closure does the network work and **returns a verdict for every pending id** — a `[String: SyncRowOutcome]` map where each id is `.confirmed` or `.rejected(error)`. Total accounting is the point: there's no "say nothing = success" default, so a row can't be silently dropped or confirmed by omission. If the map misses a pending id (or names one not in the batch), the method throws `SyncError.incompletePushAccounting` and advances nothing. Only on a fully clean pass (every row `.confirmed`) does it advance its internal history token and trim the redundant history — it writes no per-row state, so a `.rejected` (or otherwise un-pushed) change stays pending and is re-detected next call. The rejected rows come back as `[SyncPushFailure]` for you to surface (discard / edit / retry).
 
 ```swift
 let failures = try await SwiftSync.withPendingChanges(for: Task.self, in: syncContainer.mainContext) { pending in
-  // map pending.inserts / pending.updates / pending.deletes (the ids) to upsert/delete
-  // requests, call your API, and return a SyncPushFailure for each rejected id
-  try await api.push(pending)
+  // call your API for pending.inserts / pending.updates / pending.deletes (the ids), then return
+  // a verdict per id: .confirmed for accepted rows, .rejected(error) for rejected ones
+  try await api.push(pending)   // -> [String: SyncRowOutcome]
 }
-// No history token to persist — SwiftSync owns it. `failures` is empty on a fully clean pass.
+// No history token to persist — SwiftSync owns it. `failures` (the .rejected rows) is empty on a clean pass.
 ```
 
 Inbound pulls are tagged internally so a freshly-pulled row is never mistaken for a local edit; an un-pushed local insert survives a pull that omits it, and a newer local edit isn't clobbered by an older server version (last-writer-wins). Offline requires a persistent store (history is unavailable to ephemeral stores).

--- a/SwiftSync/Sources/SwiftSync/Core.swift
+++ b/SwiftSync/Sources/SwiftSync/Core.swift
@@ -1286,6 +1286,10 @@ public enum SyncError: Error, Sendable, Equatable {
     case schemaValidation(reason: String)
     /// The `ModelContainer` failed to initialize; `reason` carries the underlying cause.
     case containerInitialization(reason: String)
+    /// `withPendingChanges`'s `process` closure didn't return a verdict for exactly the pending ids:
+    /// `unaccounted` were pending but got no outcome (would be silent data loss); `unexpected` were
+    /// reported but weren't in the batch (a consumer bug). The push advances nothing.
+    case incompletePushAccounting(unaccounted: [String], unexpected: [String])
 }
 
 extension SyncError: LocalizedError {
@@ -1299,6 +1303,15 @@ extension SyncError: LocalizedError {
             return reason
         case .containerInitialization(let reason):
             return reason
+        case .incompletePushAccounting(let unaccounted, let unexpected):
+            var parts: [String] = []
+            if !unaccounted.isEmpty {
+                parts.append("no outcome reported for pending id(s): \(unaccounted.joined(separator: ", "))")
+            }
+            if !unexpected.isEmpty {
+                parts.append("outcome reported for id(s) not in the batch: \(unexpected.joined(separator: ", "))")
+            }
+            return "Push accounting incomplete — \(parts.joined(separator: "; "))."
         }
     }
 }

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -20,10 +20,22 @@ public struct SyncPendingChanges: Sendable {
     public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
+/// The consumer's verdict for one pushed row, returned from `withPendingChanges`'s `process` closure.
+/// Every pending id must get exactly one — the library throws `SyncError.incompletePushAccounting` if any
+/// is missing (or extra), so a row can never be silently dropped or confirmed-by-omission.
+public enum SyncRowOutcome: Sendable {
+    /// The server accepted this row — or it was otherwise resolved (e.g. a stale row whose server state
+    /// you adopted locally). Either way it's done and the token may advance past it.
+    case confirmed
+    /// The server rejected this row; it stays pending and is re-detected next push. Carries the
+    /// consumer's own error verbatim, surfaced back as `SyncPushFailure`.
+    case rejected(any Error & Sendable)
+}
+
 /// One pushed row the server rejected: the row `id` to keep pending, and the consumer's own `error`
-/// bubbled up verbatim. Your `process` closure returns only these — everything else in the batch is treated
-/// as confirmed (the client id is the identity the backend adopts, so a push is an idempotent upsert with
-/// no server-assigned ids to map home). The operation is the library's to know, not yours.
+/// bubbled up verbatim. Derived from the `.rejected` verdicts in the `process` closure's outcome map and
+/// returned by `withPendingChanges` (the client id is the identity the backend adopts, so a push is an
+/// idempotent upsert with no server-assigned ids to map home). The operation is the library's to know.
 public struct SyncPushFailure: Sendable {
     public let id: String
     public let error: any Error & Sendable
@@ -131,19 +143,20 @@ extension SwiftSync {
     }
 
     /// Process this model type's locally-changed rows inside a scope SwiftSync manages. Reads what changed
-    /// since the last-pushed token, hands it to your `process` closure (you own the network call), and gets
-    /// back the rejected rows. Everything you *don't* return as a failure is treated as confirmed — the
-    /// client id is the identity the server adopts, so it's an idempotent upsert with nothing to
-    /// acknowledge. Only on a fully clean pass (no failures) does it advance the token and trim the
-    /// now-redundant inbound history. SwiftSync stores no per-row state: a failed — or any un-pushed —
-    /// change stays past the token and is re-detected next call. Returns the same failures your closure
-    /// returned (empty == clean).
+    /// since the last-pushed token, hands it to your `process` closure (you own the network call), and
+    /// requires back a verdict (`.confirmed` / `.rejected`) for **every** pending id. Total accounting is
+    /// the point: there's no "say nothing = success" default, so you can't silently drop or lose a row —
+    /// if the returned map omits a pending id (or names one not in the batch), this throws
+    /// `SyncError.incompletePushAccounting` and advances nothing. Only on a fully clean pass (every row
+    /// `.confirmed`) does it advance the token and trim the now-redundant inbound history. SwiftSync stores
+    /// no per-row state: a `.rejected` — or any un-pushed — change stays past the token and is re-detected
+    /// next call. Returns the rejected rows as `SyncPushFailure`s (empty == clean).
     @discardableResult
     public static func withPendingChanges<Model: SyncUpdatableModel>(
         for _: Model.Type,
         in context: ModelContext,
         isolation: isolated (any Actor)? = #isolation,
-        process: (SyncPendingChanges) async throws -> [SyncPushFailure]
+        process: (SyncPendingChanges) async throws -> [String: SyncRowOutcome]
     ) async throws -> [SyncPushFailure] where Model.SyncID == String {
         try requireOfflineCapable(Model.self, in: context)
         try requireOfflinePushBookkeeping(in: context)
@@ -156,7 +169,22 @@ extension SwiftSync {
         // await stays past the token and is re-detected next push, instead of being silently skipped.
         let uploadedThrough = transactions.last?.token
 
-        let failures = try await process(pending)
+        let outcomes = try await process(pending)
+
+        // Total accounting: the verdict map must cover exactly the pending ids. A missing id would
+        // otherwise be confirmed-by-omission (silent data loss); an extra id signals a consumer bug.
+        let expected = Set(pending.inserts + pending.updates + pending.deletes)
+        let reported = Set(outcomes.keys)
+        if expected != reported {
+            throw SyncError.incompletePushAccounting(
+                unaccounted: expected.subtracting(reported).sorted(),
+                unexpected: reported.subtracting(expected).sorted())
+        }
+
+        let failures = outcomes.compactMap { id, outcome -> SyncPushFailure? in
+            guard case .rejected(let error) = outcome else { return nil }
+            return SyncPushFailure(id: id, error: error)
+        }
         if failures.isEmpty, let uploadedThrough {
             try setLastPushedHistoryToken(uploadedThrough, for: Model.self, in: context)
             try? trimInboundHistory(through: uploadedThrough, in: context)

--- a/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
@@ -49,7 +49,7 @@ final class OfflineHistoryTests: XCTestCase {
 
         // Push it so it's "synced" (token advances past its insert); now a later delete is a genuine
         // pending deletion rather than an insert-then-delete the server never saw.
-        _ = try await SwiftSync.withPendingChanges(for: HistoryRow.self, in: local) { _ in [] }
+        _ = try await SwiftSync.withPendingChanges(for: HistoryRow.self, in: local) { _ in ["local-1": .confirmed] }
 
         // Delete the synced row with a plain context.delete — the tombstone must yield its id.
         let row = try XCTUnwrap(

--- a/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
@@ -29,7 +29,11 @@ final class OfflinePushTests: XCTestCase {
             configurations: ModelConfiguration(url: directory.appendingPathComponent("store.sqlite")))
     }
 
-    private func noFailures(_ pending: SyncPendingChanges) -> [SyncPushFailure] { [] }
+    /// Confirm every pending id — the total-accounting verdict map for a fully-successful push.
+    private func confirmAll(_ pending: SyncPendingChanges) -> [String: SyncRowOutcome] {
+        Dictionary(
+            uniqueKeysWithValues: (pending.inserts + pending.updates + pending.deletes).map { ($0, .confirmed) })
+    }
 
     /// History-derived partitioning: after a baseline push makes some rows "synced" (behind the
     /// token), a fresh round of local edits partitions into insert/update/delete — and a row inserted
@@ -41,7 +45,7 @@ final class OfflinePushTests: XCTestCase {
         for id in ["a", "b", "d"] { context.insert(PushNote(id: id, title: id)) }
         try context.save()
         // Baseline push: a, b, d become synced (token advances past their inserts).
-        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: noFailures)
+        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: confirmAll)
 
         try mutate(context) { $0.first { $0.id == "b" }?.title = "edited" }  // update
         try delete("d", in: context)  // delete
@@ -67,7 +71,7 @@ final class OfflinePushTests: XCTestCase {
 
         let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { pending in
             XCTAssertEqual(pending.inserts, ["c1"])
-            return []
+            return ["c1": .confirmed]
         }
 
         XCTAssertTrue(failures.isEmpty)
@@ -83,7 +87,7 @@ final class OfflinePushTests: XCTestCase {
         try context.save()
 
         let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
-            [SyncPushFailure(id: "c1", error: PushTestError(message: "422"))]
+            ["c1": .rejected(PushTestError(message: "422"))]
         }
 
         XCTAssertEqual(failures.first?.id, "c1")
@@ -97,13 +101,13 @@ final class OfflinePushTests: XCTestCase {
         let context = container.mainContext
         context.insert(PushNote(id: "u1", title: "v1"))
         try context.save()
-        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: noFailures)  // synced
+        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: confirmAll)  // synced
 
         try mutate(context) { $0.first { $0.id == "u1" }?.title = "v2" }
         try context.save()
 
         _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
-            [SyncPushFailure(id: "u1", error: PushTestError(message: "500"))]
+            ["u1": .rejected(PushTestError(message: "500"))]
         }
         XCTAssertEqual(
             try SwiftSync.pendingChanges(for: PushNote.self, in: context).updates, ["u1"],
@@ -121,12 +125,62 @@ final class OfflinePushTests: XCTestCase {
         try context.save()
 
         let failures = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
-            [SyncPushFailure(id: "c2", error: PushTestError(message: "422"))]
+            ["c1": .confirmed, "c2": .rejected(PushTestError(message: "422"))]
         }
         XCTAssertEqual(failures.map(\.id), ["c2"])
         XCTAssertEqual(
             try SwiftSync.pendingChanges(for: PushNote.self, in: context).inserts.sorted(), ["c1", "c2"],
             "a failure freezes the token, so even the accepted row is re-detected")
+    }
+
+    /// Total accounting: the verdict map must cover every pending id. Omitting one would confirm it by
+    /// omission (silent data loss), so the push throws `.incompletePushAccounting` and advances nothing —
+    /// both rows stay pending.
+    func testOmittingAPendingIDThrowsAndAdvancesNothing() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        context.insert(PushNote(id: "c1", title: "reported"))
+        context.insert(PushNote(id: "c2", title: "forgotten"))
+        try context.save()
+
+        do {
+            _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
+                ["c1": .confirmed]  // c2 omitted
+            }
+            XCTFail("expected withPendingChanges to throw when a pending id has no outcome")
+        } catch let error as SyncError {
+            guard case .incompletePushAccounting(let unaccounted, let unexpected) = error else {
+                return XCTFail("expected .incompletePushAccounting, got \(error)")
+            }
+            XCTAssertEqual(unaccounted, ["c2"])
+            XCTAssertTrue(unexpected.isEmpty)
+        }
+
+        XCTAssertEqual(
+            try SwiftSync.pendingChanges(for: PushNote.self, in: context).inserts.sorted(), ["c1", "c2"],
+            "an incomplete-accounting push must advance nothing")
+    }
+
+    /// A verdict for an id that isn't in the batch is a consumer bug — the push throws rather than
+    /// silently ignoring it.
+    func testReportingAnIDNotInTheBatchThrows() async throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        context.insert(PushNote(id: "c1", title: "real"))
+        try context.save()
+
+        do {
+            _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
+                ["c1": .confirmed, "ghost": .confirmed]
+            }
+            XCTFail("expected withPendingChanges to throw for an id not in the batch")
+        } catch let error as SyncError {
+            guard case .incompletePushAccounting(let unaccounted, let unexpected) = error else {
+                return XCTFail("expected .incompletePushAccounting, got \(error)")
+            }
+            XCTAssertTrue(unaccounted.isEmpty)
+            XCTAssertEqual(unexpected, ["ghost"])
+        }
     }
 
     /// A local write during the upload await wasn't in the batch, so the token must not advance past it:
@@ -142,7 +196,7 @@ final class OfflinePushTests: XCTestCase {
             // A new local row appears after the batch was captured, while "uploading".
             context.insert(PushNote(id: "p2", title: "during upload"))
             try context.save()
-            return []
+            return ["p1": .confirmed]
         }
 
         XCTAssertTrue(failures.isEmpty)
@@ -170,7 +224,7 @@ final class OfflinePushTests: XCTestCase {
         do {
             _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context) { _ in
                 uploadCalled = true
-                return []
+                return [:]
             }
             XCTFail("expected push to throw when the bookkeeping model is not registered")
         } catch {

--- a/docs/planning/api-surface-review.md
+++ b/docs/planning/api-surface-review.md
@@ -136,7 +136,7 @@ identity the server adopts (an idempotent upsert — no server-assigned ids to m
 are derivable: `confirmed = batch − failures`. Asking the consumer to echo back which ids succeeded was
 redundant; only the **failures** carry information the library can't derive.
 
-**Now (5 structs → 2).**
+**Now (5 structs → 2, then +1 for the total-accounting refinement below).**
 - `SyncPushBatch` merged into `SyncPendingChanges` — one type is both the return of `pendingChanges(...)`
   and the value `withPendingChanges(...)` hands the `process` closure.
 - `SyncPushResponse` **deleted** — `upload` now returns `[SyncPushFailure]` directly.
@@ -155,9 +155,17 @@ redundant; only the **failures** carry information the library can't derive.
   term) became a trailing closure.
 - `inboundAuthor` demoted `public` → `internal` (consumer never referenced it).
 
-Surviving public push surface: `SyncPendingChanges` (in) and `SyncPushFailure` (out). The token still
-advances (and inbound history is trimmed) only when the `process` closure reports **no** failures — same
-at-least-once semantics, smaller seam.
+**Refinement — total accounting (safety).** Failure-only had a lossy *default*: a `process` closure that
+returned `[]` (or omitted a row) asserted "everything succeeded," so a mis-parsed response could silently
+advance the token past a rejected row. To make the wrong thing unrepresentable, `process` now returns a
+verdict for **every** pending id — `[String: SyncRowOutcome]` (`.confirmed` / `.rejected(error)`) — and
+`withPendingChanges` throws `SyncError.incompletePushAccounting` if the map doesn't cover exactly the
+pending ids. There's no silence-means-success path; a row can't be dropped or confirmed by omission. This
+adds back **one** public type (`SyncRowOutcome`), trading minimal surface for a no-silent-loss guarantee.
+
+Surviving public push surface: `SyncPendingChanges` (in), `SyncRowOutcome` (the per-id verdict), and
+`SyncPushFailure` (the `.rejected` rows, returned). The token advances (and inbound history is trimmed)
+only on a fully-`.confirmed` pass — same at-least-once semantics.
 
 ---
 


### PR DESCRIPTION
**Stacked on #644** (base: `refactor/push-seam-simplify`) — review this as a diff against the renamed seam, not master.

## Why

#644's failure-only seam has a lossy *default*: a `process` closure that returns `[]` (or omits a row) asserts "everything succeeded," so a mis-parsed server response can silently advance the token past a rejected row and **lose** it. The library can't catch it, because only the consumer sees the network. This PR makes that mistake unrepresentable.

## What

`process` now returns a **verdict for every pending id**:

```swift
let failures = try await SwiftSync.withPendingChanges(for: Task.self, in: context) { pending in
  // call your API, then classify every id:
  //   .confirmed         — server accepted (or stale-resolved)
  //   .rejected(error)   — stays pending; surfaced as SyncPushFailure
  try await api.push(pending)   // -> [String: SyncRowOutcome]
}
```

`withPendingChanges` throws `SyncError.incompletePushAccounting(unaccounted:unexpected:)` unless the returned map covers **exactly** the pending ids. No silence-means-success path: a row can't be dropped or confirmed by omission. The method still returns the `.rejected` rows as `[SyncPushFailure]` for the inbox.

## Trade-off (for your review)

Adds back **one** public type (`SyncRowOutcome`) and a small ergonomic cost — the happy path must map every id to `.confirmed` rather than `return []` — in exchange for a no-silent-loss guarantee. This is the "maximum safety" alternative to #644's lean failure-only shape; pick whichever you prefer and I'll keep that one.

## Verification (red-first)

- New `testOmittingAPendingIDThrowsAndAdvancesNothing` + `testReportingAnIDNotInTheBatchThrows` — shown red (omitted row was confirmed-by-omission and lost; ghost id uncaught) before the guard, green after.
- SwiftSync 173 tests, DemoCore 42, all green. README + `api-surface-review.md` §5 updated to the total-accounting shape.