### PR TITLE
chore: comment audit of SwiftSync/Sources

### DIFF
--- a/SwiftSync/Sources/SwiftSync/API.swift
+++ b/SwiftSync/Sources/SwiftSync/API.swift
@@ -14,8 +14,6 @@ extension SwiftSync {
         do {
             try throwIfCancelled()
             try await withRelationshipLookupCache {
-                // Gathered before applying, so the pull honors pending local edits and never prunes a
-                // never-pushed local insert.
                 let dirtyPIDs = offlineDirtyPersistentIDs(for: Model.self, in: context)
                 let entries = try syncProfile("normalize-payload") {
                     try normalize(payload: payload, model: Model.self)
@@ -369,8 +367,6 @@ extension SwiftSync {
         do {
             try throwIfCancelled()
             try await withRelationshipLookupCache {
-                // Gathered before applying, so the pull honors pending local edits and never prunes a
-                // never-pushed local insert.
                 let dirtyPIDs = offlineDirtyPersistentIDs(for: Model.self, in: context)
                 let entries = try syncProfile("normalize-payload") {
                     try normalize(payload: payload, model: Model.self)

--- a/SwiftSync/Sources/SwiftSync/Core.swift
+++ b/SwiftSync/Sources/SwiftSync/Core.swift
@@ -439,7 +439,7 @@ public func syncApplyToManyForeignKeys<Owner: SyncUpdatableModel, Related: SyncM
             return false
         }
 
-        // Old Sync behavior avoids duplicate membership; dedupe input deterministically.
+        // Old Sync behavior avoids duplicate membership.
         let desiredIDs = dedupePreservingOrder(rawIDs)
         let relatedByID = try syncFetchRelatedRowsByIdentity(Related.self, matching: desiredIDs, in: context)
         let desiredRelated = desiredIDs.compactMap { relatedByID[syncIdentityKey(from: $0)] }
@@ -836,7 +836,7 @@ func defaultExportDateFormatter() -> DateFormatter {
 public enum ExportState {
     private static let threadDictionaryKey = "SwiftSync.ExportState"
 
-    /// Enters cycle-detection scope for a model. Returns false if already visiting (cycle detected).
+    /// Returns false if already visiting (cycle detected).
     public static func enter<Model: PersistentModel>(_ model: Model) -> Bool {
         let key = String(describing: model.persistentModelID)
         var visiting = currentVisiting()
@@ -846,7 +846,6 @@ public enum ExportState {
         return true
     }
 
-    /// Leaves cycle-detection scope for a model.
     public static func leave<Model: PersistentModel>(_ model: Model) {
         let key = String(describing: model.persistentModelID)
         var visiting = currentVisiting()

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -167,7 +167,8 @@ extension SwiftSync {
     /// Dirty persistent ids for the pull, but only for models that opted into offline round-trip by
     /// marking their identity `.preserveValueOnDeletion`. A plain (non-offline) model gets an empty
     /// set, so its pull keeps "server is authoritative, always apply" semantics — the behavior the core
-    /// diffing tests rely on.
+    /// diffing tests rely on. Capture it before applying the payload, so the pull honors pending local
+    /// edits and never prunes a never-pushed local insert.
     static func offlineDirtyPersistentIDs<Model: SyncUpdatableModel>(
         for _: Model.Type, in context: ModelContext
     ) -> Set<PersistentIdentifier> {

--- a/SwiftSync/Sources/SwiftSync/SyncDateParser.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncDateParser.swift
@@ -53,7 +53,6 @@ enum SyncDateParser {
         var input = iso8601.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !input.isEmpty else { return nil }
 
-        // Date-only input is normalized to UTC midnight.
         if isDateOnly(input.utf8) {
             input += "T00:00:00+00:00"
         }

--- a/SwiftSync/Sources/SwiftSync/SyncQueryPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncQueryPublisher.swift
@@ -2,7 +2,6 @@ import Foundation
 import Observation
 import SwiftData
 
-// Observation callbacks are dispatched on queue: .main.
 @MainActor
 @Observable
 public final class SyncQueryPublisher<Model: PersistentModel> {


### PR DESCRIPTION
Comment audit of `SwiftSync/Sources` under the project bar — a comment earns its place only if it records something the code can't say. Behavior-neutral: comment-only diff, builds clean, `swift format` reports no churn, 48/48 `swift test` pass.

Most of the dense doc blocks are genuine survivors (the SQL `nil != "inbound"` trap, the CoreData `self.id = self.id` dirty-tracking gotcha, the `.preserveValueOnDeletion` offline contracts) and were left untouched. The cuts:

- **SyncDateParser** — drop `// Date-only input is normalized to UTC midnight` (narration of `isDateOnly` + the `T00:00:00+00:00` literal; the fact already lives in the `date-only -> UTC midnight` test name).
- **SyncQueryPublisher** — drop `// Observation callbacks are dispatched on queue: .main` (restates the `queue: .main` arg and the `@MainActor` annotation directly below it).
- **Core / ExportState** — remove the `Leaves cycle-detection scope` restatement on `leave`; trim `enter`'s doc to its load-bearing return-value contract.
- **Core / to-many merge** — drop the `dedupe input deterministically` clause (restates `dedupePreservingOrder`); keep the `Old Sync` provenance.
- **API** — remove the verbatim duplicate `offlineDirtyPersistentIDs` note from both `sync` overloads; the ordering contract now lives once on the declaration in `Push.swift`.