### PR TITLE
ci: single simulator build for DirtyTrackingGap + DemoUITests

### DIFF
--- a/.github/workflows/ios-regression.yml
+++ b/.github/workflows/ios-regression.yml
@@ -61,22 +61,18 @@ jobs:
           echo "Using iPhone simulator $UDID"
           echo "udid=$UDID" >> "$GITHUB_OUTPUT"
 
-      # Fast, deterministic — run it first so a regression here fails before the slow UI suite.
-      - name: iOS regression — DirtyTrackingGapTests (DemoCore)
-        working-directory: DemoCore
-        run: |
-          xcodebuild test \
-            -scheme DemoCore \
-            -destination "id=${{ steps.sim.outputs.udid }}" \
-            -only-testing:DemoCoreTests/DirtyTrackingGapTests
-
+      # Both simulator-bound suites in ONE build. The Demo app already depends on the DemoCore package
+      # locally, so DemoCoreTests is reachable from the workspace scheme (it's in Demo.xctestplan) — no
+      # need to build the shared graph (SwiftSync/DemoCore/DemoBackend) twice. DirtyTrackingGapTests is
+      # listed first in the test plan, so it still runs before the slow UI suite (fail-fast on execution).
       # -retry-tests-on-failure absorbs first-launch/UI-timing flake; a real failure still fails every attempt.
-      - name: UI tests — DemoUITests
+      - name: iOS regression + UI tests (single build)
         run: |
           xcodebuild test \
             -workspace SwiftSync.xcworkspace \
             -scheme Demo \
             -destination "id=${{ steps.sim.outputs.udid }}" \
+            -only-testing:DemoCoreTests/DirtyTrackingGapTests \
             -only-testing:DemoUITests \
             -parallel-testing-enabled NO \
             -retry-tests-on-failure \

--- a/Demo.xctestplan
+++ b/Demo.xctestplan
@@ -19,6 +19,13 @@
   "testTargets" : [
     {
       "target" : {
+        "containerPath" : "container:DemoCore",
+        "identifier" : "DemoCoreTests",
+        "name" : "DemoCoreTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:Demo.xcodeproj",
         "identifier" : "280A39832F61B0610003F40E",
         "name" : "DemoUITests"

--- a/Demo.xctestplan
+++ b/Demo.xctestplan
@@ -19,7 +19,7 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:DemoCore",
+        "containerPath" : "container:..\/DemoCore",
         "identifier" : "DemoCoreTests",
         "name" : "DemoCoreTests"
       }


### PR DESCRIPTION
The `iOS Simulator Tests` job (the slowest at ~8m) builds the shared graph (SwiftSync/DemoCore/DemoBackend/macros) for the simulator **twice** — once via the `DemoCore` package scheme for `DirtyTrackingGapTests`, once via the `Demo` workspace scheme for `DemoUITests`.

Since the Demo app already depends on the DemoCore package locally, `DemoCoreTests` is reachable from the workspace scheme. This:
- adds `DemoCoreTests` to `Demo.xctestplan`, **ordered before** `DemoUITests` so the fast deterministic test still runs first (fail-fast on execution);
- collapses the two `xcodebuild test` invocations into **one**, scoped with `-only-testing:DemoCoreTests/DirtyTrackingGapTests` + `-only-testing:DemoUITests`.

**Expected:** one build instead of two → ~8m down toward ~6.5m (the ~84s duplicate build folds in). Validating on CI because a package test target running through the app workspace test plan is the kind of thing only a real run confirms — if the test-plan reference doesn't resolve or it doesn't save time, I'll revert.

Marking ready to trigger the simulator tier for validation.