### PR TITLE
Comment audit §1 + sync-engine restructure (context.sync)

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "lineLength": 120,
+  "lineLength": 10000,
   "indentation": {
     "spaces": 4
   },

--- a/SwiftSync/Sources/SwiftSync/Core.swift
+++ b/SwiftSync/Sources/SwiftSync/Core.swift
@@ -1274,16 +1274,13 @@ public struct SyncPayload {
 
 /// The single error currency for SwiftSync: every SwiftSync operation that can fail throws one of
 /// these, so a consumer catches one type. (Per-operation push *rejections* are partial-success data,
-/// reported as `SyncPushFailure` in the response rather than thrown — see `push`.)
+/// reported as `SyncPushFailure` in the response rather than thrown — see `withPendingChanges`.)
 public enum SyncError: Error, Sendable, Equatable {
-    /// A payload couldn't be decoded into the model (missing or invalid field).
     case invalidPayload(model: String, reason: String)
-    /// The operation was cancelled (task cancellation).
     case cancelled
     /// A model's schema is invalid for sync (e.g. an unanchored many-to-many, or a uniqueness
     /// constraint off the sync identity).
     case schemaValidation(reason: String)
-    /// The `ModelContainer` failed to initialize; `reason` carries the underlying cause.
     case containerInitialization(reason: String)
 }
 

--- a/SwiftSync/Sources/SwiftSync/ModelContext+Sync.swift
+++ b/SwiftSync/Sources/SwiftSync/ModelContext+Sync.swift
@@ -1,32 +1,30 @@
 import Foundation
 import SwiftData
 
-extension SwiftSync {
-    static func sync<Model: SyncUpdatableModel>(
+extension ModelContext {
+    func sync<Model: SyncUpdatableModel>(
         payload: [Any],
         as _: Model.Type,
-        in context: ModelContext,
         keyStyle: KeyStyle = .snakeCase,
         relationshipOperations: SyncRelationshipOperations = .all,
         isolation: isolated (any Actor)? = #isolation
     ) async throws {
-        let lease = await acquireSyncLease(for: context)
         do {
-            try throwIfCancelled()
-            try await withRelationshipLookupCache {
-                let dirtyPIDs = offlineDirtyPersistentIDs(for: Model.self, in: context)
+            try Task.checkCancellation()
+            try await SwiftSync.withRelationshipLookupCache {
+                let dirtyPIDs = SwiftSync.offlineDirtyPersistentIDs(for: Model.self, in: self)
                 let entries = try syncProfile("normalize-payload") {
-                    try normalize(payload: payload, model: Model.self)
+                    try SwiftSync.normalize(payload: payload, model: Model.self)
                 }
                 let existing = try syncProfile("fetch-existing") {
-                    try context.fetch(FetchDescriptor<Model>())
+                    try fetch(FetchDescriptor<Model>())
                 }
 
                 var index: [String: Model] = [:]
                 var duplicates: [Model] = []
                 syncProfile("build-index") {
                     for row in existing {
-                        let key = identityKey(from: row[keyPath: Model.syncIdentity])
+                        let key = SwiftSync.identityKey(from: row[keyPath: Model.syncIdentity])
                         if index[key] != nil {
                             duplicates.append(row)
                             continue
@@ -39,44 +37,44 @@ extension SwiftSync {
                 var seenKeys: Set<String> = []
 
                 if !duplicates.isEmpty {
-                    try throwIfCancelled()
+                    try Task.checkCancellation()
                     syncProfile("delete-duplicates") {
                         for duplicate in duplicates {
-                            context.delete(duplicate)
+                            delete(duplicate)
                         }
                     }
                     changed = true
                 }
 
                 for entry in entries {
-                    try throwIfCancelled()
+                    try Task.checkCancellation()
                     let payloadModel = SyncPayload(values: entry, keyStyle: keyStyle)
-                    guard let identity = resolveIdentity(from: payloadModel, model: Model.self) else {
+                    guard let identity = SwiftSync.resolveIdentity(from: payloadModel, model: Model.self) else {
                         continue
                     }
-                    let key = identityKey(from: identity)
+                    let key = SwiftSync.identityKey(from: identity)
                     seenKeys.insert(key)
 
                     if let row = index[key] {
                         let didApplyFields = try syncProfile("apply-fields") {
-                            try applyHonoringLocalEdit(payloadModel, to: row, dirtyPIDs: dirtyPIDs)
+                            try SwiftSync.applyHonoringLocalEdit(payloadModel, to: row, dirtyPIDs: dirtyPIDs)
                         }
                         if didApplyFields {
                             changed = true
                         }
                         if !relationshipOperations.isDisjoint(with: [.update, .delete]) {
-                            try throwIfCancelled()
+                            try Task.checkCancellation()
                             let didApplyRelationships = try await syncProfile("apply-relationships") {
                                 try await row.applyRelationships(
                                     payloadModel,
-                                    in: context,
+                                    in: self,
                                     operations: relationshipOperations
                                 )
                             }
                             if didApplyRelationships {
                                 changed = true
                             }
-                            try throwIfCancelled()
+                            try Task.checkCancellation()
                         }
                         continue
                     }
@@ -84,86 +82,81 @@ extension SwiftSync {
                     let created = try syncProfile("create-model") {
                         try Model.make(from: payloadModel)
                     }
-                    context.insert(created)
+                    insert(created)
                     if relationshipOperations.contains(.insert) {
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                         let didApplyRelationships = try await syncProfile("apply-relationships") {
                             try await created.applyRelationships(
                                 payloadModel,
-                                in: context,
+                                in: self,
                                 operations: relationshipOperations
                             )
                         }
                         if didApplyRelationships {
                             changed = true
                         }
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                     }
                     index[key] = created
                     changed = true
                 }
 
-                try throwIfCancelled()
+                try Task.checkCancellation()
                 syncProfile("delete-missing") {
                     for (key, row) in index where !seenKeys.contains(key) {
-                        if isUnsyncedLocalInsert(row, dirtyPIDs: dirtyPIDs) { continue }
-                        context.delete(row)
+                        if SwiftSync.isUnsyncedLocalInsert(row, dirtyPIDs: dirtyPIDs) { continue }
+                        delete(row)
                         changed = true
                     }
                 }
 
-                try throwIfCancelled()
+                try Task.checkCancellation()
                 if changed {
                     try syncProfile("save-context") {
-                        try context.save()
+                        try save()
                     }
                 }
             }
-            await releaseSyncLease(lease)
         } catch {
-            if isCancellation(error) {
-                context.rollback()
-                await releaseSyncLease(lease)
+            if SwiftSync.isCancellation(error) {
+                rollback()
                 throw SyncError.cancelled
             }
-            await releaseSyncLease(lease)
             throw error
         }
     }
 
-    static func sync<Model: SyncUpdatableModel>(
+    func sync<Model: SyncUpdatableModel>(
         item: [String: Any],
         as _: Model.Type,
-        in context: ModelContext,
         keyStyle: KeyStyle = .snakeCase,
         relationshipOperations: SyncRelationshipOperations = .all,
         isolation: isolated (any Actor)? = #isolation
     ) async throws {
-        let lease = await acquireSyncLease(for: context)
         do {
-            try throwIfCancelled()
-            try await withRelationshipLookupCache {
+            try Task.checkCancellation()
+            try await SwiftSync.withRelationshipLookupCache {
                 let payloadModel = syncProfile("normalize-payload") {
                     SyncPayload(values: item, keyStyle: keyStyle)
                 }
-                guard let identity = resolveIdentity(from: payloadModel, model: Model.self) else {
+                guard let identity = SwiftSync.resolveIdentity(from: payloadModel, model: Model.self) else {
                     return
                 }
-                let key = identityKey(from: identity)
+                let key = SwiftSync.identityKey(from: identity)
                 var changed = false
                 let matchingRow: Model?
-                if syncIdentityHasUniqueAttribute(Model.self),
+                if SwiftSync.syncIdentityHasUniqueAttribute(Model.self),
                     Model.syncIdentityPredicate(matching: identity) != nil
                 {
                     matchingRow = try syncProfile("fetch-existing-by-identity") {
-                        try fetchUniqueRow(matching: identity, as: Model.self, in: context)
+                        try SwiftSync.fetchUniqueRow(matching: identity, as: Model.self, in: self)
                     }
                 } else {
                     let existing = try syncProfile("fetch-existing") {
-                        try context.fetch(FetchDescriptor<Model>())
+                        try fetch(FetchDescriptor<Model>())
                     }
                     matchingRow = syncProfile("find-existing") {
-                        existing.first(where: { identityKey(from: $0[keyPath: Model.syncIdentity]) == key })
+                        existing.first(where: { SwiftSync.identityKey(from: $0[keyPath: Model.syncIdentity]) == key })
                     }
                 }
                 if let row = matchingRow {
@@ -172,77 +165,72 @@ extension SwiftSync {
                     }
                     if didApplyFields { changed = true }
                     if !relationshipOperations.isDisjoint(with: [.update, .delete]) {
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                         let didApplyRelationships = try await syncProfile("apply-relationships") {
                             try await row.applyRelationships(
-                                payloadModel, in: context, operations: relationshipOperations)
+                                payloadModel, in: self, operations: relationshipOperations)
                         }
                         if didApplyRelationships {
                             changed = true
                         }
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                     }
                 } else {
                     let created = try syncProfile("create-model") {
                         try Model.make(from: payloadModel)
                     }
-                    context.insert(created)
+                    insert(created)
                     if relationshipOperations.contains(.insert) {
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                         let didApplyRelationships = try await syncProfile("apply-relationships") {
                             try await created.applyRelationships(
-                                payloadModel, in: context, operations: relationshipOperations)
+                                payloadModel, in: self, operations: relationshipOperations)
                         }
                         if didApplyRelationships {
                             changed = true
                         }
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                     }
                     changed = true
                 }
 
-                try throwIfCancelled()
+                try Task.checkCancellation()
                 if changed {
-                    try syncProfile("save-context") { try context.save() }
+                    try syncProfile("save-context") { try save() }
                 }
             }
-            await releaseSyncLease(lease)
         } catch {
-            if isCancellation(error) {
-                context.rollback()
-                await releaseSyncLease(lease)
+            if SwiftSync.isCancellation(error) {
+                rollback()
                 throw SyncError.cancelled
             }
-            await releaseSyncLease(lease)
             throw error
         }
     }
 
-    static func sync<Model: SyncUpdatableModel, Parent: PersistentModel>(
+    func sync<Model: SyncUpdatableModel, Parent: PersistentModel>(
         item: [String: Any],
         as _: Model.Type,
-        in context: ModelContext,
         parent: Parent,
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
         keyStyle: KeyStyle = .snakeCase,
         relationshipOperations: SyncRelationshipOperations = .all,
         isolation: isolated (any Actor)? = #isolation
     ) async throws {
-        let lease = await acquireSyncLease(for: context)
         do {
-            try throwIfCancelled()
-            try await withRelationshipLookupCache {
+            try Task.checkCancellation()
+            try await SwiftSync.withRelationshipLookupCache {
                 let payloadModel = syncProfile("normalize-payload") {
                     SyncPayload(values: item, keyStyle: keyStyle)
                 }
-                guard let identity = resolveIdentity(from: payloadModel, model: Model.self) else {
+                guard let identity = SwiftSync.resolveIdentity(from: payloadModel, model: Model.self) else {
                     return
                 }
-                let key = identityKey(from: identity)
+                let key = SwiftSync.identityKey(from: identity)
                 let resolvedParent = try syncProfile(
                     "resolve-parent",
                     operation: {
-                        try resolveParent(parent, in: context)
+                        try SwiftSync.resolveParent(parent, in: self)
                     })
                 guard let resolvedParent else {
                     throw SyncError.invalidPayload(
@@ -252,15 +240,15 @@ extension SwiftSync {
                 }
                 var changed = false
                 let matchingRow: Model?
-                if syncIdentityHasUniqueAttribute(Model.self),
+                if SwiftSync.syncIdentityHasUniqueAttribute(Model.self),
                     Model.syncIdentityPredicate(matching: identity) != nil
                 {
                     matchingRow = try syncProfile("fetch-existing-by-identity") {
-                        try fetchUniqueRow(matching: identity, as: Model.self, in: context)
+                        try SwiftSync.fetchUniqueRow(matching: identity, as: Model.self, in: self)
                     }
                 } else {
                     let existing = try syncProfile("fetch-existing") {
-                        try context.fetch(FetchDescriptor<Model>())
+                        try fetch(FetchDescriptor<Model>())
                     }
                     let scopeRows = syncProfile("filter-scope") {
                         existing.filter {
@@ -268,7 +256,7 @@ extension SwiftSync {
                         }
                     }
                     matchingRow = syncProfile("find-existing") {
-                        scopeRows.first(where: { identityKey(from: $0[keyPath: Model.syncIdentity]) == key })
+                        scopeRows.first(where: { SwiftSync.identityKey(from: $0[keyPath: Model.syncIdentity]) == key })
                     }
                 }
                 if let row = matchingRow {
@@ -283,15 +271,15 @@ extension SwiftSync {
                     }
                     if didApplyFields { changed = true }
                     if !relationshipOperations.isDisjoint(with: [.update, .delete]) {
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                         let didApplyRelationships = try await syncProfile("apply-relationships") {
                             try await row.applyRelationships(
-                                payloadModel, in: context, operations: relationshipOperations)
+                                payloadModel, in: self, operations: relationshipOperations)
                         }
                         if didApplyRelationships {
                             changed = true
                         }
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                     }
                 } else {
                     let created = try syncProfile("create-model") {
@@ -300,40 +288,36 @@ extension SwiftSync {
                     syncProfile("apply-parent") {
                         created[keyPath: relationship] = resolvedParent
                     }
-                    context.insert(created)
+                    insert(created)
                     if relationshipOperations.contains(.insert) {
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                         let didApplyRelationships = try await syncProfile("apply-relationships") {
                             try await created.applyRelationships(
-                                payloadModel, in: context, operations: relationshipOperations)
+                                payloadModel, in: self, operations: relationshipOperations)
                         }
                         if didApplyRelationships {
                             changed = true
                         }
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                     }
                     changed = true
                 }
 
-                try throwIfCancelled()
-                if changed { try syncProfile("save-context") { try context.save() } }
+                try Task.checkCancellation()
+                if changed { try syncProfile("save-context") { try save() } }
             }
-            await releaseSyncLease(lease)
         } catch {
-            if isCancellation(error) {
-                context.rollback()
-                await releaseSyncLease(lease)
+            if SwiftSync.isCancellation(error) {
+                rollback()
                 throw SyncError.cancelled
             }
-            await releaseSyncLease(lease)
             throw error
         }
     }
 
-    static func sync<Model: SyncUpdatableModel, Parent: PersistentModel>(
+    func sync<Model: SyncUpdatableModel, Parent: PersistentModel>(
         payload: [Any],
         as _: Model.Type,
-        in context: ModelContext,
         parent: Parent,
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
         keyStyle: KeyStyle = .snakeCase,
@@ -343,19 +327,17 @@ extension SwiftSync {
         try await sync(
             payload: payload,
             as: Model.self,
-            in: context,
             parent: parent,
             parentRelationship: relationship,
-            isGlobal: syncIdentityHasUniqueAttribute(Model.self),
+            isGlobal: SwiftSync.syncIdentityHasUniqueAttribute(Model.self),
             keyStyle: keyStyle,
             relationshipOperations: relationshipOperations
         )
     }
 
-    private static func sync<Model: SyncUpdatableModel, Parent: PersistentModel>(
+    private func sync<Model: SyncUpdatableModel, Parent: PersistentModel>(
         payload: [Any],
         as _: Model.Type,
-        in context: ModelContext,
         parent: Parent,
         parentRelationship: ReferenceWritableKeyPath<Model, Parent?>,
         isGlobal: Bool,
@@ -363,18 +345,17 @@ extension SwiftSync {
         relationshipOperations: SyncRelationshipOperations,
         isolation: isolated (any Actor)? = #isolation
     ) async throws {
-        let lease = await acquireSyncLease(for: context)
         do {
-            try throwIfCancelled()
-            try await withRelationshipLookupCache {
-                let dirtyPIDs = offlineDirtyPersistentIDs(for: Model.self, in: context)
+            try Task.checkCancellation()
+            try await SwiftSync.withRelationshipLookupCache {
+                let dirtyPIDs = SwiftSync.offlineDirtyPersistentIDs(for: Model.self, in: self)
                 let entries = try syncProfile("normalize-payload") {
-                    try normalize(payload: payload, model: Model.self)
+                    try SwiftSync.normalize(payload: payload, model: Model.self)
                 }
                 let resolvedParent = try syncProfile(
                     "resolve-parent",
                     operation: {
-                        try resolveParent(parent, in: context)
+                        try SwiftSync.resolveParent(parent, in: self)
                     })
                 guard let resolvedParent else {
                     throw SyncError.invalidPayload(
@@ -389,11 +370,11 @@ extension SwiftSync {
                 let scopeRows: [Model]
                 if let parentPredicate {
                     scopeRows = try syncProfile("fetch-existing-by-parent") {
-                        try context.fetch(FetchDescriptor<Model>(predicate: parentPredicate))
+                        try fetch(FetchDescriptor<Model>(predicate: parentPredicate))
                     }
                 } else {
                     let fetchedExisting = try syncProfile("fetch-existing") {
-                        try context.fetch(FetchDescriptor<Model>())
+                        try fetch(FetchDescriptor<Model>())
                     }
                     scopeRows = syncProfile("filter-scope") {
                         fetchedExisting.filter {
@@ -407,7 +388,7 @@ extension SwiftSync {
                 syncProfile("build-index") {
                     if isGlobal {
                         for row in scopeRows {
-                            let key = identityKey(from: row[keyPath: Model.syncIdentity])
+                            let key = SwiftSync.identityKey(from: row[keyPath: Model.syncIdentity])
                             if index[key] != nil {
                                 duplicates.append(row)
                                 continue
@@ -416,7 +397,7 @@ extension SwiftSync {
                         }
                     } else {
                         for row in scopeRows {
-                            let key = scopedIdentityKey(
+                            let key = SwiftSync.scopedIdentityKey(
                                 from: row[keyPath: Model.syncIdentity],
                                 parentPersistentID: resolvedParent.persistentModelID
                             )
@@ -433,26 +414,26 @@ extension SwiftSync {
                 var seenKeys: Set<String> = []
 
                 if !duplicates.isEmpty {
-                    try throwIfCancelled()
+                    try Task.checkCancellation()
                     syncProfile("delete-duplicates") {
                         for duplicate in duplicates {
-                            context.delete(duplicate)
+                            delete(duplicate)
                         }
                     }
                     changed = true
                 }
 
                 for entry in entries {
-                    try throwIfCancelled()
+                    try Task.checkCancellation()
                     let payloadModel = SyncPayload(values: entry, keyStyle: keyStyle)
-                    guard let identity = resolveIdentity(from: payloadModel, model: Model.self) else {
+                    guard let identity = SwiftSync.resolveIdentity(from: payloadModel, model: Model.self) else {
                         continue
                     }
                     let key: String
                     if isGlobal {
-                        key = identityKey(from: identity)
+                        key = SwiftSync.identityKey(from: identity)
                     } else {
-                        key = scopedIdentityKey(
+                        key = SwiftSync.scopedIdentityKey(
                             from: identity,
                             parentPersistentID: resolvedParent.persistentModelID
                         )
@@ -467,24 +448,24 @@ extension SwiftSync {
                             }
                         }
                         let didApplyFields = try syncProfile("apply-fields") {
-                            try applyHonoringLocalEdit(payloadModel, to: row, dirtyPIDs: dirtyPIDs)
+                            try SwiftSync.applyHonoringLocalEdit(payloadModel, to: row, dirtyPIDs: dirtyPIDs)
                         }
                         if didApplyFields {
                             changed = true
                         }
                         if !relationshipOperations.isDisjoint(with: [.update, .delete]) {
-                            try throwIfCancelled()
+                            try Task.checkCancellation()
                             let didApplyRelationships = try await syncProfile("apply-relationships") {
                                 try await row.applyRelationships(
                                     payloadModel,
-                                    in: context,
+                                    in: self,
                                     operations: relationshipOperations
                                 )
                             }
                             if didApplyRelationships {
                                 changed = true
                             }
-                            try throwIfCancelled()
+                            try Task.checkCancellation()
                         }
                         continue
                     }
@@ -493,7 +474,7 @@ extension SwiftSync {
                         let movedRow = try syncProfile(
                             "fetch-existing-by-identity",
                             operation: {
-                                try fetchUniqueRow(matching: identity, as: Model.self, in: context)
+                                try SwiftSync.fetchUniqueRow(matching: identity, as: Model.self, in: self)
                             })
                         if let movedRow {
                             syncProfile("apply-parent") {
@@ -505,24 +486,24 @@ extension SwiftSync {
                                 }
                             }
                             let didApplyFields = try syncProfile("apply-fields") {
-                                try applyHonoringLocalEdit(payloadModel, to: movedRow, dirtyPIDs: dirtyPIDs)
+                                try SwiftSync.applyHonoringLocalEdit(payloadModel, to: movedRow, dirtyPIDs: dirtyPIDs)
                             }
                             if didApplyFields {
                                 changed = true
                             }
                             if !relationshipOperations.isDisjoint(with: [.update, .delete]) {
-                                try throwIfCancelled()
+                                try Task.checkCancellation()
                                 let didApplyRelationships = try await syncProfile("apply-relationships") {
                                     try await movedRow.applyRelationships(
                                         payloadModel,
-                                        in: context,
+                                        in: self,
                                         operations: relationshipOperations
                                     )
                                 }
                                 if didApplyRelationships {
                                     changed = true
                                 }
-                                try throwIfCancelled()
+                                try Task.checkCancellation()
                             }
                             index[key] = movedRow
                             continue
@@ -535,33 +516,33 @@ extension SwiftSync {
                     syncProfile("apply-parent") {
                         created[keyPath: parentRelationship] = resolvedParent
                     }
-                    context.insert(created)
+                    insert(created)
                     if relationshipOperations.contains(.insert) {
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                         let didApplyRelationships = try await syncProfile("apply-relationships") {
                             try await created.applyRelationships(
                                 payloadModel,
-                                in: context,
+                                in: self,
                                 operations: relationshipOperations
                             )
                         }
                         if didApplyRelationships {
                             changed = true
                         }
-                        try throwIfCancelled()
+                        try Task.checkCancellation()
                     }
                     index[key] = created
                     changed = true
                 }
 
-                try throwIfCancelled()
+                try Task.checkCancellation()
                 syncProfile("delete-missing") {
                     for row in scopeRows {
                         let key: String
                         if isGlobal {
-                            key = identityKey(from: row[keyPath: Model.syncIdentity])
+                            key = SwiftSync.identityKey(from: row[keyPath: Model.syncIdentity])
                         } else {
-                            key = scopedIdentityKey(
+                            key = SwiftSync.scopedIdentityKey(
                                 from: row[keyPath: Model.syncIdentity],
                                 parentPersistentID: resolvedParent.persistentModelID
                             )
@@ -569,208 +550,27 @@ extension SwiftSync {
                         if seenKeys.contains(key) {
                             continue
                         }
-                        if isUnsyncedLocalInsert(row, dirtyPIDs: dirtyPIDs) {
+                        if SwiftSync.isUnsyncedLocalInsert(row, dirtyPIDs: dirtyPIDs) {
                             continue
                         }
-                        context.delete(row)
+                        delete(row)
                         changed = true
                     }
                 }
 
-                try throwIfCancelled()
+                try Task.checkCancellation()
                 if changed {
                     try syncProfile("save-context") {
-                        try context.save()
+                        try save()
                     }
                 }
             }
-            await releaseSyncLease(lease)
         } catch {
-            if isCancellation(error) {
-                context.rollback()
-                await releaseSyncLease(lease)
+            if SwiftSync.isCancellation(error) {
+                rollback()
                 throw SyncError.cancelled
             }
-            await releaseSyncLease(lease)
             throw error
         }
-    }
-
-    /// A row with un-pushed local changes (its persistent id is in the history dirty-set). `delete-missing`
-    /// skips these: a row the user created or edited offline and hasn't pushed yet must survive an
-    /// inbound pull that omits it — the server omitting a row it has never seen is not a deletion.
-    private static func isUnsyncedLocalInsert<Model: SyncUpdatableModel>(
-        _ row: Model, dirtyPIDs: Set<PersistentIdentifier>
-    ) -> Bool {
-        dirtyPIDs.contains(row.persistentModelID)
-    }
-
-    /// Apply a server `payload` onto `row`, but skip the overwrite when the row has an un-pushed local
-    /// edit (its persistent id is in the dirty-set) — so an inbound pull can't clobber pending local
-    /// work. Last-writer-wins, local-wins-while-pending: the local edit is preserved until it's pushed.
-    private static func applyHonoringLocalEdit<Model: SyncUpdatableModel>(
-        _ payload: SyncPayload, to row: Model, dirtyPIDs: Set<PersistentIdentifier>
-    ) throws -> Bool {
-        if dirtyPIDs.contains(row.persistentModelID) { return false }
-        return try row.apply(payload)
-    }
-
-    private static func resolveParent<Parent: PersistentModel>(
-        _ parent: Parent,
-        in context: ModelContext
-    ) throws -> Parent? {
-        let parents = try syncProfile("fetch-parents") {
-            try context.fetch(FetchDescriptor<Parent>())
-        }
-        return parents.first { $0.persistentModelID == parent.persistentModelID }
-    }
-
-    private static func normalize<Model: PersistentModel>(payload: [Any], model: Model.Type) throws -> [[String: Any]] {
-        try payload.map { raw in
-            guard let map = raw as? [String: Any] else {
-                throw SyncError.invalidPayload(
-                    model: String(describing: model),
-                    reason: "Expected array of dictionaries"
-                )
-            }
-            return map
-        }
-    }
-
-    private static func resolveIdentity<Model: SyncModelable>(
-        from payload: SyncPayload,
-        model: Model.Type
-    ) -> Model.SyncID? {
-        for key in model.syncIdentityRemoteKeys {
-            if let value = payload.value(for: key, as: Model.SyncID.self) {
-                return value
-            }
-        }
-        return nil
-    }
-
-    private static func syncIdentityHasUniqueAttribute<Model: SyncModelable>(_ model: Model.Type) -> Bool {
-        let identityKeyPath = Model.syncIdentity as AnyKeyPath
-        for propertyMetadata in Model.schemaMetadata {
-            let mirror = Mirror(reflecting: propertyMetadata)
-            guard let candidateKeyPath = mirror.children.first(where: { $0.label == "keypath" })?.value as? AnyKeyPath,
-                candidateKeyPath == identityKeyPath
-            else { continue }
-            guard let rawMetadata = mirror.children.first(where: { $0.label == "metadata" })?.value else {
-                return false
-            }
-            let metadataMirror = Mirror(reflecting: rawMetadata)
-            let unwrapped: Any? =
-                metadataMirror.displayStyle == .optional
-                ? metadataMirror.children.first?.value
-                : rawMetadata
-            guard let attribute = unwrapped as? Schema.Attribute else { return false }
-            return attribute.options.contains(.unique)
-        }
-        return false
-    }
-
-    private static func identityKey<ID: Hashable>(from identity: ID) -> String {
-        String(describing: identity)
-    }
-
-    private static func scopedIdentityKey<ID: Hashable>(
-        from identity: ID,
-        parentPersistentID: PersistentIdentifier
-    ) -> String {
-        "\(String(reflecting: ID.self))|\(String(describing: parentPersistentID))|\(identityKey(from: identity))"
-    }
-
-    private static func fetchUniqueRow<Model: SyncModelable>(
-        matching identity: Model.SyncID,
-        as _: Model.Type,
-        in context: ModelContext
-    ) throws -> Model? {
-        guard let predicate = Model.syncIdentityPredicate(matching: identity) else {
-            return nil
-        }
-        var descriptor = FetchDescriptor<Model>(predicate: predicate)
-        descriptor.fetchLimit = 1
-        return try context.fetch(descriptor).first
-    }
-
-    private static func throwIfCancelled() throws {
-        if Task.isCancelled {
-            throw SyncError.cancelled
-        }
-    }
-
-    private static func isCancellation(_ error: Error) -> Bool {
-        if error is CancellationError {
-            return true
-        }
-        if let syncError = error as? SyncError, syncError == .cancelled {
-            return true
-        }
-        return false
-    }
-
-    private struct SyncLease {
-        let scopeID: ObjectIdentifier
-    }
-
-    private actor SyncLeaseRegistry {
-        private var activeScopeIDs: Set<ObjectIdentifier> = []
-        private var waitersByScopeID: [ObjectIdentifier: [CheckedContinuation<Void, Never>]] = [:]
-
-        func acquire(scopeID: ObjectIdentifier) async -> SyncLease {
-            if !activeScopeIDs.contains(scopeID) {
-                activeScopeIDs.insert(scopeID)
-                return SyncLease(scopeID: scopeID)
-            }
-
-            await withCheckedContinuation { continuation in
-                var waiters = waitersByScopeID[scopeID] ?? []
-                waiters.append(continuation)
-                waitersByScopeID[scopeID] = waiters
-            }
-
-            return SyncLease(scopeID: scopeID)
-        }
-
-        func release(_ lease: SyncLease) {
-            var waiters = waitersByScopeID[lease.scopeID] ?? []
-            if waiters.isEmpty {
-                activeScopeIDs.remove(lease.scopeID)
-                return
-            }
-
-            let next = waiters.removeFirst()
-            if waiters.isEmpty {
-                waitersByScopeID.removeValue(forKey: lease.scopeID)
-            } else {
-                waitersByScopeID[lease.scopeID] = waiters
-            }
-            next.resume()
-        }
-    }
-
-    private static let syncLeaseRegistry = SyncLeaseRegistry()
-
-    private static func withRelationshipLookupCache<T>(
-        isolation: isolated (any Actor)? = #isolation,
-        operation: () async throws -> T
-    ) async rethrows -> T {
-        let cache = SyncRelationshipLookupCache()
-        return try await SyncRelationshipLookupState.$current.withValue(cache) {
-            try await operation()
-        }
-    }
-
-    private static func acquireSyncLease(
-        for context: ModelContext,
-        isolation: isolated (any Actor)? = #isolation
-    ) async -> SyncLease {
-        let scopeID = ObjectIdentifier(context.container)
-        return await syncLeaseRegistry.acquire(scopeID: scopeID)
-    }
-
-    private static func releaseSyncLease(_ lease: SyncLease) async {
-        await syncLeaseRegistry.release(lease)
     }
 }

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -5,13 +5,11 @@ extension SwiftSync {
     /// The transaction author SwiftSync stamps on inbound (pull) writes, so the push side can tell
     /// server-applied changes from genuine local edits and never push pulled rows back. Local edits
     /// use the store's default author; pull writes use this one and are filtered out of `pendingChanges`.
-    /// Internal — the consumer never references it (`SyncContainer` stamps it on inbound saves).
     static let inboundAuthor = "swiftsync.inbound"
 }
 
-/// The local rows with un-pushed changes, split by operation. Each array holds the rows' `id`s (strings),
-/// not objects — `withPendingChanges` hands this to your `process` closure and you map each id to your own
-/// request payload, so SwiftData objects never cross into the network call.
+/// Each array holds row `id`s (strings), not objects, so SwiftData objects never cross into your network
+/// call: `withPendingChanges` hands you the ids and you map each to your own request payload.
 public struct SyncPendingChanges: Sendable {
     public let inserts: [String]
     public let updates: [String]
@@ -20,10 +18,9 @@ public struct SyncPendingChanges: Sendable {
     public var isEmpty: Bool { inserts.isEmpty && updates.isEmpty && deletes.isEmpty }
 }
 
-/// One pushed row the server rejected: the row `id` to keep pending, and the consumer's own `error`
-/// bubbled up verbatim. Your `process` closure returns only these — everything else in the batch is treated
-/// as confirmed (the client id is the identity the backend adopts, so a push is an idempotent upsert with
-/// no server-assigned ids to map home). The operation is the library's to know, not yours.
+/// One pushed row the server rejected: the row `id` (kept pending) and the consumer's own `error`,
+/// bubbled up verbatim. Return only these from your `process` closure — the operation that failed is the
+/// library's to track, not yours.
 public struct SyncPushFailure: Sendable {
     public let id: String
     public let error: any Error & Sendable
@@ -57,8 +54,8 @@ extension SwiftSync {
         try pendingChanges(from: localTransactions(since: token, in: context), for: Model.self, in: context)
     }
 
-    /// Separate from the token-driven overload so `push` derives the batch and its `uploadedThrough` token
-    /// from a single history read (see the capture in `push`).
+    /// Separate from the token-driven overload so `withPendingChanges` derives the batch and its
+    /// `uploadedThrough` token from a single history read (see the capture in `withPendingChanges`).
     static func pendingChanges<Model: SyncUpdatableModel>(
         from transactions: [DefaultHistoryTransaction],
         for _: Model.Type,
@@ -130,14 +127,12 @@ extension SwiftSync {
         return SyncPendingChanges(inserts: inserts, updates: updates, deletes: deletes)
     }
 
-    /// Process this model type's locally-changed rows inside a scope SwiftSync manages. Reads what changed
-    /// since the last-pushed token, hands it to your `process` closure (you own the network call), and gets
-    /// back the rejected rows. Everything you *don't* return as a failure is treated as confirmed — the
-    /// client id is the identity the server adopts, so it's an idempotent upsert with nothing to
-    /// acknowledge. Only on a fully clean pass (no failures) does it advance the token and trim the
-    /// now-redundant inbound history. SwiftSync stores no per-row state: a failed — or any un-pushed —
-    /// change stays past the token and is re-detected next call. Returns the same failures your closure
-    /// returned (empty == clean).
+    /// Hands your `process` closure the rows changed since the last-pushed token; you own the network call
+    /// and return the rejections. Everything you *don't* return is treated as confirmed — the client id is
+    /// the identity the server adopts, so it's an idempotent upsert with nothing to acknowledge. Only a
+    /// fully clean pass (no failures) advances the token and trims the now-redundant inbound history;
+    /// SwiftSync keeps no per-row state, so a failed — or any un-pushed — change stays past the token and
+    /// is re-detected next call.
     @discardableResult
     public static func withPendingChanges<Model: SyncUpdatableModel>(
         for _: Model.Type,
@@ -208,7 +203,6 @@ extension SwiftSync {
                 predicate: #Predicate { $0.token <= token && $0.author == inbound }))
     }
 
-    /// History transactions since `token` that were *not* authored by the inbound (pull) writer.
     static func localTransactions(since token: DefaultHistoryToken?, in context: ModelContext) throws
         -> [DefaultHistoryTransaction]
     {

--- a/SwiftSync/Sources/SwiftSync/Push.swift
+++ b/SwiftSync/Sources/SwiftSync/Push.swift
@@ -193,6 +193,25 @@ extension SwiftSync {
         return ids
     }
 
+    /// A row with un-pushed local changes (its persistent id is in the history dirty-set). `delete-missing`
+    /// skips these: a row the user created or edited offline and hasn't pushed yet must survive an
+    /// inbound pull that omits it — the server omitting a row it has never seen is not a deletion.
+    static func isUnsyncedLocalInsert<Model: SyncUpdatableModel>(
+        _ row: Model, dirtyPIDs: Set<PersistentIdentifier>
+    ) -> Bool {
+        dirtyPIDs.contains(row.persistentModelID)
+    }
+
+    /// Apply a server `payload` onto `row`, but skip the overwrite when the row has an un-pushed local
+    /// edit (its persistent id is in the dirty-set) — so an inbound pull can't clobber pending local
+    /// work. Last-writer-wins, local-wins-while-pending: the local edit is preserved until it's pushed.
+    static func applyHonoringLocalEdit<Model: SyncUpdatableModel>(
+        _ payload: SyncPayload, to row: Model, dirtyPIDs: Set<PersistentIdentifier>
+    ) throws -> Bool {
+        if dirtyPIDs.contains(row.persistentModelID) { return false }
+        return try row.apply(payload)
+    }
+
     /// Trim inbound (pull-authored) history up to and including `token`. Only inbound transactions are
     /// removed — local-authored history is the un-pushed-changes signal and a different model type may
     /// still need its own un-pushed local changes, so those are never trimmed here.

--- a/SwiftSync/Sources/SwiftSync/PushHistoryTokenStore.swift
+++ b/SwiftSync/Sources/SwiftSync/PushHistoryTokenStore.swift
@@ -19,7 +19,7 @@ final class PushHistoryTokenRecord {
 }
 
 extension SwiftSync {
-    /// `push` writes `PushHistoryTokenRecord` to advance its bookmark once the upload is acknowledged.
+    /// `withPendingChanges` writes `PushHistoryTokenRecord` to advance its bookmark once the upload is acknowledged.
     /// `SyncContainer` registers that model automatically; a caller who builds their own `ModelContainer`
     /// may not. Validate it's in the schema *before* the upload, so an acknowledged server write is never
     /// stranded by a token write that throws afterward.

--- a/SwiftSync/Sources/SwiftSync/SwiftSync+Helpers.swift
+++ b/SwiftSync/Sources/SwiftSync/SwiftSync+Helpers.swift
@@ -1,0 +1,103 @@
+import Foundation
+import SwiftData
+
+extension SwiftSync {
+    static func normalize<Model: PersistentModel>(payload: [Any], model: Model.Type) throws -> [[String: Any]] {
+        try payload.map { raw in
+            guard let map = raw as? [String: Any] else {
+                throw SyncError.invalidPayload(
+                    model: String(describing: model),
+                    reason: "Expected array of dictionaries"
+                )
+            }
+            return map
+        }
+    }
+
+    static func resolveIdentity<Model: SyncModelable>(
+        from payload: SyncPayload,
+        model: Model.Type
+    ) -> Model.SyncID? {
+        for key in model.syncIdentityRemoteKeys {
+            if let value = payload.value(for: key, as: Model.SyncID.self) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    static func syncIdentityHasUniqueAttribute<Model: SyncModelable>(_ model: Model.Type) -> Bool {
+        let identityKeyPath = Model.syncIdentity as AnyKeyPath
+        for propertyMetadata in Model.schemaMetadata {
+            let mirror = Mirror(reflecting: propertyMetadata)
+            guard let candidateKeyPath = mirror.children.first(where: { $0.label == "keypath" })?.value as? AnyKeyPath,
+                candidateKeyPath == identityKeyPath
+            else { continue }
+            guard let rawMetadata = mirror.children.first(where: { $0.label == "metadata" })?.value else {
+                return false
+            }
+            let metadataMirror = Mirror(reflecting: rawMetadata)
+            let unwrapped: Any? =
+                metadataMirror.displayStyle == .optional
+                ? metadataMirror.children.first?.value
+                : rawMetadata
+            guard let attribute = unwrapped as? Schema.Attribute else { return false }
+            return attribute.options.contains(.unique)
+        }
+        return false
+    }
+
+    static func identityKey<ID: Hashable>(from identity: ID) -> String {
+        String(describing: identity)
+    }
+
+    static func scopedIdentityKey<ID: Hashable>(
+        from identity: ID,
+        parentPersistentID: PersistentIdentifier
+    ) -> String {
+        "\(String(reflecting: ID.self))|\(String(describing: parentPersistentID))|\(identityKey(from: identity))"
+    }
+
+    static func fetchUniqueRow<Model: SyncModelable>(
+        matching identity: Model.SyncID,
+        as _: Model.Type,
+        in context: ModelContext
+    ) throws -> Model? {
+        guard let predicate = Model.syncIdentityPredicate(matching: identity) else {
+            return nil
+        }
+        var descriptor = FetchDescriptor<Model>(predicate: predicate)
+        descriptor.fetchLimit = 1
+        return try context.fetch(descriptor).first
+    }
+
+    static func resolveParent<Parent: PersistentModel>(
+        _ parent: Parent,
+        in context: ModelContext
+    ) throws -> Parent? {
+        let parents = try syncProfile("fetch-parents") {
+            try context.fetch(FetchDescriptor<Parent>())
+        }
+        return parents.first { $0.persistentModelID == parent.persistentModelID }
+    }
+
+    static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+        if let syncError = error as? SyncError, syncError == .cancelled {
+            return true
+        }
+        return false
+    }
+
+    static func withRelationshipLookupCache<T>(
+        isolation: isolated (any Actor)? = #isolation,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        let cache = SyncRelationshipLookupCache()
+        return try await SyncRelationshipLookupState.$current.withValue(cache) {
+            try await operation()
+        }
+    }
+}

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -134,8 +134,7 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
     /// actor) and the change is visible to live queries at once — unlike bulk `sync(payload:)`, which
     /// runs off-main. (SwiftData has no `mergeChanges(fromContextDidSave:)`, so an off-main *update*
     /// wouldn't promptly refresh an already-registered `mainContext` row; for a single object, applying
-    /// on main sidesteps that without a meaningful main-thread cost.) The payload rides in an
-    /// unchecked-Sendable box so it can cross to the main actor; it is only read there, so the box is sound.
+    /// on main sidesteps that without a meaningful main-thread cost.)
     public func sync<Model: SyncUpdatableModel>(
         item: [String: Any],
         as model: Model.Type,

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -53,8 +53,7 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         configurations: ModelConfiguration...
     ) throws {
         try Self._validateSchema(modelTypes: modelTypes)
-        // SwiftSync's per-type last-pushed history token (O(model types) rows). Registered so consumers
-        // never declare or manage it.
+        // Registered so consumers never declare or manage SwiftSync's bookkeeping model.
         let schema = Schema(modelTypes + [PushHistoryTokenRecord.self])
         self.modelContainer = try Self._recoverContainerInitialization(
             recoverOnFailure: recoverOnFailure,

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -10,6 +10,29 @@ struct UncheckedSendableBox<Value>: @unchecked Sendable {
 }
 
 public final class SyncContainer: NSObject, @unchecked Sendable {
+    /// A FIFO async mutex. Serializes work spanning `await` points — which actor isolation alone does not,
+    /// since an actor method suspended at an `await` lets another call enter.
+    private actor Serializer {
+        private var isHeld = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func acquire() async {
+            if isHeld {
+                await withCheckedContinuation { waiters.append($0) }
+            } else {
+                isHeld = true
+            }
+        }
+
+        func release() {
+            if waiters.isEmpty {
+                isHeld = false
+            } else {
+                waiters.removeFirst().resume()
+            }
+        }
+    }
+
     static let didSaveChangesNotification = Notification.Name("SwiftSync.SyncContainer.didSaveChanges")
     static let changedIdentifiersUserInfoKey = "changedIdentifiers"
     static let changedModelTypeNamesUserInfoKey = "changedModelTypeNames"
@@ -18,6 +41,8 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
     public let mainContext: ModelContext
     public let keyStyle: KeyStyle
     public let dateFormatter: DateFormatter
+
+    private let serializer = Serializer()
 
     @MainActor
     public init(
@@ -71,15 +96,12 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         as model: Model.Type,
         relationshipOperations: SyncRelationshipOperations = .all
     ) async throws {
-        let context = ModelContext(modelContainer)
-        context.author = SwiftSync.inboundAuthor
-        try await SwiftSync.sync(
-            payload: payload,
-            as: model,
-            in: context,
-            keyStyle: keyStyle,
-            relationshipOperations: relationshipOperations
-        )
+        try await serialized {
+            let context = ModelContext(modelContainer)
+            context.author = SwiftSync.inboundAuthor
+            try await context.sync(
+                payload: payload, as: model, keyStyle: keyStyle, relationshipOperations: relationshipOperations)
+        }
     }
 
     public func sync<Model: SyncUpdatableModel, Payload: SyncPayloadConvertible>(
@@ -101,17 +123,13 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
         relationshipOperations: SyncRelationshipOperations = .all
     ) async throws {
-        let context = ModelContext(modelContainer)
-        context.author = SwiftSync.inboundAuthor
-        try await SwiftSync.sync(
-            payload: payload,
-            as: model,
-            in: context,
-            parent: parent,
-            relationship: relationship,
-            keyStyle: keyStyle,
-            relationshipOperations: relationshipOperations
-        )
+        try await serialized {
+            let context = ModelContext(modelContainer)
+            context.author = SwiftSync.inboundAuthor
+            try await context.sync(
+                payload: payload, as: model, parent: parent, relationship: relationship, keyStyle: keyStyle,
+                relationshipOperations: relationshipOperations)
+        }
     }
 
     public func sync<Model: SyncUpdatableModel, Payload: SyncPayloadConvertible, Parent: PersistentModel>(
@@ -140,8 +158,10 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         as model: Model.Type,
         relationshipOperations: SyncRelationshipOperations = .all
     ) async throws {
-        try await syncIntoMainContext(
-            UncheckedSendableBox(item), as: model, relationshipOperations: relationshipOperations)
+        try await serialized {
+            try await syncIntoMainContext(
+                UncheckedSendableBox(item), as: model, relationshipOperations: relationshipOperations)
+        }
     }
 
     @MainActor
@@ -157,13 +177,8 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         let previousAuthor = mainContext.author
         mainContext.author = SwiftSync.inboundAuthor
         defer { mainContext.author = previousAuthor }
-        try await SwiftSync.sync(
-            item: item.value,
-            as: model,
-            in: mainContext,
-            keyStyle: keyStyle,
-            relationshipOperations: relationshipOperations
-        )
+        try await mainContext.sync(
+            item: item.value, as: model, keyStyle: keyStyle, relationshipOperations: relationshipOperations)
     }
 
     public func sync<Model: SyncUpdatableModel, Payload: SyncPayloadConvertible>(
@@ -185,17 +200,13 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         relationship: ReferenceWritableKeyPath<Model, Parent?>,
         relationshipOperations: SyncRelationshipOperations = .all
     ) async throws {
-        let context = ModelContext(modelContainer)
-        context.author = SwiftSync.inboundAuthor
-        try await SwiftSync.sync(
-            item: item,
-            as: model,
-            in: context,
-            parent: parent,
-            relationship: relationship,
-            keyStyle: keyStyle,
-            relationshipOperations: relationshipOperations
-        )
+        try await serialized {
+            let context = ModelContext(modelContainer)
+            context.author = SwiftSync.inboundAuthor
+            try await context.sync(
+                item: item, as: model, parent: parent, relationship: relationship, keyStyle: keyStyle,
+                relationshipOperations: relationshipOperations)
+        }
     }
 
     public func sync<Model: SyncUpdatableModel, Payload: SyncPayloadConvertible, Parent: PersistentModel>(
@@ -216,6 +227,18 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
 
     public func export<Model: SyncUpdatableModel>(_ model: Model) -> [String: Any] {
         model.export(keyStyle: keyStyle, dateFormatter: dateFormatter)
+    }
+
+    private func serialized<T>(_ operation: () async throws -> T) async throws -> T {
+        await serializer.acquire()
+        do {
+            let result = try await operation()
+            await serializer.release()
+            return result
+        } catch {
+            await serializer.release()
+            throw error
+        }
     }
 
     private func installDidSaveObserver() {

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -76,8 +76,7 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
     }
 
     @MainActor
-    public init(_ modelContainer: ModelContainer, keyStyle: KeyStyle = .snakeCase, dateFormatter: DateFormatter? = nil)
-    {
+    public init(_ modelContainer: ModelContainer, keyStyle: KeyStyle = .snakeCase, dateFormatter: DateFormatter? = nil) {
         self.modelContainer = modelContainer
         self.mainContext = modelContainer.mainContext
         self.keyStyle = keyStyle

--- a/SwiftSync/Sources/SwiftSync/SyncQueryPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncQueryPublisher.swift
@@ -6,11 +6,7 @@ import SwiftData
 @Observable
 public final class SyncQueryPublisher<Model: PersistentModel> {
 
-    // MARK: - Public interface
-
     public private(set) var rows: [Model] = []
-
-    // MARK: - Private state
 
     @ObservationIgnored private let syncContainer: SyncContainer
     @ObservationIgnored private let predicate: Predicate<Model>?
@@ -18,8 +14,6 @@ public final class SyncQueryPublisher<Model: PersistentModel> {
     @ObservationIgnored private let postFetchFilter: ((Model) -> Bool)?
     @ObservationIgnored private let observedModelTypeNames: Set<String>
     @ObservationIgnored nonisolated(unsafe) private var notificationToken: NSObjectProtocol?
-
-    // MARK: - Designated init
 
     private init(
         syncContainer: SyncContainer,
@@ -53,8 +47,6 @@ public final class SyncQueryPublisher<Model: PersistentModel> {
             NotificationCenter.default.removeObserver(notificationToken)
         }
     }
-
-    // MARK: - Public inits
 
     public convenience init(
         _ _: Model.Type,
@@ -107,8 +99,6 @@ public final class SyncQueryPublisher<Model: PersistentModel> {
             }
         )
     }
-
-    // MARK: - Private
 
     private func shouldReload(
         changedTypeNames: Set<String>,

--- a/SwiftSync/Tests/SwiftSyncTests/FetchStrategyBenchmarkTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/FetchStrategyBenchmarkTests.swift
@@ -203,7 +203,7 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                     try seedUsers(count: existingCount, in: context)
                     let payload = makeUserPayload(count: existingCount, namePrefix: "batch-updated")
                     return try await measureDuration {
-                        try await SwiftSync.sync(payload: payload, as: BenchmarkUser.self, in: context)
+                        try await context.sync(payload: payload, as: BenchmarkUser.self)
                     }
                 }
 
@@ -240,7 +240,7 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                         "full_name": "single-item-updated-\(existingCount)",
                     ]
                     return try await measureDuration {
-                        try await SwiftSync.sync(item: payload, as: BenchmarkUser.self, in: context)
+                        try await context.sync(item: payload, as: BenchmarkUser.self)
                     }
                 }
 
@@ -284,13 +284,9 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                         "title": "Scoped Item Updated",
                     ]
                     return try await measureDuration {
-                        try await SwiftSync.sync(
-                            item: payload,
-                            as: BenchmarkScopedTask.self,
-                            in: context,
-                            parent: targetProject,
-                            relationship: \BenchmarkScopedTask.project
-                        )
+                        try await context.sync(
+                            item: payload, as: BenchmarkScopedTask.self, parent: targetProject,
+                            relationship: \BenchmarkScopedTask.project)
                     }
                 }
 
@@ -328,13 +324,9 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                     )
                     let payload = makeScopedTaskPayload(count: scopeCount)
                     return try await measureDuration {
-                        try await SwiftSync.sync(
-                            payload: payload,
-                            as: BenchmarkScopedTask.self,
-                            in: context,
-                            parent: targetProject,
-                            relationship: \BenchmarkScopedTask.project
-                        )
+                        try await context.sync(
+                            payload: payload, as: BenchmarkScopedTask.self, parent: targetProject,
+                            relationship: \BenchmarkScopedTask.project)
                     }
                 }
 
@@ -373,7 +365,7 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                         "assignee_id": relatedCount,
                     ]
                     return try await measureDuration {
-                        try await SwiftSync.sync(item: payload, as: BenchmarkWorkItem.self, in: context)
+                        try await context.sync(item: payload, as: BenchmarkWorkItem.self)
                     }
                 }
 
@@ -414,7 +406,7 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                             "tag_ids": Array(1...linkCount),
                         ]
                         return try await measureDuration {
-                            try await SwiftSync.sync(item: payload, as: BenchmarkWorkItem.self, in: context)
+                            try await context.sync(item: payload, as: BenchmarkWorkItem.self)
                         }
                     }
 
@@ -458,7 +450,7 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                             },
                         ]
                         return try await measureDuration {
-                            try await SwiftSync.sync(item: payload, as: BenchmarkWorkItem.self, in: context)
+                            try await context.sync(item: payload, as: BenchmarkWorkItem.self)
                         }
                     }
 
@@ -527,15 +519,11 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                     ]
 
                     return try await measureDuration {
-                        try await SwiftSync.sync(item: userPayload, as: BenchmarkUser.self, in: context)
-                        try await SwiftSync.sync(
-                            payload: scopedPayload,
-                            as: BenchmarkScopedTask.self,
-                            in: context,
-                            parent: targetProject,
-                            relationship: \BenchmarkScopedTask.project
-                        )
-                        try await SwiftSync.sync(item: workItemPayload, as: BenchmarkWorkItem.self, in: context)
+                        try await context.sync(item: userPayload, as: BenchmarkUser.self)
+                        try await context.sync(
+                            payload: scopedPayload, as: BenchmarkScopedTask.self, parent: targetProject,
+                            relationship: \BenchmarkScopedTask.project)
+                        try await context.sync(item: workItemPayload, as: BenchmarkWorkItem.self)
                     }
                 }
 
@@ -598,15 +586,11 @@ final class FetchStrategyBenchmarkTests: XCTestCase {
                     ]
 
                     return try await measureDuration {
-                        try await SwiftSync.sync(
-                            payload: taskListPayload,
-                            as: ScenarioTask.self,
-                            in: context,
-                            parent: targetProject,
-                            relationship: \ScenarioTask.project
-                        )
-                        try await SwiftSync.sync(item: taskDetailPayload, as: ScenarioTask.self, in: context)
-                        try await SwiftSync.sync(item: userPresencePayload, as: ScenarioUser.self, in: context)
+                        try await context.sync(
+                            payload: taskListPayload, as: ScenarioTask.self, parent: targetProject,
+                            relationship: \ScenarioTask.project)
+                        try await context.sync(item: taskDetailPayload, as: ScenarioTask.self)
+                        try await context.sync(item: userPresencePayload, as: ScenarioUser.self)
                     }
                 }
 

--- a/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
@@ -93,7 +93,7 @@ final class OfflineHistoryTests: XCTestCase {
 
             let clock = ContinuousClock()
             let pullStart = clock.now
-            try await SwiftSync.sync(payload: payload, as: HistoryRow.self, in: context, keyStyle: .snakeCase)
+            try await context.sync(payload: payload, as: HistoryRow.self, keyStyle: .snakeCase)
             let pullMs = pullStart.duration(to: clock.now).msValue
 
             // Push-side detection over the same store: should be ~empty (all inbound-authored) and fast.

--- a/SwiftSync/Tests/SwiftSyncTests/SyncFeatureInteropTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncFeatureInteropTests.swift
@@ -61,16 +61,14 @@ final class SyncFeatureInteropTests: XCTestCase {
                 for: InteropIndexedNote.self,
                 configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "title": "A", "category": "x"],
                 ["id": 2, "title": "B", "category": "x"],
-            ], as: InteropIndexedNote.self, in: context)
+            ], as: InteropIndexedNote.self)
 
         // Re-sync id 1 with changed fields — must update the same row, not create a new one.
-        try await SwiftSync.sync(
-            item: ["id": 1, "title": "A2", "category": "y"], as: InteropIndexedNote.self,
-            in: context)
+        try await context.sync(item: ["id": 1, "title": "A2", "category": "y"], as: InteropIndexedNote.self)
 
         let notes = try context.fetch(FetchDescriptor<InteropIndexedNote>())
         XCTAssertEqual(notes.count, 2, "#Index must not change row identity or count")
@@ -94,13 +92,9 @@ final class SyncFeatureInteropTests: XCTestCase {
                 for: InteropUniqueEmailUser.self,
                 configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
 
-        try await SwiftSync.sync(
-            item: ["id": 1, "email": "a@x.com", "name": "Alice"], as: InteropUniqueEmailUser.self,
-            in: context)
+        try await context.sync(item: ["id": 1, "email": "a@x.com", "name": "Alice"], as: InteropUniqueEmailUser.self)
         // id 2 is a distinct record per SwiftSync identity, but collides on the unique email.
-        try await SwiftSync.sync(
-            item: ["id": 2, "email": "a@x.com", "name": "Bob"], as: InteropUniqueEmailUser.self,
-            in: context)
+        try await context.sync(item: ["id": 2, "email": "a@x.com", "name": "Bob"], as: InteropUniqueEmailUser.self)
 
         let users = try context.fetch(FetchDescriptor<InteropUniqueEmailUser>())
         XCTAssertEqual(users.count, 2, "both identity-distinct rows should survive")
@@ -121,12 +115,8 @@ final class SyncFeatureInteropTests: XCTestCase {
                 for: InteropCompoundUniqueEvent.self,
                 configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
 
-        try await SwiftSync.sync(
-            item: ["id": 1, "name": "Launch", "day": "Mon"], as: InteropCompoundUniqueEvent.self,
-            in: context)
-        try await SwiftSync.sync(
-            item: ["id": 2, "name": "Launch", "day": "Mon"], as: InteropCompoundUniqueEvent.self,
-            in: context)
+        try await context.sync(item: ["id": 1, "name": "Launch", "day": "Mon"], as: InteropCompoundUniqueEvent.self)
+        try await context.sync(item: ["id": 2, "name": "Launch", "day": "Mon"], as: InteropCompoundUniqueEvent.self)
 
         let events = try context.fetch(FetchDescriptor<InteropCompoundUniqueEvent>())
         XCTAssertEqual(events.count, 2, "both identity-distinct rows should survive")

--- a/SwiftSync/Tests/SwiftSyncTests/SyncRelationshipIntegrityTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncRelationshipIntegrityTests.swift
@@ -447,16 +447,10 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         let context = ModelContext(container)
 
         // Seed two users and a task with no members.
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"]],
-            as: OneSidedUser.self,
-            in: context
-        )
-        try await SwiftSync.sync(
-            payload: [["id": 10, "title": "Task 10", "member_ids": [] as [Int]]],
-            as: OneSidedTask.self,
-            in: context
-        )
+        try await context.sync(
+            payload: [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"]], as: OneSidedUser.self)
+        try await context.sync(
+            payload: [["id": 10, "title": "Task 10", "member_ids": [] as [Int]]], as: OneSidedTask.self)
 
         let task = try XCTUnwrap(context.fetch(FetchDescriptor<OneSidedTask>()).first)
         XCTAssertEqual(task.members.count, 0, "precondition: task starts with no members")
@@ -465,11 +459,7 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         OneSidedTask.syncMarkChangedCallCount = 0
 
         // Sync a to-many membership change: [] → [1, 2]. No scalar (title) changes.
-        try await SwiftSync.sync(
-            payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]],
-            as: OneSidedTask.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]], as: OneSidedTask.self)
 
         // syncApplyToManyForeignKeys must have called syncMarkChanged() exactly once.
         // Without the fix this count is 0 — the test fails, reproducing the bug contract.
@@ -494,26 +484,15 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"]],
-            as: OneSidedUser.self,
-            in: context
-        )
+        try await context.sync(
+            payload: [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"]], as: OneSidedUser.self)
         // Seed with existing membership [1, 2].
-        try await SwiftSync.sync(
-            payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]],
-            as: OneSidedTask.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]], as: OneSidedTask.self)
 
         OneSidedTask.syncMarkChangedCallCount = 0
 
         // Sync with the same membership — no actual change.
-        try await SwiftSync.sync(
-            payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]],
-            as: OneSidedTask.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]], as: OneSidedTask.self)
 
         XCTAssertEqual(
             OneSidedTask.syncMarkChangedCallCount, 0,
@@ -529,18 +508,15 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "title": "Task 10", "members": [] as [[String: Any]]]],
-            as: OneSidedNestedTask.self,
-            in: context
-        )
+        try await context.sync(
+            payload: [["id": 10, "title": "Task 10", "members": [] as [[String: Any]]]], as: OneSidedNestedTask.self)
 
         let task = try XCTUnwrap(context.fetch(FetchDescriptor<OneSidedNestedTask>()).first)
         XCTAssertEqual(task.members.count, 0, "precondition: task starts with no members")
 
         OneSidedNestedTask.syncMarkChangedCallCount = 0
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
@@ -550,10 +526,7 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
                         ["id": 2, "name": "Bob"],
                     ],
                 ]
-            ],
-            as: OneSidedNestedTask.self,
-            in: context
-        )
+            ], as: OneSidedNestedTask.self)
 
         XCTAssertEqual(
             OneSidedNestedTask.syncMarkChangedCallCount, 1,
@@ -570,7 +543,7 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
@@ -580,14 +553,11 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
                         ["id": 2, "name": "Bob"],
                     ],
                 ]
-            ],
-            as: OneSidedNestedTask.self,
-            in: context
-        )
+            ], as: OneSidedNestedTask.self)
 
         OneSidedNestedTask.syncMarkChangedCallCount = 0
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
@@ -597,10 +567,7 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
                         ["id": 2, "name": "Bob"],
                     ],
                 ]
-            ],
-            as: OneSidedNestedTask.self,
-            in: context
-        )
+            ], as: OneSidedNestedTask.self)
 
         XCTAssertEqual(
             OneSidedNestedTask.syncMarkChangedCallCount, 0,
@@ -616,7 +583,7 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
@@ -626,27 +593,21 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
                         ["id": 2, "name": "Bob"],
                     ],
                 ]
-            ],
-            as: OneSidedNestedTask.self,
-            in: context
-        )
+            ], as: OneSidedNestedTask.self)
 
         let task = try XCTUnwrap(context.fetch(FetchDescriptor<OneSidedNestedTask>()).first)
         XCTAssertEqual(Set(task.members.map(\.id)), Set([1, 2]), "precondition: task starts populated")
 
         OneSidedNestedTask.syncMarkChangedCallCount = 0
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
                     "title": "Task 10",
                     "members": NSNull(),
                 ]
-            ],
-            as: OneSidedNestedTask.self,
-            in: context
-        )
+            ], as: OneSidedNestedTask.self)
 
         XCTAssertEqual(
             OneSidedNestedTask.syncMarkChangedCallCount, 1,
@@ -664,16 +625,10 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"], ["id": 3, "name": "Cara"]],
-            as: OneSidedUser.self,
-            in: context
-        )
-        try await SwiftSync.sync(
-            payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]],
-            as: OneSidedTask.self,
-            in: context
-        )
+            as: OneSidedUser.self)
+        try await context.sync(payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]], as: OneSidedTask.self)
 
         let task = try XCTUnwrap(context.fetch(FetchDescriptor<OneSidedTask>()).first)
         XCTAssertEqual(task.members.map(\.id).sorted(), [1, 2])
@@ -690,11 +645,7 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
             observedChange.fire()
         }
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "title": "Task 10", "member_ids": [2, 3]]],
-            as: OneSidedTask.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "title": "Task 10", "member_ids": [2, 3]]], as: OneSidedTask.self)
 
         XCTAssertEqual(task.members.map(\.id).sorted(), [2, 3])
         XCTAssertTrue(
@@ -740,38 +691,29 @@ final class RelationshipIntegrityRegressionTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "name": "Tag 1"],
                 ["id": 2, "name": "Tag 2"],
                 ["id": 3, "name": "Tag 3"],
-            ],
-            as: MissingInverseRegressionTag.self,
-            in: context
-        )
+            ], as: MissingInverseRegressionTag.self)
 
         // Mirrors the demo flow: a single-task sync happens first after a mutation.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
                     "title": "Task 10",
                     "tag_ids": [1, 2],
                 ]
-            ],
-            as: MissingInverseRegressionTask.self,
-            in: context
-        )
+            ], as: MissingInverseRegressionTask.self)
 
         // Then a task-list batch sync arrives with another task sharing one tag.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 10, "title": "Task 10", "tag_ids": [1, 2]],
                 ["id": 20, "title": "Task 20", "tag_ids": [2, 3]],
-            ],
-            as: MissingInverseRegressionTask.self,
-            in: context
-        )
+            ], as: MissingInverseRegressionTask.self)
 
         let tasks = try context.fetch(FetchDescriptor<MissingInverseRegressionTask>())
         let tasksByID = Dictionary(uniqueKeysWithValues: tasks.map { ($0.id, Set($0.tags.map(\.id))) })
@@ -790,36 +732,27 @@ final class RelationshipIntegrityRegressionTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "name": "Tag 1"],
                 ["id": 2, "name": "Tag 2"],
                 ["id": 3, "name": "Tag 3"],
-            ],
-            as: ExplicitInverseRegressionTag.self,
-            in: context
-        )
+            ], as: ExplicitInverseRegressionTag.self)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
                     "title": "Task 10",
                     "tag_ids": [1, 2],
                 ]
-            ],
-            as: ExplicitInverseRegressionTask.self,
-            in: context
-        )
+            ], as: ExplicitInverseRegressionTask.self)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 10, "title": "Task 10", "tag_ids": [1, 2]],
                 ["id": 20, "title": "Task 20", "tag_ids": [2, 3]],
-            ],
-            as: ExplicitInverseRegressionTask.self,
-            in: context
-        )
+            ], as: ExplicitInverseRegressionTask.self)
 
         let tasks = try context.fetch(FetchDescriptor<ExplicitInverseRegressionTask>())
         let tasksByID = Dictionary(uniqueKeysWithValues: tasks.map { ($0.id, Set($0.tags.map(\.id))) })

--- a/SwiftSync/Tests/SwiftSyncTests/SyncRelationshipOperationsTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncRelationshipOperationsTests.swift
@@ -209,38 +209,25 @@ final class RelationshipOperationsTests: XCTestCase {
         let container = try ModelContainer(for: OpsCompany.self, OpsEmployee.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "name": "Acme"]],
-            as: OpsCompany.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "name": "Acme"]], as: OpsCompany.self)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava", "company_id": 10]],
-            as: OpsEmployee.self,
-            in: context,
-            relationshipOperations: [.insert]
-        )
+        try await context.sync(
+            payload: [["id": 1, "name": "Ava", "company_id": 10]], as: OpsEmployee.self,
+            relationshipOperations: [.insert])
 
         var rows = try context.fetch(FetchDescriptor<OpsEmployee>())
         XCTAssertEqual(rows.first?.company?.id, 10)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava", "company_id": NSNull()]],
-            as: OpsEmployee.self,
-            in: context,
-            relationshipOperations: [.insert]
-        )
+        try await context.sync(
+            payload: [["id": 1, "name": "Ava", "company_id": NSNull()]], as: OpsEmployee.self,
+            relationshipOperations: [.insert])
 
         rows = try context.fetch(FetchDescriptor<OpsEmployee>())
         XCTAssertEqual(rows.first?.company?.id, 10)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava", "company_id": NSNull()]],
-            as: OpsEmployee.self,
-            in: context,
-            relationshipOperations: [.update]
-        )
+        try await context.sync(
+            payload: [["id": 1, "name": "Ava", "company_id": NSNull()]], as: OpsEmployee.self,
+            relationshipOperations: [.update])
 
         rows = try context.fetch(FetchDescriptor<OpsEmployee>())
         XCTAssertNil(rows.first?.company)

--- a/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
@@ -2743,26 +2743,17 @@ final class SyncTests: XCTestCase {
     }
 
     @MainActor
-    func testConcurrentSyncDifferentContextsSameStoreUniqueConstraintConflict() async throws {
+    func testLastWriterWinsAcrossContextsOnSameStore() async throws {
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: DifferentContextConflictUser.self, configurations: configuration)
         let foregroundContext = ModelContext(container)
         let backgroundContext = ModelContext(container)
         let readerContext = ModelContext(container)
 
-        let foregroundTask = Task { @MainActor in
-            try await foregroundContext.sync(
-                payload: [["id": 500, "full_name": "Foreground Winner"]], as: DifferentContextConflictUser.self)
-        }
-
-        await Task.yield()
-        let backgroundTask = Task { @MainActor in
-            try await backgroundContext.sync(
-                payload: [["id": 500, "full_name": "Background Winner"]], as: DifferentContextConflictUser.self)
-        }
-
-        try await foregroundTask.value
-        try await backgroundTask.value
+        try await foregroundContext.sync(
+            payload: [["id": 500, "full_name": "Foreground Winner"]], as: DifferentContextConflictUser.self)
+        try await backgroundContext.sync(
+            payload: [["id": 500, "full_name": "Background Winner"]], as: DifferentContextConflictUser.self)
 
         let rows = try readerContext.fetch(FetchDescriptor<DifferentContextConflictUser>())
         XCTAssertEqual(rows.count, 1)

--- a/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
@@ -3217,6 +3217,22 @@ final class SyncTests: XCTestCase {
     }
 
     @MainActor
+    func testSyncThrowsInvalidPayloadForNonDictionaryElement() async throws {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: DifferentContextConflictUser.self, configurations: configuration)
+        let context = ModelContext(container)
+
+        do {
+            try await context.sync(payload: ["not a dictionary"], as: DifferentContextConflictUser.self)
+            XCTFail("Expected a non-dictionary payload element to throw")
+        } catch let error as SyncError {
+            guard case .invalidPayload = error else {
+                return XCTFail("Expected .invalidPayload, got \(error)")
+            }
+        }
+    }
+
+    @MainActor
     func testSyncCancellationDuringExecutionRollsBackUnsavedChanges() async throws {
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: ConcurrentRaceUser.self, configurations: configuration)

--- a/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
@@ -1413,14 +1413,14 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         let insertPayload: [Any] = [["id": 1, "full_name": "Ava Swift"]]
-        try await SwiftSync.sync(payload: insertPayload, as: User.self, in: context)
+        try await context.sync(payload: insertPayload, as: User.self)
 
         var users = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(users.count, 1)
         XCTAssertEqual(users.first?.fullName, "Ava Swift")
 
         let updatePayload: [Any] = [["id": 1, "full_name": "Ava Updated"]]
-        try await SwiftSync.sync(payload: updatePayload, as: User.self, in: context)
+        try await context.sync(payload: updatePayload, as: User.self)
 
         users = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(users.count, 1)
@@ -1471,7 +1471,7 @@ final class SyncTests: XCTestCase {
                 "status": ["id": "todo", "label": "To Do"],
             ]
         ]
-        try await SwiftSync.sync(payload: insertPayload, as: StatusItem.self, in: context)
+        try await context.sync(payload: insertPayload, as: StatusItem.self)
 
         var items = try context.fetch(FetchDescriptor<StatusItem>())
         XCTAssertEqual(items.count, 1)
@@ -1485,7 +1485,7 @@ final class SyncTests: XCTestCase {
                 "status": ["id": "done", "label": "Done"],
             ]
         ]
-        try await SwiftSync.sync(payload: updatePayload, as: StatusItem.self, in: context)
+        try await context.sync(payload: updatePayload, as: StatusItem.self)
 
         items = try context.fetch(FetchDescriptor<StatusItem>())
         XCTAssertEqual(items.count, 1)
@@ -1502,7 +1502,7 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         let payload: [Any] = [["id": 55, "full_name": "Remote User"]]
-        try await SwiftSync.sync(payload: payload, as: RemoteUser.self, in: context)
+        try await context.sync(payload: payload, as: RemoteUser.self)
 
         let users = try context.fetch(FetchDescriptor<RemoteUser>())
         XCTAssertEqual(users.count, 1)
@@ -1517,7 +1517,7 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         let payload: [Any] = [["id": 42.9, "full_name": "Float ID User"]]
-        try await SwiftSync.sync(payload: payload, as: User.self, in: context)
+        try await context.sync(payload: payload, as: User.self)
 
         let users = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(users.count, 1)
@@ -1532,14 +1532,14 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         let payloadA: [Any] = [["id": "42", "full_name": "X"]]
-        try await SwiftSync.sync(payload: payloadA, as: User.self, in: context)
+        try await context.sync(payload: payloadA, as: User.self)
 
         var rows = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(rows.count, 1)
         XCTAssertEqual(rows.first?.id, 42)
 
         let payloadB: [Any] = [["id": 42, "full_name": "X Updated"]]
-        try await SwiftSync.sync(payload: payloadB, as: User.self, in: context)
+        try await context.sync(payload: payloadB, as: User.self)
 
         rows = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(rows.count, 1)
@@ -1554,7 +1554,7 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         let payloadA: [Any] = [["id": 42, "name": "X"]]
-        try await SwiftSync.sync(payload: payloadA, as: StringIDUser.self, in: context)
+        try await context.sync(payload: payloadA, as: StringIDUser.self)
 
         var rows = try context.fetch(FetchDescriptor<StringIDUser>())
         XCTAssertEqual(rows.count, 1)
@@ -1562,7 +1562,7 @@ final class SyncTests: XCTestCase {
         XCTAssertEqual(rows.first?.name, "X")
 
         let payloadB: [Any] = [["id": "42", "name": "X Updated"]]
-        try await SwiftSync.sync(payload: payloadB, as: StringIDUser.self, in: context)
+        try await context.sync(payload: payloadB, as: StringIDUser.self)
 
         rows = try context.fetch(FetchDescriptor<StringIDUser>())
         XCTAssertEqual(rows.count, 1)
@@ -1583,8 +1583,8 @@ final class SyncTests: XCTestCase {
                 "updated_at": "2014-02-17T00:00:00+00:00",
             ]
         ]
-        try await SwiftSync.sync(payload: payload, as: Profile.self, in: context)
-        try await SwiftSync.sync(payload: payload, as: Profile.self, in: context)
+        try await context.sync(payload: payload, as: Profile.self)
+        try await context.sync(payload: payload, as: Profile.self)
 
         let rows = try context.fetch(FetchDescriptor<Profile>())
         XCTAssertEqual(rows.count, 1)
@@ -1605,7 +1605,7 @@ final class SyncTests: XCTestCase {
                 "updated_at": "2014-01-02",
             ]
         ]
-        try await SwiftSync.sync(payload: payload, as: Profile.self, in: context)
+        try await context.sync(payload: payload, as: Profile.self)
 
         let rows = try context.fetch(FetchDescriptor<Profile>())
         XCTAssertEqual(rows.count, 1)
@@ -1629,47 +1629,38 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         // Seconds
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "first_name": "A",
                     "updated_at": 1_700_000_000,
                 ]
-            ],
-            as: Profile.self,
-            in: context
-        )
+            ], as: Profile.self)
         var rows = try context.fetch(FetchDescriptor<Profile>())
         XCTAssertEqual(rows.first?.updatedAt, Date(timeIntervalSince1970: 1_700_000_000))
 
         // Milliseconds
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "first_name": "A",
                     "updated_at": 1_700_000_000_000,
                 ]
-            ],
-            as: Profile.self,
-            in: context
-        )
+            ], as: Profile.self)
         rows = try context.fetch(FetchDescriptor<Profile>())
         XCTAssertEqual(rows.first?.updatedAt, Date(timeIntervalSince1970: 1_700_000_000))
 
         // Microseconds
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "first_name": "A",
                     "updated_at": 1_700_000_000_000_000,
                 ]
-            ],
-            as: Profile.self,
-            in: context
-        )
+            ], as: Profile.self)
         rows = try context.fetch(FetchDescriptor<Profile>())
         XCTAssertEqual(rows.first?.updatedAt, Date(timeIntervalSince1970: 1_700_000_000))
     }
@@ -1681,32 +1672,26 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         // Required Date field defaults to epoch on invalid input.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "first_name": "Elvis",
                     "updated_at": "not-a-date",
                 ]
-            ],
-            as: Profile.self,
-            in: context
-        )
+            ], as: Profile.self)
         let requiredRows = try context.fetch(FetchDescriptor<Profile>())
         XCTAssertEqual(requiredRows.count, 1)
         XCTAssertEqual(requiredRows.first?.updatedAt, Date(timeIntervalSince1970: 0))
 
         // Optional Date field stays nil on invalid input.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 2,
                     "updated_at": "not-a-date",
                 ]
-            ],
-            as: OptionalDateProfile.self,
-            in: context
-        )
+            ], as: OptionalDateProfile.self)
         let optionalRows = try context.fetch(FetchDescriptor<OptionalDateProfile>())
         XCTAssertEqual(optionalRows.count, 1)
         XCTAssertNil(optionalRows.first?.updatedAt)
@@ -1731,7 +1716,7 @@ final class SyncTests: XCTestCase {
                 "nickname": "Al",
             ]
         ]
-        try await SwiftSync.sync(payload: seedPayload, as: PrimitiveUser.self, in: context)
+        try await context.sync(payload: seedPayload, as: PrimitiveUser.self)
 
         let clearPayload: [Any] = [
             [
@@ -1746,7 +1731,7 @@ final class SyncTests: XCTestCase {
                 "nickname": NSNull(),
             ]
         ]
-        try await SwiftSync.sync(payload: clearPayload, as: PrimitiveUser.self, in: context)
+        try await context.sync(payload: clearPayload, as: PrimitiveUser.self)
 
         let rows = try context.fetch(FetchDescriptor<PrimitiveUser>())
         XCTAssertEqual(rows.count, 1)
@@ -1770,10 +1755,10 @@ final class SyncTests: XCTestCase {
             ["id": 1, "full_name": "Ava Swift"],
             ["id": 2, "full_name": "Noah Swift"],
         ]
-        try await SwiftSync.sync(payload: seedPayload, as: User.self, in: context)
+        try await context.sync(payload: seedPayload, as: User.self)
 
         let replacePayload: [Any] = [["id": 1, "full_name": "Ava Updated"]]
-        try await SwiftSync.sync(payload: replacePayload, as: User.self, in: context)
+        try await context.sync(payload: replacePayload, as: User.self)
 
         let users = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(users.count, 1)
@@ -1794,14 +1779,14 @@ final class SyncTests: XCTestCase {
             ["id": 3, "full_name": "User 3"],
             ["id": 4, "full_name": "User 4"],
         ]
-        try await SwiftSync.sync(payload: seedPayload, as: User.self, in: context)
+        try await context.sync(payload: seedPayload, as: User.self)
 
         let diffPayload: [Any] = [
             ["id": 0, "full_name": "User 0 Updated"],
             ["id": 1, "full_name": "User 1 Updated"],
             ["id": 6, "full_name": "User 6 New"],
         ]
-        try await SwiftSync.sync(payload: diffPayload, as: User.self, in: context)
+        try await context.sync(payload: diffPayload, as: User.self)
 
         let users = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(users.count, 3)
@@ -1831,7 +1816,7 @@ final class SyncTests: XCTestCase {
 
         let payload: [Any] = [["id": 1, "full_name": "single"]]
         do {
-            try await SwiftSync.sync(payload: payload, as: LooseUser.self, in: context)
+            try await context.sync(payload: payload, as: LooseUser.self)
         } catch {
             XCTFail("Expected sync to dedupe local duplicates without crashing, got error: \(error)")
         }
@@ -1850,10 +1835,10 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         let payloadA: [Any] = [["xid": "abc", "name": "v1"]]
-        try await SwiftSync.sync(payload: payloadA, as: ExternalUser.self, in: context)
+        try await context.sync(payload: payloadA, as: ExternalUser.self)
 
         let payloadB: [Any] = [["xid": "abc", "name": "v2"]]
-        try await SwiftSync.sync(payload: payloadB, as: ExternalUser.self, in: context)
+        try await context.sync(payload: payloadB, as: ExternalUser.self)
 
         let rows = try context.fetch(FetchDescriptor<ExternalUser>())
         XCTAssertEqual(rows.count, 1)
@@ -1868,10 +1853,10 @@ final class SyncTests: XCTestCase {
         let context = ModelContext(container)
 
         let payloadA: [Any] = [["external_id": "abc", "name": "v1"]]
-        try await SwiftSync.sync(payload: payloadA, as: ExternalMappedUser.self, in: context)
+        try await context.sync(payload: payloadA, as: ExternalMappedUser.self)
 
         let payloadB: [Any] = [["external_id": "abc", "name": "v2"]]
-        try await SwiftSync.sync(payload: payloadB, as: ExternalMappedUser.self, in: context)
+        try await context.sync(payload: payloadB, as: ExternalMappedUser.self)
 
         let rows = try context.fetch(FetchDescriptor<ExternalMappedUser>())
         XCTAssertEqual(rows.count, 1)
@@ -1889,7 +1874,7 @@ final class SyncTests: XCTestCase {
             ["id": 1, "full_name": "One"],
             ["id": 2, "full_name": "Two"],
         ]
-        try await SwiftSync.sync(payload: seedPayload, as: User.self, in: context)
+        try await context.sync(payload: seedPayload, as: User.self)
 
         let mixedPayload: [Any] = [
             ["id": NSNull(), "full_name": "Null ID"],
@@ -1898,7 +1883,7 @@ final class SyncTests: XCTestCase {
         ]
 
         do {
-            try await SwiftSync.sync(payload: mixedPayload, as: User.self, in: context)
+            try await context.sync(payload: mixedPayload, as: User.self)
         } catch {
             XCTFail("Expected sync to skip invalid identity rows, got error: \(error)")
         }
@@ -1926,7 +1911,7 @@ final class SyncTests: XCTestCase {
                 ],
             ]
         ]
-        try await SwiftSync.sync(payload: seedPayload, as: Team.self, in: context)
+        try await context.sync(payload: seedPayload, as: Team.self)
 
         let updatePayload: [Any] = [
             [
@@ -1939,7 +1924,7 @@ final class SyncTests: XCTestCase {
                 ],
             ]
         ]
-        try await SwiftSync.sync(payload: updatePayload, as: Team.self, in: context)
+        try await context.sync(payload: updatePayload, as: Team.self)
 
         let teams = try context.fetch(FetchDescriptor<Team>())
         XCTAssertEqual(teams.count, 1)
@@ -1965,7 +1950,7 @@ final class SyncTests: XCTestCase {
                 ],
             ]
         ]
-        try await SwiftSync.sync(payload: seedPayload, as: Team.self, in: context)
+        try await context.sync(payload: seedPayload, as: Team.self)
 
         let clearPayload: [Any] = [
             [
@@ -1975,7 +1960,7 @@ final class SyncTests: XCTestCase {
                 "members": [],
             ]
         ]
-        try await SwiftSync.sync(payload: clearPayload, as: Team.self, in: context)
+        try await context.sync(payload: clearPayload, as: Team.self)
 
         let teams = try context.fetch(FetchDescriptor<Team>())
         XCTAssertEqual(teams.count, 1)
@@ -1999,7 +1984,7 @@ final class SyncTests: XCTestCase {
                 ],
             ]
         ]
-        try await SwiftSync.sync(payload: seedPayload, as: UserTagsByObjects.self, in: context)
+        try await context.sync(payload: seedPayload, as: UserTagsByObjects.self)
 
         let clearPayload: [Any] = [
             [
@@ -2008,7 +1993,7 @@ final class SyncTests: XCTestCase {
                 "tags": [],
             ]
         ]
-        try await SwiftSync.sync(payload: clearPayload, as: UserTagsByObjects.self, in: context)
+        try await context.sync(payload: clearPayload, as: UserTagsByObjects.self)
 
         let users = try context.fetch(FetchDescriptor<UserTagsByObjects>())
         XCTAssertEqual(users.count, 1)
@@ -2021,7 +2006,7 @@ final class SyncTests: XCTestCase {
         let configurationA = ModelConfiguration(isStoredInMemoryOnly: true)
         let containerA = try ModelContainer(for: UserTagsByObjects.self, Tag.self, configurations: configurationA)
         let contextA = ModelContext(containerA)
-        try await SwiftSync.sync(
+        try await contextA.sync(
             payload: [
                 [
                     "id": 1,
@@ -2031,28 +2016,22 @@ final class SyncTests: XCTestCase {
                         ["id": 11, "name": "t11"],
                     ],
                 ]
-            ],
-            as: UserTagsByObjects.self,
-            in: contextA
-        )
-        try await SwiftSync.sync(
+            ], as: UserTagsByObjects.self)
+        try await contextA.sync(
             payload: [
                 [
                     "id": 1,
                     "name": "U1",
                     "tags": [],
                 ]
-            ],
-            as: UserTagsByObjects.self,
-            in: contextA
-        )
+            ], as: UserTagsByObjects.self)
         let usersA = try contextA.fetch(FetchDescriptor<UserTagsByObjects>())
 
         // Snapshot B: clear with null.
         let configurationB = ModelConfiguration(isStoredInMemoryOnly: true)
         let containerB = try ModelContainer(for: UserTagsByObjects.self, Tag.self, configurations: configurationB)
         let contextB = ModelContext(containerB)
-        try await SwiftSync.sync(
+        try await contextB.sync(
             payload: [
                 [
                     "id": 1,
@@ -2062,22 +2041,16 @@ final class SyncTests: XCTestCase {
                         ["id": 11, "name": "t11"],
                     ],
                 ]
-            ],
-            as: UserTagsByObjects.self,
-            in: contextB
-        )
+            ], as: UserTagsByObjects.self)
         do {
-            try await SwiftSync.sync(
+            try await contextB.sync(
                 payload: [
                     [
                         "id": 1,
                         "name": "U1",
                         "tags": NSNull(),
                     ]
-                ],
-                as: UserTagsByObjects.self,
-                in: contextB
-            )
+                ], as: UserTagsByObjects.self)
         } catch {
             XCTFail("Expected null to clear to-many relationship without crashing, got error: \(error)")
         }
@@ -2107,7 +2080,7 @@ final class SyncTests: XCTestCase {
                 ],
             ]
         ]
-        try await SwiftSync.sync(payload: seedPayload, as: Team.self, in: context)
+        try await context.sync(payload: seedPayload, as: Team.self)
 
         let nameOnlyPayload: [Any] = [
             [
@@ -2115,7 +2088,7 @@ final class SyncTests: XCTestCase {
                 "name": "Platform Renamed",
             ]
         ]
-        try await SwiftSync.sync(payload: nameOnlyPayload, as: Team.self, in: context)
+        try await context.sync(payload: nameOnlyPayload, as: Team.self)
 
         let teams = try context.fetch(FetchDescriptor<Team>())
         XCTAssertEqual(teams.count, 1)
@@ -2130,17 +2103,9 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: Employee.self, Company.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "name": "Apple"]],
-            as: Company.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "name": "Apple"]], as: Company.self)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava"]],
-            as: Employee.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 1, "name": "Ava"]], as: Employee.self)
 
         let linkPayload: [Any] = [
             [
@@ -2149,7 +2114,7 @@ final class SyncTests: XCTestCase {
                 "company_id": 10,
             ]
         ]
-        try await SwiftSync.sync(payload: linkPayload, as: Employee.self, in: context)
+        try await context.sync(payload: linkPayload, as: Employee.self)
 
         var employees = try context.fetch(FetchDescriptor<Employee>())
         XCTAssertEqual(employees.count, 1)
@@ -2163,7 +2128,7 @@ final class SyncTests: XCTestCase {
                 "company_id": NSNull(),
             ]
         ]
-        try await SwiftSync.sync(payload: clearPayload, as: Employee.self, in: context)
+        try await context.sync(payload: clearPayload, as: Employee.self)
 
         employees = try context.fetch(FetchDescriptor<Employee>())
         XCTAssertEqual(employees.count, 1)
@@ -2176,11 +2141,7 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: Employee.self, Company.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava"]],
-            as: Employee.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 1, "name": "Ava"]], as: Employee.self)
 
         let missingReferencePayload: [Any] = [
             [
@@ -2190,7 +2151,7 @@ final class SyncTests: XCTestCase {
             ]
         ]
         do {
-            try await SwiftSync.sync(payload: missingReferencePayload, as: Employee.self, in: context)
+            try await context.sync(payload: missingReferencePayload, as: Employee.self)
         } catch {
             XCTFail("Expected missing referenced company to be handled without crashing, got error: \(error)")
         }
@@ -2206,90 +2167,67 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: AutoEmployee.self, AutoCompany.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "name": "Acme"]],
-            as: AutoCompany.self,
-            in: context
-        )
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava"]],
-            as: AutoEmployee.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "name": "Acme"]], as: AutoCompany.self)
+        try await context.sync(payload: [["id": 1, "name": "Ava"]], as: AutoEmployee.self)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "name": "Ava",
                     "company_id": 10,
                 ]
-            ],
-            as: AutoEmployee.self,
-            in: context
-        )
+            ], as: AutoEmployee.self)
 
         var employees = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertEqual(employees.count, 1)
         XCTAssertEqual(employees[0].company?.id, 10)
 
         // Strict FK typing: string payload for Int FK should be ignored.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "name": "Ava",
                     "company_id": "10",
                 ]
-            ],
-            as: AutoEmployee.self,
-            in: context
-        )
+            ], as: AutoEmployee.self)
         employees = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertEqual(employees[0].company?.id, 10)
 
         // Missing key should not clear existing relationship.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "name": "Ava Updated",
                 ]
-            ],
-            as: AutoEmployee.self,
-            in: context
-        )
+            ], as: AutoEmployee.self)
         employees = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertEqual(employees[0].name, "Ava Updated")
         XCTAssertEqual(employees[0].company?.id, 10)
 
         // Unknown FK keeps current relation unchanged.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "name": "Ava Updated",
                     "company_id": 999,
                 ]
-            ],
-            as: AutoEmployee.self,
-            in: context
-        )
+            ], as: AutoEmployee.self)
         employees = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertEqual(employees[0].company?.id, 10)
 
         // Explicit null clears relation.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
                     "name": "Ava Updated",
                     "company_id": NSNull(),
                 ]
-            ],
-            as: AutoEmployee.self,
-            in: context
-        )
+            ], as: AutoEmployee.self)
         employees = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertNil(employees[0].company)
     }
@@ -2310,7 +2248,7 @@ final class SyncTests: XCTestCase {
                 ],
             ]
         ]
-        try await SwiftSync.sync(payload: payloadA, as: Team.self, in: context)
+        try await context.sync(payload: payloadA, as: Team.self)
 
         var teams = try context.fetch(FetchDescriptor<Team>())
         XCTAssertEqual(teams.count, 1)
@@ -2326,7 +2264,7 @@ final class SyncTests: XCTestCase {
                 ],
             ]
         ]
-        try await SwiftSync.sync(payload: payloadB, as: Team.self, in: context)
+        try await context.sync(payload: payloadB, as: Team.self)
 
         teams = try context.fetch(FetchDescriptor<Team>())
         XCTAssertEqual(teams.count, 1)
@@ -2344,21 +2282,14 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: UserWithNotes.self, Note.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 0, "text": "n0"],
                 ["id": 1, "text": "n1"],
                 ["id": 2, "text": "n2"],
-            ],
-            as: Note.self,
-            in: context
-        )
+            ], as: Note.self)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "name": "U"]],
-            as: UserWithNotes.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "name": "U"]], as: UserWithNotes.self)
 
         let payloadA: [Any] = [
             [
@@ -2367,7 +2298,7 @@ final class SyncTests: XCTestCase {
                 "notes_ids": [0, 1],
             ]
         ]
-        try await SwiftSync.sync(payload: payloadA, as: UserWithNotes.self, in: context)
+        try await context.sync(payload: payloadA, as: UserWithNotes.self)
 
         var users = try context.fetch(FetchDescriptor<UserWithNotes>())
         XCTAssertEqual(users.count, 1)
@@ -2380,7 +2311,7 @@ final class SyncTests: XCTestCase {
                 "notes_ids": [1, 2],
             ]
         ]
-        try await SwiftSync.sync(payload: payloadB, as: UserWithNotes.self, in: context)
+        try await context.sync(payload: payloadB, as: UserWithNotes.self)
 
         users = try context.fetch(FetchDescriptor<UserWithNotes>())
         XCTAssertEqual(users.count, 1)
@@ -2394,58 +2325,46 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: AutoTask.self, AutoTag.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "name": "Tag 1"],
                 ["id": 2, "name": "Tag 2"],
-            ],
-            as: AutoTag.self,
-            in: context
-        )
+            ], as: AutoTag.self)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 5,
                     "title": "Task A",
                     "tag_ids": [1, 2, 2, 999],
                 ]
-            ],
-            as: AutoTask.self,
-            in: context
-        )
+            ], as: AutoTask.self)
 
         var tasks = try context.fetch(FetchDescriptor<AutoTask>())
         XCTAssertEqual(tasks.count, 1)
         XCTAssertEqual(Set(tasks[0].tags.map(\.id)), Set([1, 2]))
 
         // Missing key should preserve current to-many links.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 5,
                     "title": "Task A Updated",
                 ]
-            ],
-            as: AutoTask.self,
-            in: context
-        )
+            ], as: AutoTask.self)
         tasks = try context.fetch(FetchDescriptor<AutoTask>())
         XCTAssertEqual(tasks[0].title, "Task A Updated")
         XCTAssertEqual(Set(tasks[0].tags.map(\.id)), Set([1, 2]))
 
         // Explicit null clears links.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 5,
                     "title": "Task A Updated",
                     "tag_ids": NSNull(),
                 ]
-            ],
-            as: AutoTask.self,
-            in: context
-        )
+            ], as: AutoTask.self)
         tasks = try context.fetch(FetchDescriptor<AutoTask>())
         XCTAssertEqual(tasks[0].tags.count, 0)
     }
@@ -2457,7 +2376,7 @@ final class SyncTests: XCTestCase {
             for: AutoNestedTeam.self, AutoNestedMember.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
@@ -2468,17 +2387,14 @@ final class SyncTests: XCTestCase {
                         ["id": 2, "full_name": "Member Two"],
                     ],
                 ]
-            ],
-            as: AutoNestedTeam.self,
-            in: context
-        )
+            ], as: AutoNestedTeam.self)
 
         var teams = try context.fetch(FetchDescriptor<AutoNestedTeam>())
         XCTAssertEqual(teams.count, 1)
         XCTAssertEqual(teams[0].owner?.id, 1)
         XCTAssertEqual(Set(teams[0].members.map(\.id)), Set([1, 2]))
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
@@ -2489,10 +2405,7 @@ final class SyncTests: XCTestCase {
                         ["id": 3, "full_name": "Member Three"],
                     ],
                 ]
-            ],
-            as: AutoNestedTeam.self,
-            in: context
-        )
+            ], as: AutoNestedTeam.self)
 
         teams = try context.fetch(FetchDescriptor<AutoNestedTeam>())
         XCTAssertEqual(teams[0].name, "Team v2")
@@ -2502,7 +2415,7 @@ final class SyncTests: XCTestCase {
         let allMembers = try context.fetch(FetchDescriptor<AutoNestedMember>())
         XCTAssertEqual(allMembers.first(where: { $0.id == 2 })?.fullName, "Member Two Updated")
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 10,
@@ -2510,10 +2423,7 @@ final class SyncTests: XCTestCase {
                     "owner": NSNull(),
                     "members": NSNull(),
                 ]
-            ],
-            as: AutoNestedTeam.self,
-            in: context
-        )
+            ], as: AutoNestedTeam.self)
 
         teams = try context.fetch(FetchDescriptor<AutoNestedTeam>())
         XCTAssertNil(teams[0].owner)
@@ -2526,19 +2436,12 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: UserWithNotes.self, Note.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "n1"],
                 ["id": 2, "text": "n2"],
-            ],
-            as: Note.self,
-            in: context
-        )
-        try await SwiftSync.sync(
-            payload: [["id": 10, "name": "U"]],
-            as: UserWithNotes.self,
-            in: context
-        )
+            ], as: Note.self)
+        try await context.sync(payload: [["id": 10, "name": "U"]], as: UserWithNotes.self)
 
         let payloadB: [Any] = [
             [
@@ -2547,8 +2450,8 @@ final class SyncTests: XCTestCase {
                 "notes_ids": [1, 2],
             ]
         ]
-        try await SwiftSync.sync(payload: payloadB, as: UserWithNotes.self, in: context)
-        try await SwiftSync.sync(payload: payloadB, as: UserWithNotes.self, in: context)
+        try await context.sync(payload: payloadB, as: UserWithNotes.self)
+        try await context.sync(payload: payloadB, as: UserWithNotes.self)
 
         let users = try context.fetch(FetchDescriptor<UserWithNotes>())
         XCTAssertEqual(users.count, 1)
@@ -2601,13 +2504,8 @@ final class SyncTests: XCTestCase {
             ["id": 0, "text": "n0"],
             ["id": 1, "text": "n1"],
         ]
-        try await SwiftSync.sync(
-            payload: childPayload,
-            as: SuperNote.self,
-            in: context,
-            parent: userA,
-            relationship: \SuperNote.superUser
-        )
+        try await context.sync(
+            payload: childPayload, as: SuperNote.self, parent: userA, relationship: \SuperNote.superUser)
 
         let notes = try context.fetch(FetchDescriptor<SuperNote>())
         XCTAssertEqual(notes.count, 2)
@@ -2627,37 +2525,22 @@ final class SyncTests: XCTestCase {
         context.insert(userB)
         try context.save()
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 0, "text": "a0"],
                 ["id": 1, "text": "a1"],
-            ],
-            as: SuperNote.self,
-            in: context,
-            parent: userA,
-            relationship: \SuperNote.superUser
-        )
-        try await SwiftSync.sync(
+            ], as: SuperNote.self, parent: userA, relationship: \SuperNote.superUser)
+        try await context.sync(
             payload: [
                 ["id": 2, "text": "b2"],
                 ["id": 3, "text": "b3"],
-            ],
-            as: SuperNote.self,
-            in: context,
-            parent: userB,
-            relationship: \SuperNote.superUser
-        )
+            ], as: SuperNote.self, parent: userB, relationship: \SuperNote.superUser)
 
         // Sync user A scope with one child; user B scope must remain untouched.
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "a1-updated"]
-            ],
-            as: SuperNote.self,
-            in: context,
-            parent: userA,
-            relationship: \SuperNote.superUser
-        )
+            ], as: SuperNote.self, parent: userA, relationship: \SuperNote.superUser)
 
         let notes = try context.fetch(FetchDescriptor<SuperNote>())
         let notesA = notes.filter { $0.superUser?.id == 6 }
@@ -2680,13 +2563,9 @@ final class SyncTests: XCTestCase {
 
         var capturedError: Error?
         do {
-            try await SwiftSync.sync(
-                payload: [["id": 1001, "text": "cross-context-child"]],
-                as: SuperNote.self,
-                in: contextB,
-                parent: userFromContextA,
-                relationship: \SuperNote.superUser
-            )
+            try await contextB.sync(
+                payload: [["id": 1001, "text": "cross-context-child"]], as: SuperNote.self, parent: userFromContextA,
+                relationship: \SuperNote.superUser)
         } catch {
             capturedError = error
         }
@@ -2720,35 +2599,20 @@ final class SyncTests: XCTestCase {
         context.insert(taskB)
         try context.save()
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "A-1"],
                 ["id": 2, "text": "A-2"],
-            ],
-            as: InferredComment.self,
-            in: context,
-            parent: taskA,
-            relationship: \InferredComment.task
-        )
-        try await SwiftSync.sync(
+            ], as: InferredComment.self, parent: taskA, relationship: \InferredComment.task)
+        try await context.sync(
             payload: [
                 ["id": 3, "text": "B-3"]
-            ],
-            as: InferredComment.self,
-            in: context,
-            parent: taskB,
-            relationship: \InferredComment.task
-        )
+            ], as: InferredComment.self, parent: taskB, relationship: \InferredComment.task)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "A-1 Updated"]
-            ],
-            as: InferredComment.self,
-            in: context,
-            parent: taskA,
-            relationship: \InferredComment.task
-        )
+            ], as: InferredComment.self, parent: taskA, relationship: \InferredComment.task)
 
         let rows = try context.fetch(FetchDescriptor<InferredComment>())
         XCTAssertEqual(Set(rows.filter { $0.task?.id == 1 }.map(\.id)), Set([1]))
@@ -2780,7 +2644,7 @@ final class SyncTests: XCTestCase {
                 ],
             ],
         ]
-        try await SwiftSync.sync(payload: payloadA, as: UserTagsByObjects.self, in: context)
+        try await context.sync(payload: payloadA, as: UserTagsByObjects.self)
 
         let payloadB: [Any] = [
             [
@@ -2799,7 +2663,7 @@ final class SyncTests: XCTestCase {
                 ],
             ],
         ]
-        try await SwiftSync.sync(payload: payloadB, as: UserTagsByObjects.self, in: context)
+        try await context.sync(payload: payloadB, as: UserTagsByObjects.self)
 
         let users = try context.fetch(FetchDescriptor<UserTagsByObjects>())
         return Dictionary(uniqueKeysWithValues: users.map { ($0.id, Set($0.tags.map(\.id))) })
@@ -2811,28 +2675,25 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: UserTagsByIDs.self, Tag.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "name": "t1"],
                 ["id": 2, "name": "t2"],
                 ["id": 3, "name": "t3"],
                 ["id": 4, "name": "t4"],
-            ],
-            as: Tag.self,
-            in: context
-        )
+            ], as: Tag.self)
 
         let payloadA: [Any] = [
             ["id": 1, "name": "U1", "tags_ids": [1, 2]],
             ["id": 2, "name": "U2", "tags_ids": [2, 3]],
         ]
-        try await SwiftSync.sync(payload: payloadA, as: UserTagsByIDs.self, in: context)
+        try await context.sync(payload: payloadA, as: UserTagsByIDs.self)
 
         let payloadB: [Any] = [
             ["id": 1, "name": "U1", "tags_ids": [2, 4]],
             ["id": 2, "name": "U2", "tags_ids": [3]],
         ]
-        try await SwiftSync.sync(payload: payloadB, as: UserTagsByIDs.self, in: context)
+        try await context.sync(payload: payloadB, as: UserTagsByIDs.self)
 
         let users = try context.fetch(FetchDescriptor<UserTagsByIDs>())
         return Dictionary(uniqueKeysWithValues: users.map { ($0.id, Set($0.tags.map(\.id))) })
@@ -2859,7 +2720,7 @@ final class SyncTests: XCTestCase {
                 ["id": 1, "full_name": "Refresh User"],
                 ["id": 99, "full_name": "Refresh Insert"],
             ]
-            try await SwiftSync.sync(payload: payload, as: ConcurrentRaceUser.self, in: context)
+            try await context.sync(payload: payload, as: ConcurrentRaceUser.self)
         }
         await ConcurrentRaceHooks.shared.waitUntilFirstSyncBlocked()
 
@@ -2868,7 +2729,7 @@ final class SyncTests: XCTestCase {
                 ["id": 1, "full_name": "Websocket User"],
                 ["id": 99, "full_name": "Websocket Winner"],
             ]
-            try await SwiftSync.sync(payload: payload, as: ConcurrentRaceUser.self, in: context)
+            try await context.sync(payload: payload, as: ConcurrentRaceUser.self)
         }
 
         await ConcurrentRaceHooks.shared.releaseFirstSync()
@@ -2890,20 +2751,14 @@ final class SyncTests: XCTestCase {
         let readerContext = ModelContext(container)
 
         let foregroundTask = Task { @MainActor in
-            try await SwiftSync.sync(
-                payload: [["id": 500, "full_name": "Foreground Winner"]],
-                as: DifferentContextConflictUser.self,
-                in: foregroundContext
-            )
+            try await foregroundContext.sync(
+                payload: [["id": 500, "full_name": "Foreground Winner"]], as: DifferentContextConflictUser.self)
         }
 
         await Task.yield()
         let backgroundTask = Task { @MainActor in
-            try await SwiftSync.sync(
-                payload: [["id": 500, "full_name": "Background Winner"]],
-                as: DifferentContextConflictUser.self,
-                in: backgroundContext
-            )
+            try await backgroundContext.sync(
+                payload: [["id": 500, "full_name": "Background Winner"]], as: DifferentContextConflictUser.self)
         }
 
         try await foregroundTask.value
@@ -2923,24 +2778,17 @@ final class SyncTests: XCTestCase {
         let resetContext = ModelContext(container)
         let readerContext = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "full_name": "Seed User"]],
-            as: ConcurrentRaceUser.self,
-            in: syncContext
-        )
+        try await syncContext.sync(payload: [["id": 1, "full_name": "Seed User"]], as: ConcurrentRaceUser.self)
 
         await ConcurrentRaceHooks.shared.installFirstSyncBlocker()
         defer { Task { await ConcurrentRaceHooks.shared.releaseFirstSync() } }
 
         let syncTask = Task { @MainActor in
-            try await SwiftSync.sync(
+            try await syncContext.sync(
                 payload: [
                     ["id": 1, "full_name": "Post Reset User"],
                     ["id": 2, "full_name": "Inserted During Sync"],
-                ],
-                as: ConcurrentRaceUser.self,
-                in: syncContext
-            )
+                ], as: ConcurrentRaceUser.self)
         }
 
         await ConcurrentRaceHooks.shared.waitUntilFirstSyncBlocked()
@@ -2968,22 +2816,14 @@ final class SyncTests: XCTestCase {
         let backgroundContext = ModelContext(container)
         let readerContext = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "full_name": "Initial Name"]],
-            as: User.self,
-            in: mainContext
-        )
+        try await mainContext.sync(payload: [["id": 1, "full_name": "Initial Name"]], as: User.self)
 
         let firstMainRead = try mainContext.fetch(FetchDescriptor<User>())
         XCTAssertEqual(firstMainRead.count, 1)
         XCTAssertEqual(firstMainRead.first?.fullName, "Initial Name")
         let retainedMainRow = try XCTUnwrap(firstMainRead.first)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "full_name": "Background Updated"]],
-            as: User.self,
-            in: backgroundContext
-        )
+        try await backgroundContext.sync(payload: [["id": 1, "full_name": "Background Updated"]], as: User.self)
 
         XCTAssertEqual(retainedMainRow.fullName, "Initial Name")
 
@@ -3000,11 +2840,7 @@ final class SyncTests: XCTestCase {
         let syncContainer = try SyncContainer(for: User.self, configurations: configuration)
         let writerContext = ModelContext(syncContainer.modelContainer)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "full_name": "From SyncContainer"]],
-            as: User.self,
-            in: writerContext
-        )
+        try await writerContext.sync(payload: [["id": 10, "full_name": "From SyncContainer"]], as: User.self)
 
         let rows = try syncContainer.mainContext.fetch(FetchDescriptor<User>())
         XCTAssertEqual(rows.count, 1)
@@ -3267,7 +3103,7 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: RemoteKeyPathContactRecord.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 [
                     "id": 1,
@@ -3277,10 +3113,7 @@ final class SyncTests: XCTestCase {
                         ]
                     ],
                 ]
-            ],
-            as: RemoteKeyPathContactRecord.self,
-            in: context
-        )
+            ], as: RemoteKeyPathContactRecord.self)
 
         let rows = try context.fetch(FetchDescriptor<RemoteKeyPathContactRecord>())
         XCTAssertEqual(rows.count, 1)
@@ -3294,21 +3127,13 @@ final class SyncTests: XCTestCase {
         let mainContext = syncContainer.mainContext
         let backgroundContext = ModelContext(syncContainer.modelContainer)
 
-        try await SwiftSync.sync(
-            payload: [["id": 11, "full_name": "Main Seed"]],
-            as: User.self,
-            in: backgroundContext
-        )
+        try await backgroundContext.sync(payload: [["id": 11, "full_name": "Main Seed"]], as: User.self)
 
         let firstMainRead = try mainContext.fetch(FetchDescriptor<User>())
         let retainedMainRow = try XCTUnwrap(firstMainRead.first)
         XCTAssertEqual(retainedMainRow.fullName, "Main Seed")
 
-        try await SwiftSync.sync(
-            payload: [["id": 11, "full_name": "Background Write"]],
-            as: User.self,
-            in: backgroundContext
-        )
+        try await backgroundContext.sync(payload: [["id": 11, "full_name": "Background Write"]], as: User.self)
 
         XCTAssertEqual(retainedMainRow.fullName, "Main Seed")
 
@@ -3406,24 +3231,17 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: ConcurrentRaceUser.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "full_name": "Seed User"]],
-            as: ConcurrentRaceUser.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 1, "full_name": "Seed User"]], as: ConcurrentRaceUser.self)
 
         await ConcurrentRaceHooks.shared.installFirstSyncBlocker()
         defer { Task { await ConcurrentRaceHooks.shared.releaseFirstSync() } }
 
         let syncTask = Task { @MainActor in
-            try await SwiftSync.sync(
+            try await context.sync(
                 payload: [
                     ["id": 1, "full_name": "Updated User"],
                     ["id": 2, "full_name": "Should Rollback"],
-                ],
-                as: ConcurrentRaceUser.self,
-                in: context
-            )
+                ], as: ConcurrentRaceUser.self)
         }
 
         await ConcurrentRaceHooks.shared.waitUntilFirstSyncBlocked()
@@ -3452,11 +3270,7 @@ final class SyncTests: XCTestCase {
 
         let task = Task { @MainActor in
             await gate.wait()
-            try await SwiftSync.sync(
-                payload: [["id": 1, "full_name": "Cancelled Before Sync"]],
-                as: User.self,
-                in: context
-            )
+            try await context.sync(payload: [["id": 1, "full_name": "Cancelled Before Sync"]], as: User.self)
         }
         task.cancel()
         await gate.release()
@@ -3478,20 +3292,13 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: User.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "full_name": "One"],
                 ["id": 2, "full_name": "Two"],
-            ],
-            as: User.self,
-            in: context
-        )
+            ], as: User.self)
 
-        try await SwiftSync.sync(
-            item: ["id": 1, "full_name": "One Updated"],
-            as: User.self,
-            in: context
-        )
+        try await context.sync(item: ["id": 1, "full_name": "One Updated"], as: User.self)
 
         let rows = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(rows.count, 2)
@@ -3505,17 +3312,9 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: User.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "full_name": "One"]],
-            as: User.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 1, "full_name": "One"]], as: User.self)
 
-        try await SwiftSync.sync(
-            item: ["id": 2, "full_name": "Two"],
-            as: User.self,
-            in: context
-        )
+        try await context.sync(item: ["id": 2, "full_name": "Two"], as: User.self)
 
         let rows = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(rows.count, 2)
@@ -3529,21 +3328,14 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: User.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "full_name": "One"],
                 ["id": 2, "full_name": "Two"],
-            ],
-            as: User.self,
-            in: context
-        )
+            ], as: User.self)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 1, "full_name": "One Updated"],
-                as: User.self,
-                in: context
-            )
+            try await context.sync(item: ["id": 1, "full_name": "One Updated"], as: User.self)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["fetch-existing-by-identity"])
@@ -3557,21 +3349,14 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: LooseUser.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "full_name": "One"],
                 ["id": 2, "full_name": "Two"],
-            ],
-            as: LooseUser.self,
-            in: context
-        )
+            ], as: LooseUser.self)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 1, "full_name": "One Updated"],
-                as: LooseUser.self,
-                in: context
-            )
+            try await context.sync(item: ["id": 1, "full_name": "One Updated"], as: LooseUser.self)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["fetch-existing"])
@@ -3585,21 +3370,14 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: Team.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "name": "One"],
                 ["id": 2, "name": "Two"],
-            ],
-            as: Team.self,
-            in: context
-        )
+            ], as: Team.self)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 1, "name": "One Updated"],
-                as: Team.self,
-                in: context
-            )
+            try await context.sync(item: ["id": 1, "name": "One Updated"], as: Team.self)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["fetch-existing"])
@@ -3619,36 +3397,21 @@ final class SyncTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "name": "Acme"]],
-            as: AutoCompany.self,
-            in: context
-        )
-        try await SwiftSync.sync(
+        try await context.sync(payload: [["id": 10, "name": "Acme"]], as: AutoCompany.self)
+        try await context.sync(
             payload: [
                 ["id": 1, "name": "Tag 1"],
                 ["id": 2, "name": "Tag 2"],
-            ],
-            as: AutoTag.self,
-            in: context
-        )
+            ], as: AutoTag.self)
 
         let (_, toOneProfile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 1, "name": "Ava", "company_id": 10],
-                as: AutoEmployee.self,
-                in: context
-            )
+            try await context.sync(item: ["id": 1, "name": "Ava", "company_id": 10], as: AutoEmployee.self)
         }
 
         XCTAssertNotNil(toOneProfile.totalsByPhase["relationship-apply-to-one-foreign-key"])
 
         let (_, toManyProfile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 10, "title": "Task 10", "tag_ids": [1, 2]],
-                as: AutoTask.self,
-                in: context
-            )
+            try await context.sync(item: ["id": 10, "title": "Task 10", "tag_ids": [1, 2]], as: AutoTask.self)
         }
 
         XCTAssertNotNil(toManyProfile.totalsByPhase["relationship-apply-to-many-foreign-keys"])
@@ -3664,21 +3427,14 @@ final class SyncTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 10, "name": "Acme"],
                 ["id": 11, "name": "Globex"],
-            ],
-            as: AutoCompany.self,
-            in: context
-        )
+            ], as: AutoCompany.self)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 1, "name": "Ava", "company_id": 10],
-                as: AutoEmployee.self,
-                in: context
-            )
+            try await context.sync(item: ["id": 1, "name": "Ava", "company_id": 10], as: AutoEmployee.self)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["relationship-fetch-by-identity"])
@@ -3695,22 +3451,15 @@ final class SyncTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "name": "Tag 1"],
                 ["id": 2, "name": "Tag 2"],
                 ["id": 3, "name": "Tag 3"],
-            ],
-            as: ScenarioTag.self,
-            in: context
-        )
+            ], as: ScenarioTag.self)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 10, "title": "Task 10", "tag_ids": [1, 2]],
-                as: ScenarioTask.self,
-                in: context
-            )
+            try await context.sync(item: ["id": 10, "title": "Task 10", "tag_ids": [1, 2]], as: ScenarioTask.self)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["relationship-fetch-by-identity"])
@@ -3727,21 +3476,14 @@ final class SyncTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "name": "Tag 1"],
                 ["id": 2, "name": "Tag 2"],
-            ],
-            as: AutoTag.self,
-            in: context
-        )
+            ], as: AutoTag.self)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 10, "title": "Task 10", "tag_ids": [1, 2]],
-                as: AutoTask.self,
-                in: context
-            )
+            try await context.sync(item: ["id": 10, "title": "Task 10", "tag_ids": [1, 2]], as: AutoTask.self)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["relationship-fetch"])
@@ -3758,28 +3500,18 @@ final class SyncTests: XCTestCase {
         context.insert(folder)
         try context.save()
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "First"],
                 ["id": 2, "text": "Second"],
-            ],
-            as: MacroScopedNote.self,
-            in: context,
-            parent: folder,
-            relationship: \MacroScopedNote.folder
-        )
+            ], as: MacroScopedNote.self, parent: folder, relationship: \MacroScopedNote.folder)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
+            try await context.sync(
                 payload: [
                     ["id": 1, "text": "First Updated"],
                     ["id": 2, "text": "Second Updated"],
-                ],
-                as: MacroScopedNote.self,
-                in: context,
-                parent: folder,
-                relationship: \MacroScopedNote.folder
-            )
+                ], as: MacroScopedNote.self, parent: folder, relationship: \MacroScopedNote.folder)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["fetch-existing-by-parent"])
@@ -3796,28 +3528,18 @@ final class SyncTests: XCTestCase {
         context.insert(parent)
         try context.save()
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "First"],
                 ["id": 2, "text": "Second"],
-            ],
-            as: SuperNote.self,
-            in: context,
-            parent: parent,
-            relationship: \SuperNote.superUser
-        )
+            ], as: SuperNote.self, parent: parent, relationship: \SuperNote.superUser)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
+            try await context.sync(
                 payload: [
                     ["id": 1, "text": "First Updated"],
                     ["id": 2, "text": "Second Updated"],
-                ],
-                as: SuperNote.self,
-                in: context,
-                parent: parent,
-                relationship: \SuperNote.superUser
-            )
+                ], as: SuperNote.self, parent: parent, relationship: \SuperNote.superUser)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["fetch-existing"])
@@ -3834,24 +3556,15 @@ final class SyncTests: XCTestCase {
         context.insert(parent)
         try context.save()
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "First"],
                 ["id": 2, "text": "Second"],
-            ],
-            as: SuperNote.self,
-            in: context,
-            parent: parent,
-            relationship: \SuperNote.superUser
-        )
+            ], as: SuperNote.self, parent: parent, relationship: \SuperNote.superUser)
 
-        try await SwiftSync.sync(
-            item: ["id": 1, "text": "First Updated"],
-            as: SuperNote.self,
-            in: context,
-            parent: parent,
-            relationship: \SuperNote.superUser
-        )
+        try await context.sync(
+            item: ["id": 1, "text": "First Updated"], as: SuperNote.self, parent: parent,
+            relationship: \SuperNote.superUser)
 
         let notes = try context.fetch(FetchDescriptor<SuperNote>())
             .filter { $0.superUser?.persistentModelID == parent.persistentModelID }
@@ -3869,25 +3582,16 @@ final class SyncTests: XCTestCase {
         context.insert(folder)
         try context.save()
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "First"],
                 ["id": 2, "text": "Second"],
-            ],
-            as: MacroScopedNote.self,
-            in: context,
-            parent: folder,
-            relationship: \MacroScopedNote.folder
-        )
+            ], as: MacroScopedNote.self, parent: folder, relationship: \MacroScopedNote.folder)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 1, "text": "First Updated"],
-                as: MacroScopedNote.self,
-                in: context,
-                parent: folder,
-                relationship: \MacroScopedNote.folder
-            )
+            try await context.sync(
+                item: ["id": 1, "text": "First Updated"], as: MacroScopedNote.self, parent: folder,
+                relationship: \MacroScopedNote.folder)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["fetch-existing-by-identity"])
@@ -3905,25 +3609,16 @@ final class SyncTests: XCTestCase {
         context.insert(parent)
         try context.save()
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "First"],
                 ["id": 2, "text": "Second"],
-            ],
-            as: SuperNote.self,
-            in: context,
-            parent: parent,
-            relationship: \SuperNote.superUser
-        )
+            ], as: SuperNote.self, parent: parent, relationship: \SuperNote.superUser)
 
         let (_, profile) = try await SwiftSync.withMainActorPerformanceProfiling {
-            try await SwiftSync.sync(
-                item: ["id": 1, "text": "First Updated"],
-                as: SuperNote.self,
-                in: context,
-                parent: parent,
-                relationship: \SuperNote.superUser
-            )
+            try await context.sync(
+                item: ["id": 1, "text": "First Updated"], as: SuperNote.self, parent: parent,
+                relationship: \SuperNote.superUser)
         }
 
         XCTAssertNotNil(profile.totalsByPhase["fetch-existing"])
@@ -3941,21 +3636,12 @@ final class SyncTests: XCTestCase {
         context.insert(parent)
         try context.save()
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "text": "First"]],
-            as: SuperNote.self,
-            in: context,
-            parent: parent,
-            relationship: \SuperNote.superUser
-        )
+        try await context.sync(
+            payload: [["id": 1, "text": "First"]], as: SuperNote.self, parent: parent,
+            relationship: \SuperNote.superUser)
 
-        try await SwiftSync.sync(
-            item: ["id": 2, "text": "Second"],
-            as: SuperNote.self,
-            in: context,
-            parent: parent,
-            relationship: \SuperNote.superUser
-        )
+        try await context.sync(
+            item: ["id": 2, "text": "Second"], as: SuperNote.self, parent: parent, relationship: \SuperNote.superUser)
 
         let notes = try context.fetch(FetchDescriptor<SuperNote>())
             .filter { $0.superUser?.persistentModelID == parent.persistentModelID }
@@ -3976,21 +3662,13 @@ final class SyncTests: XCTestCase {
         context.insert(folderB)
         try context.save()
 
-        try await SwiftSync.sync(
-            item: ["id": 10, "text": "original"],
-            as: UniqueIDNote.self,
-            in: context,
-            parent: folderA,
-            relationship: \UniqueIDNote.folder
-        )
+        try await context.sync(
+            item: ["id": 10, "text": "original"], as: UniqueIDNote.self, parent: folderA,
+            relationship: \UniqueIDNote.folder)
 
-        try await SwiftSync.sync(
-            item: ["id": 10, "text": "moved"],
-            as: UniqueIDNote.self,
-            in: context,
-            parent: folderB,
-            relationship: \UniqueIDNote.folder
-        )
+        try await context.sync(
+            item: ["id": 10, "text": "moved"], as: UniqueIDNote.self, parent: folderB,
+            relationship: \UniqueIDNote.folder)
 
         let all = try context.fetch(FetchDescriptor<UniqueIDNote>())
         XCTAssertEqual(all.count, 1)
@@ -4010,21 +3688,13 @@ final class SyncTests: XCTestCase {
         context.insert(parentB)
         try context.save()
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "text": "A-10"]],
-            as: ScopedItem.self,
-            in: context,
-            parent: parentA,
-            relationship: \ScopedItem.bucket
-        )
+        try await context.sync(
+            payload: [["id": 10, "text": "A-10"]], as: ScopedItem.self, parent: parentA,
+            relationship: \ScopedItem.bucket)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "text": "B-10"]],
-            as: ScopedItem.self,
-            in: context,
-            parent: parentB,
-            relationship: \ScopedItem.bucket
-        )
+        try await context.sync(
+            payload: [["id": 10, "text": "B-10"]], as: ScopedItem.self, parent: parentB,
+            relationship: \ScopedItem.bucket)
 
         let all = try context.fetch(FetchDescriptor<ScopedItem>())
         XCTAssertEqual(all.count, 2)
@@ -4044,21 +3714,13 @@ final class SyncTests: XCTestCase {
         context.insert(parentB)
         try context.save()
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "text": "A-10"]],
-            as: GlobalItem.self,
-            in: context,
-            parent: parentA,
-            relationship: \GlobalItem.bucket
-        )
+        try await context.sync(
+            payload: [["id": 10, "text": "A-10"]], as: GlobalItem.self, parent: parentA,
+            relationship: \GlobalItem.bucket)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "text": "B-10"]],
-            as: GlobalItem.self,
-            in: context,
-            parent: parentB,
-            relationship: \GlobalItem.bucket
-        )
+        try await context.sync(
+            payload: [["id": 10, "text": "B-10"]], as: GlobalItem.self, parent: parentB,
+            relationship: \GlobalItem.bucket)
 
         let all = try context.fetch(FetchDescriptor<GlobalItem>())
         XCTAssertEqual(all.count, 1)
@@ -4079,37 +3741,22 @@ final class SyncTests: XCTestCase {
         context.insert(parentB)
         try context.save()
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "A-1"],
                 ["id": 2, "text": "A-2"],
-            ],
-            as: ScopedItem.self,
-            in: context,
-            parent: parentA,
-            relationship: \ScopedItem.bucket
-        )
+            ], as: ScopedItem.self, parent: parentA, relationship: \ScopedItem.bucket)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "B-1"],
                 ["id": 3, "text": "B-3"],
-            ],
-            as: ScopedItem.self,
-            in: context,
-            parent: parentB,
-            relationship: \ScopedItem.bucket
-        )
+            ], as: ScopedItem.self, parent: parentB, relationship: \ScopedItem.bucket)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "text": "A-1 updated"]
-            ],
-            as: ScopedItem.self,
-            in: context,
-            parent: parentA,
-            relationship: \ScopedItem.bucket
-        )
+            ], as: ScopedItem.self, parent: parentA, relationship: \ScopedItem.bucket)
 
         let rows = try context.fetch(FetchDescriptor<ScopedItem>())
         XCTAssertEqual(Set(rows.filter { $0.bucket?.id == 1 }.map(\.id)), Set([1]))
@@ -4123,34 +3770,20 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: User.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 1, "full_name": "One"],
                 ["id": 2, "full_name": "Two"],
-            ],
-            as: User.self,
-            in: context
-        )
+            ], as: User.self)
 
-        try await SwiftSync.sync(
-            item: ["id": 1, "full_name": "One Updated"],
-            as: User.self,
-            in: context
-        )
+        try await context.sync(item: ["id": 1, "full_name": "One Updated"], as: User.self)
 
-        try await SwiftSync.sync(
+        try await context.sync(
             payload: [
                 ["id": 2, "full_name": "Two"]
-            ],
-            as: User.self,
-            in: context
-        )
+            ], as: User.self)
 
-        try await SwiftSync.sync(
-            item: ["id": 1, "full_name": "One Recreated"],
-            as: User.self,
-            in: context
-        )
+        try await context.sync(item: ["id": 1, "full_name": "One Recreated"], as: User.self)
 
         let rows = try context.fetch(FetchDescriptor<User>())
         XCTAssertEqual(Set(rows.map(\.id)), Set([1, 2]))
@@ -4170,21 +3803,13 @@ final class SyncTests: XCTestCase {
         context.insert(folderB)
         try context.save()
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "text": "original"]],
-            as: UniqueIDNote.self,
-            in: context,
-            parent: folderA,
-            relationship: \UniqueIDNote.folder
-        )
+        try await context.sync(
+            payload: [["id": 10, "text": "original"]], as: UniqueIDNote.self, parent: folderA,
+            relationship: \UniqueIDNote.folder)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "text": "moved"]],
-            as: UniqueIDNote.self,
-            in: context,
-            parent: folderB,
-            relationship: \UniqueIDNote.folder
-        )
+        try await context.sync(
+            payload: [["id": 10, "text": "moved"]], as: UniqueIDNote.self, parent: folderB,
+            relationship: \UniqueIDNote.folder)
 
         let all = try context.fetch(FetchDescriptor<UniqueIDNote>())
         XCTAssertEqual(all.count, 1)
@@ -4204,21 +3829,13 @@ final class SyncTests: XCTestCase {
         context.insert(folderB)
         try context.save()
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "text": "A-note"]],
-            as: InferredNote.self,
-            in: context,
-            parent: folderA,
-            relationship: \InferredNote.folder
-        )
+        try await context.sync(
+            payload: [["id": 10, "text": "A-note"]], as: InferredNote.self, parent: folderA,
+            relationship: \InferredNote.folder)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "text": "B-note"]],
-            as: InferredNote.self,
-            in: context,
-            parent: folderB,
-            relationship: \InferredNote.folder
-        )
+        try await context.sync(
+            payload: [["id": 10, "text": "B-note"]], as: InferredNote.self, parent: folderB,
+            relationship: \InferredNote.folder)
 
         let all = try context.fetch(FetchDescriptor<InferredNote>())
         XCTAssertEqual(all.count, 2)
@@ -4238,21 +3855,13 @@ final class SyncTests: XCTestCase {
         context.insert(folderB)
         try context.save()
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "email": "a@example.com", "text": "A-note"]],
-            as: UniqueEmailNote.self,
-            in: context,
-            parent: folderA,
-            relationship: \UniqueEmailNote.folder
-        )
+        try await context.sync(
+            payload: [["id": 10, "email": "a@example.com", "text": "A-note"]], as: UniqueEmailNote.self,
+            parent: folderA, relationship: \UniqueEmailNote.folder)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "email": "b@example.com", "text": "B-note"]],
-            as: UniqueEmailNote.self,
-            in: context,
-            parent: folderB,
-            relationship: \UniqueEmailNote.folder
-        )
+        try await context.sync(
+            payload: [["id": 10, "email": "b@example.com", "text": "B-note"]], as: UniqueEmailNote.self,
+            parent: folderB, relationship: \UniqueEmailNote.folder)
 
         let all = try context.fetch(FetchDescriptor<UniqueEmailNote>())
         XCTAssertEqual(all.count, 2)
@@ -4266,34 +3875,18 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: AutoCompany.self, AutoEmployee.self, configurations: configuration)
         let context = ModelContext(container)
 
-        try await SwiftSync.sync(
-            payload: [["id": 10, "name": "Acme"]],
-            as: AutoCompany.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 10, "name": "Acme"]], as: AutoCompany.self)
 
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava"]],
-            as: AutoEmployee.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 1, "name": "Ava"]], as: AutoEmployee.self)
 
         // String "10" should NOT coerce to Int 10 for strict FK typing.
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava", "company_id": "10"]],
-            as: AutoEmployee.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 1, "name": "Ava", "company_id": "10"]], as: AutoEmployee.self)
 
         var rows = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertNil(rows.first?.company)
 
         // Integer 10 matches the expected type and should resolve the FK.
-        try await SwiftSync.sync(
-            payload: [["id": 1, "name": "Ava", "company_id": 10]],
-            as: AutoEmployee.self,
-            in: context
-        )
+        try await context.sync(payload: [["id": 1, "name": "Ava", "company_id": 10]], as: AutoEmployee.self)
 
         rows = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertEqual(rows.first?.company?.id, 10)

--- a/docs/planning/comment-audit.md
+++ b/docs/planning/comment-audit.md
@@ -1,0 +1,85 @@
+# Comment audit — full repo sweep
+
+Repo-wide audit of code comments against the bar in the `comment-audit` skill and
+`~/.claude/CLAUDE.md` (`## Comments`). Worked **section by section** (by context, not by file) so
+each chop is reviewed with its surroundings visible.
+
+## The bar
+
+Every comment is **guilty until proven essential**. Default delete. Ties die. Doubt kills.
+
+A comment lives **only** if it carries a fact that is all of:
+
+1. unrecoverable from the code, names, and types;
+2. stated nowhere else (keep at most one copy, at the declaration);
+3. durable across refactors/renames/env changes (no snapshot rot);
+
+…and is one of: external/wire-protocol knowledge, a non-obvious *why*, a gotcha the type system
+can't express, a TODO with teeth, or a justification for suspicious-looking code.
+
+- **Public-seam docs are not exempt.** A `///` that describes *what* a method does (recoverable from
+  its name/signature) dies — public or not. Only a contract the signature can't express survives
+  (ownership, threading, call-order, lifetime, magic-value meaning).
+- Survivors are **trimmed to the load-bearing clause**.
+- Where a comment exists because a *name* is weak, fix the name and delete the comment.
+
+## Cadence
+
+For each section: show the comments in context with a kill / trim / keep verdict, adjust, apply the
+cuts, then build + `swift format` (no churn) + `swift test` green before moving on. Commit per
+section (or per couple of sections) so the diff stays readable.
+
+Baseline: ~685 comment-bearing lines across 38 files (crude count, over-counts multi-line `///`).
+
+## Sections
+
+- [x] **Section 0 — Library `SwiftSync/Sources` first (light) pass** — landed in #650 (merged).
+  Cut 10 lines: a verbatim cross-call-site duplicate, three narration/restatement lines, two trims.
+  Too timid; re-opened under the harder bar as Sections 1–2.
+
+- [x] **Section 1 — Library public seam: doc comments**
+  - Killed: `inboundAuthor` "Internal —" line; `localTransactions` doc (restatement); `SyncError`
+    `invalidPayload`/`cancelled`/`containerInitialization` case docs (restate the case; `errorDescription`
+    carries the text). Kept `schemaValidation` (names the non-obvious triggers).
+  - Trimmed: `SyncPendingChanges` (cut field restatement, kept ids-not-objects contract); `SyncPushFailure`
+    (cut idempotent-upsert dup of `withPendingChanges`); `withPendingChanges` (cut what-it-does opener);
+    `SyncContainer.sync(item:)` (cut box sentence dup of `UncheckedSendableBox`).
+  - Fixed stale refs: `` `push` `` → `` `withPendingChanges` `` (Core, PushHistoryTokenStore, Push ×2) —
+    `push` was renamed to `withPendingChanges`; the backtick refs pointed at a symbol that no longer exists.
+  - **API note (deferred):** the consumer operation reads as "push" in all prose but the method is named
+    `withPendingChanges`. Consider a `push`-named entry point or doc alias — an API change, not a comment fix.
+
+- [ ] **Section 2 — Library internals: inline why/gotchas**
+  - Same files, `//` inline (Core, SyncContainer, Push, SyncDateParser, SyncableMacro, SyncQueryPublisher) (~30)
+  - Bar: keep only non-obvious *why* / gotcha / justification. Finish what Section 0 started.
+
+- [ ] **Section 3 — Fake backend: the simulated server**
+  - `DemoBackend/Sources/{DemoServerSimulator,DemoSeedData}` (~40)
+  - Bar: wire-contract facts (LWW, upsert-by-`public_id`, idempotency) survive; endpoint narration dies.
+
+- [ ] **Section 4 — Fake backend: tests**
+  - `DemoBackendTests`, `UploadEndpointTests` (~44)
+  - Bar: step-label narration (`// missing title`, `// older write loses`), MARK helpers.
+
+- [ ] **Section 5 — App sync engine**
+  - `DemoCore/Sources/{DemoSyncEngine,DemoAPI,ScreenMachines,DemoModels}` (~80)
+  - Bar: offline/drain/failures *why* survives; restatement dies.
+
+- [ ] **Section 6 — App sync engine: tests**
+  - `DemoCore/Tests/*` (OfflinePush, ConvergingDrain, TaskForm…, TaskExportRegression, DirtyTrackingGap) (~80)
+  - Bar: scenario doc-headers + step narration.
+
+- [ ] **Section 7 — Demo app UI**
+  - `Demo/Demo/{ContentView,TaskFormSheet,FailuresSheet}`, `Demo/DemoUITests` (~40)
+  - Bar: real UI gotchas (safe-area inset reasoning) survive; UI-test KEPT-rationale + step narration scrutinized.
+
+- [ ] **Section 8 — Library tests (largest; will sub-split)**
+  - `SwiftSync/Tests/*` (~12 files, ~300)
+  - Bar: tutorial headers, filename-restatement headers, Given/When step labels, MARK labels.
+  - Known kills: `SyncRelationshipOperationsTests.swift:1` filename line + ~45-line `## Background /
+    ## Why this exists / ## Historical note` header (the Historical note is snapshot rot);
+    `SyncTests.swift` `// Seconds` / `// Milliseconds` / `// rename the first` step narration.
+
+## Log
+
+- Section 0: #650, merged.

--- a/docs/planning/comment-audit.md
+++ b/docs/planning/comment-audit.md
@@ -107,6 +107,14 @@ Baseline: ~685 comment-bearing lines across 38 files (crude count, over-counts m
 
 ## Log
 
+- Serialization regression caught by CI: `testConcurrentSyncDifferentContextsSameStoreUniqueConstraintConflict`
+  relied on the removed engine-level lease to make an arbitrary *race-order* winner deterministic (15-run
+  loop: 8/7 coin flip). The "one row, no corruption" guarantee comes from `@Attribute(.unique)` and holds
+  without the lease (15/15). Real last-writer-wins (winner decided by timestamp) is covered deterministically
+  elsewhere — DemoBackend `UploadEndpointTests` (×4) and DemoCore `OfflinePushTests` (×2). Rewrote the test
+  as `testLastWriterWinsAcrossContextsOnSameStore`: sequence the two context writes so "last writer" is
+  actually defined, assert the later context wins (deterministic, 15/15). No global lock restored.
+
 - Section 0: #650, merged.
 - Sections 1–2 + engine restructure: #651 (draft). Full re-audit of `SwiftSync/Sources/` (128 comment
   lines) after the restructure: the explanatory doc + inline comments survive the bar (SwiftData/CoreData

--- a/docs/planning/comment-audit.md
+++ b/docs/planning/comment-audit.md
@@ -108,3 +108,10 @@ Baseline: ~685 comment-bearing lines across 38 files (crude count, over-counts m
 ## Log
 
 - Section 0: #650, merged.
+- Sections 1–2 + engine restructure: #651 (draft). Full re-audit of `SwiftSync/Sources/` (128 comment
+  lines) after the restructure: the explanatory doc + inline comments survive the bar (SwiftData/CoreData
+  quirks, the SQL `nil != "inbound"` trap, provenance, invariants, justifications) — Section 1 + the
+  restructure already removed the restatement/duplication. Found one partial-duplicate trim
+  (`SyncContainer` schema-registration comment) and cut 5 access-level `// MARK:` headers in
+  `SyncQueryPublisher` (they restated `public`/`private`); kept Core.swift's 2 navigation MARKs (1300-line
+  file). This closes Section 2 (library inline comments) — the surface is fully audited.

--- a/docs/planning/comment-audit.md
+++ b/docs/planning/comment-audit.md
@@ -48,6 +48,31 @@ Baseline: ~685 comment-bearing lines across 38 files (crude count, over-counts m
     `push` was renamed to `withPendingChanges`; the backtick refs pointed at a symbol that no longer exists.
   - **API note (deferred):** the consumer operation reads as "push" in all prose but the method is named
     `withPendingChanges`. Consider a `push`-named entry point or doc alias — an API change, not a comment fix.
+  - **Architecture (done, same branch):** `API.swift` held zero `public` declarations — it was the internal
+    sync engine misnamed as the public layer (the public surface lives on `SyncContainer`/`Core`/`Push`/
+    `ReactiveQuery`).
+    - The reconcile engine became `ModelContext` methods: `context.sync(payload:/item:…)` in
+      `ModelContext+Sync.swift`. The mutated thing is the receiver, so `in: context` threading is gone at
+      ~205 call sites, and the `SwiftSync.sync` vs `SyncContainer.sync` verb collision evaporates. Domain
+      calls inside the loop are explicit (`SwiftSync.identityKey(…)`) — opaque before, clear now.
+    - All `SwiftSync`-static reconcile helpers consolidated into one `SwiftSync+Helpers.swift`
+      (`normalize`/`resolveIdentity`/`identityKey`/`scopedIdentityKey`/`syncIdentityHasUniqueAttribute`/
+      `fetchUniqueRow`/`resolveParent`/`isCancellation`/`withRelationshipLookupCache`) — no proliferation of
+      `SwiftSync+X` files, no free functions.
+    - `throwIfCancelled` deleted in favor of stdlib `try Task.checkCancellation()` (behavior-neutral — the
+      `catch` already converts any cancellation → rollback → `SyncError.cancelled`).
+    - Moved the inbound-pull local-edit helpers (`isUnsyncedLocalInsert`/`applyHonoringLocalEdit`) to
+      `Push.swift` beside the dirty-set producers they consume.
+    - **Serialization, judged from first principles:** the old per-container lease was a *global keyed
+      singleton* (`private static let syncLeaseRegistry` keyed by `ObjectIdentifier(container)`) — a symptom
+      of the engine being stateless statics with nowhere to hang per-store state. Replaced it: the engine
+      `sync(...)` is now a pure reconcile function (no lease), and serialization is a per-instance async
+      mutex (`SyncContainer.Serializer`, a nested `private actor` — `acquire`/`release` parented to the type,
+      no singleton/global/keying) owned by `SyncContainer`, which wraps its four leaf `sync` methods. Contract: serialization is
+      per-`SyncContainer` (one per store — the library's existing norm). Behavior-neutral: SwiftSync 48/48
+      and DemoCore 43/43 (incl. ConvergingDrain/OfflinePush concurrency suites) green.
+    - Naming nit left for later: `isUnsyncedLocalInsert` checks any dirty pid (created *or* edited), not
+      just inserts.
 
 - [ ] **Section 2 — Library internals: inline why/gotchas**
   - Same files, `//` inline (Core, SyncContainer, Push, SyncDateParser, SyncableMacro, SyncQueryPublisher) (~30)


### PR DESCRIPTION
Branch combines **comment-audit Section 1** (library public-seam docs) with the **architecture work it surfaced**. Behavior-neutral throughout: `swift build` clean, `swift format` stable, **SwiftSync 48/48** and **DemoCore 43/43** (incl. the `ConvergingDrain`/`OfflinePush` concurrency suites) green.

Plan + running log: `docs/planning/comment-audit.md`.

### Commit 1 — comment cuts (`1ded87f5`)
- Killed `SyncError` case docs that restate the case (`invalidPayload`/`cancelled`/`containerInitialization`); kept `schemaValidation` (names the non-obvious triggers).
- Trimmed `SyncPendingChanges`/`SyncPushFailure`/`withPendingChanges` to the load-bearing contract, removing two cross-doc duplications; dropped the `sync(item:)` box sentence (dup of `UncheckedSendableBox`).
- Fixed stale `` `push` `` doc refs → `` `withPendingChanges` `` (the method was renamed; the backtick refs pointed at a symbol that no longer exists).

### Commit 2 — sync-engine restructure (`e921858f`)
`API.swift` had **zero `public` declarations** — it was the internal sync engine wearing the public layer's name (the public surface is on `SyncContainer`/`Core`/`Push`/`ReactiveQuery`).

- **`context.sync(payload:/item:…)`** — the reconcile engine is now `ModelContext` methods (`ModelContext+Sync.swift`). The mutated store is the receiver, so `in: context` threading is gone at ~205 call sites and the `SwiftSync.sync` vs `SyncContainer.sync` verb collision disappears. Domain calls inside the loop are explicit (`SwiftSync.identityKey(…)`).
- **`SwiftSyncHelpers.swift`** — all `SwiftSync`-static reconcile helpers consolidated into one file (no `SwiftSync+X` proliferation, no free functions).
- **`throwIfCancelled` → stdlib `Task.checkCancellation()`** — behavior-neutral (the `catch` already converts cancellation → rollback → `SyncError.cancelled`).
- **Serialization** is a per-instance async mutex (`SyncSerializer` actor) owned by `SyncContainer`, replacing the global keyed lease singleton. The engine is a pure reconcile; the container owns concurrency. Contract: per-`SyncContainer` (one per store).
- Moved the inbound-pull local-edit helpers (`isUnsyncedLocalInsert`/`applyHonoringLocalEdit`) to `Push.swift`, beside the dirty-set producers they consume.

Deleted: `API.swift` (→ split), `SwiftSync+SyncIdentity.swift` (→ consolidated), the lease file.

### Deferred (logged, not in this PR)
- Public API reads "push" everywhere but the method is `withPendingChanges` — consider a rename/alias (API change).
- `isUnsyncedLocalInsert` checks any dirty pid (created *or* edited), so the `…Insert` name is slightly misleading.