### PR TITLE
perf(test): disable simulated network latency in DemoCore tests

### DIFF
--- a/DemoCore/Tests/DemoCoreTests/ConvergingDrainTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/ConvergingDrainTests.swift
@@ -18,7 +18,7 @@ final class ConvergingDrainTests: XCTestCase {
     func testLateEditDuringDrainReachesServer() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -11,7 +11,7 @@ final class OfflinePushTests: XCTestCase {
     func testOfflineCreateThenPushStampsRemoteIDAndReachesBackend() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -49,7 +49,7 @@ final class OfflinePushTests: XCTestCase {
     func testOnlineCreateTaskPersistsLocallyAndReachesBackend() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -70,7 +70,7 @@ final class OfflinePushTests: XCTestCase {
     func testOnlineDeleteTaskRemovesLocallyAndOnBackend() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -91,7 +91,7 @@ final class OfflinePushTests: XCTestCase {
     func testUpdateTaskItemsAddRenameDelete() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -127,7 +127,7 @@ final class OfflinePushTests: XCTestCase {
     func testOfflineDeleteThenPushHardDeletesLocallyAndOnBackend() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -157,7 +157,7 @@ final class OfflinePushTests: XCTestCase {
     func testRejectedPushPersistsFailureReasonOnTheRow() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -193,7 +193,7 @@ final class OfflinePushTests: XCTestCase {
     func testDiscardFailedChangeRestoresServerStateAndClearsFailure() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -224,7 +224,7 @@ final class OfflinePushTests: XCTestCase {
     func testEditingAFailedInsertReinsertsInsteadOf404() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -266,7 +266,7 @@ final class OfflinePushTests: XCTestCase {
     func testEditingAFailedSyncedRowOnlineClearsFailure() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -308,7 +308,7 @@ final class OfflinePushTests: XCTestCase {
             .appendingPathComponent("stale-adopt-\(UUID().uuidString).sqlite")
         addTeardownBlock { try? FileManager.default.removeItem(at: url) }
         let backend = try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
-        let apiClient = FakeDemoAPIClient(backend: backend)
+        let apiClient = FakeDemoAPIClient(backend: backend, networkDelayMode: .disabled)
         let syncContainer = try makeSyncContainer()
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
@@ -352,7 +352,7 @@ final class OfflinePushTests: XCTestCase {
     func testOfflineEditOfCreatedTaskUpdatesTitleAndKeepsProjectLink() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -388,7 +388,7 @@ final class OfflinePushTests: XCTestCase {
             .appendingPathComponent("offline-update-people-\(UUID().uuidString).sqlite")
         addTeardownBlock { try? FileManager.default.removeItem(at: url) }
         let backend = try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
-        let apiClient = FakeDemoAPIClient(backend: backend)
+        let apiClient = FakeDemoAPIClient(backend: backend, networkDelayMode: .disabled)
         let syncContainer = try makeSyncContainer()
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
@@ -435,7 +435,7 @@ final class OfflinePushTests: XCTestCase {
             .appendingPathComponent("offline-people-\(UUID().uuidString).sqlite")
         addTeardownBlock { try? FileManager.default.removeItem(at: url) }
         let backend = try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
-        let apiClient = FakeDemoAPIClient(backend: backend)
+        let apiClient = FakeDemoAPIClient(backend: backend, networkDelayMode: .disabled)
         let syncContainer = try makeSyncContainer()
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
@@ -473,7 +473,7 @@ final class OfflinePushTests: XCTestCase {
     func testPushWhileOfflineIsANoOp() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -507,7 +507,7 @@ final class OfflinePushTests: XCTestCase {
             .appendingPathComponent("offline-read-\(UUID().uuidString).sqlite")
         addTeardownBlock { try? FileManager.default.removeItem(at: url) }
         let backend = try DemoServerSimulator(databaseURL: url, seedData: DemoSeedData.generate())
-        let apiClient = FakeDemoAPIClient(backend: backend)
+        let apiClient = FakeDemoAPIClient(backend: backend, networkDelayMode: .disabled)
         let syncContainer = try makeSyncContainer()
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
@@ -547,7 +547,7 @@ final class OfflinePushTests: XCTestCase {
     func testRejectedOfflineCreatedTaskSurvivesProjectPull() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -579,7 +579,7 @@ final class OfflinePushTests: XCTestCase {
     func testOfflineEditSurvivesServerSideDeleteOnReconnect() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -611,7 +611,7 @@ final class OfflinePushTests: XCTestCase {
     func testFailedOfflineEditIsNotClobberedByProjectRefresh() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -640,7 +640,7 @@ final class OfflinePushTests: XCTestCase {
     func testNewerServerVersionOverwritesPollutedLocalEdit() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -678,7 +678,7 @@ final class OfflinePushTests: XCTestCase {
     func testPollutedRowDoesNotBlockSiblingRefresh() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity

--- a/DemoCore/Tests/DemoCoreTests/TaskFormDescriptionNormalizationTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/TaskFormDescriptionNormalizationTests.swift
@@ -1,6 +1,7 @@
 import SwiftData
 import SwiftSync
 import XCTest
+
 @testable import DemoCore
 
 final class TaskFormDescriptionNormalizationTests: XCTestCase {
@@ -9,7 +10,7 @@ final class TaskFormDescriptionNormalizationTests: XCTestCase {
     func testSaveBlankDescriptionClearsStoredDescriptionToNil() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity
@@ -33,9 +34,12 @@ final class TaskFormDescriptionNormalizationTests: XCTestCase {
         draft.descriptionText = "   "
 
         let saved = expectation(description: "save callback")
-        machine.send(.save(mode: .edit(task: originalTask), draft: draft, onSuccess: {
-            saved.fulfill()
-        }))
+        machine.send(
+            .save(
+                mode: .edit(task: originalTask), draft: draft,
+                onSuccess: {
+                    saved.fulfill()
+                }))
         await fulfillment(of: [saved], timeout: 10)
 
         let updatedTask = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))

--- a/DemoCore/Tests/DemoCoreTests/TaskFormPeopleMutationTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/TaskFormPeopleMutationTests.swift
@@ -11,7 +11,7 @@ final class TaskFormPeopleMutationTests: XCTestCase {
     func testEditTaskPeopleFlowReplacesReviewersAndWatchers() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.notificationsReliability
@@ -78,7 +78,7 @@ final class TaskFormPeopleMutationTests: XCTestCase {
     func testTaskViewMachineObservesReviewerAndWatcherChangesAfterPeopleSave() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.notificationsReliability
@@ -162,7 +162,7 @@ final class TaskFormPeopleMutationTests: XCTestCase {
     func testUnsavedFormEditsInEditContextDoNotReachTheStore() async throws {
         let seed = DemoSeedData.generate()
         let syncContainer = try makeSyncContainer()
-        let apiClient = FakeDemoAPIClient(seedData: seed)
+        let apiClient = FakeDemoAPIClient(seedData: seed, networkDelayMode: .disabled)
         let engine = DemoSyncEngine(syncContainer: syncContainer, apiClient: apiClient)
 
         let projectID = DemoSeedData.SeedIDs.Projects.accountSecurity


### PR DESCRIPTION
DemoCore is the slowest macOS CI job (~2m25s) because its tests built `FakeDemoAPIClient` with the default `networkDelayMode: .scenarioDriven`, so every request slept to simulate network latency (150ms base + up to ~470ms for mutations + jitter). With dozens of round-trips per test, the suite ran ~70s.

**None of the tests actually need that latency:**
- the offline/push tests `await` their round-trips (ordering comes from `await`, not the sleep);
- the drain/race tests (`ConvergingDrainTests`) control ordering with explicit continuation hooks, not the ambient delay.

So this constructs every **test** client with the existing first-class `.disabled` mode (no new mechanism, no env var). The real app (`DemoRuntime`) is untouched — it keeps `.scenarioDriven` (and its `.disabled` UI-test path).

**Result:** the 43 tests drop **70.3s → ~1.1s**. Verified green across 3 consecutive runs — removing the delay didn't expose any race it was masking.

Scope: test-only, 25 construction sites across 4 files; no production code changed.