### PR TITLE
perf: single-row publisher fetches by identity; ProjectViewMachine uses it

### DIFF
--- a/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
+++ b/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
@@ -120,7 +120,7 @@ public final class ProjectViewMachine {
     public private(set) var loadState: ScreenLoadState = .idle
     public private(set) var deleteState: SubmissionState = .idle
     public var project: Project? {
-        projectPublisher.rows.first(where: { $0.id == projectID })
+        projectPublisher.row
     }
     public var tasks: [Task] {
         // Offline-deleted tasks are hard-deleted (their deletion lives in store history), so they're
@@ -140,7 +140,7 @@ public final class ProjectViewMachine {
 
     private let projectID: String
     private let syncEngine: DemoSyncEngine
-    private let projectPublisher: SyncQueryPublisher<Project>
+    private let projectPublisher: SyncModelPublisher<Project>
     private let taskPublisher: SyncQueryPublisher<Task>
     private let loadMachine: ScreenLoadMachine
     private let deleteMachine: SubmissionMachine
@@ -152,11 +152,7 @@ public final class ProjectViewMachine {
     public init(projectID: String, syncContainer: SyncContainer, syncEngine: DemoSyncEngine) {
         self.projectID = projectID
         self.syncEngine = syncEngine
-        self.projectPublisher = SyncQueryPublisher(
-            Project.self,
-            in: syncContainer,
-            sortBy: [SortDescriptor(\Project.name), SortDescriptor(\Project.id)]
-        )
+        self.projectPublisher = SyncModelPublisher(Project.self, id: projectID, in: syncContainer)
         self.taskPublisher = SyncQueryPublisher(
             Task.self,
             relationship: \Task.project,

--- a/SwiftSync/Sources/SwiftSync/ReactiveQuery.swift
+++ b/SwiftSync/Sources/SwiftSync/ReactiveQuery.swift
@@ -102,6 +102,8 @@ private final class SyncQueryObserver<Model: PersistentModel> {
     }
 }
 
+/// SwiftUI property wrapper observing a **collection**; the UIKit/plain-Swift equivalent is
+/// `SyncQueryPublisher`. For a single row by id, use `@SyncModel`.
 @MainActor
 @propertyWrapper
 public struct SyncQuery<Model: PersistentModel>: DynamicProperty {
@@ -393,6 +395,8 @@ private final class SyncModelObserver<Model: PersistentModel & SyncModelable> {
     }
 }
 
+/// SwiftUI property wrapper observing the **single row** matching an id; the UIKit/plain-Swift equivalent
+/// is `SyncModelPublisher`. For a collection, use `@SyncQuery`.
 @MainActor
 @propertyWrapper
 public struct SyncModel<Model: PersistentModel & SyncModelable>: DynamicProperty {

--- a/SwiftSync/Sources/SwiftSync/SyncModelPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncModelPublisher.swift
@@ -60,8 +60,20 @@ public final class SyncModelPublisher<Model: PersistentModel & SyncModelable> {
 
     private func reload() {
         do {
-            let rows = try syncContainer.mainContext.fetch(FetchDescriptor<Model>())
-            let fetchedRow = rows.first { $0[keyPath: Model.syncIdentity] == id }
+            let fetchedRow: Model?
+            if let predicate = Model.syncIdentityPredicate(matching: id) {
+                var descriptor = FetchDescriptor<Model>(predicate: predicate)
+                descriptor.fetchLimit = 1
+                fetchedRow = try syncPerformanceProfile(.fetchExistingByIdentity) {
+                    try syncContainer.mainContext.fetch(descriptor).first
+                }
+            } else {
+                // Hand-written conformances may not synthesize an identity predicate; scan as a fallback.
+                fetchedRow = try syncPerformanceProfile(.fetchExisting) {
+                    try syncContainer.mainContext.fetch(FetchDescriptor<Model>())
+                        .first { $0[keyPath: Model.syncIdentity] == id }
+                }
+            }
             withMutation(keyPath: \.row) {
                 _row = fetchedRow
             }

--- a/SwiftSync/Sources/SwiftSync/SyncModelPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncModelPublisher.swift
@@ -2,6 +2,9 @@ import Foundation
 import Observation
 import SwiftData
 
+/// Observes the **single row** matching `id` (`row`), kept current as the store syncs — the single-row
+/// counterpart of `SyncQueryPublisher` (collection); in SwiftUI, `@SyncModel`. Requires `SyncModelable`
+/// (not just `PersistentModel`) because it fetches by sync identity.
 @MainActor
 @Observable
 public final class SyncModelPublisher<Model: PersistentModel & SyncModelable> {

--- a/SwiftSync/Sources/SwiftSync/SyncQueryPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncQueryPublisher.swift
@@ -2,6 +2,8 @@ import Foundation
 import Observation
 import SwiftData
 
+/// Observes a **collection** (`rows`), kept current as the store syncs — all rows, a `predicate`, or a
+/// relationship scope. For the single row matching an id use `SyncModelPublisher`; in SwiftUI, `@SyncQuery`.
 @MainActor
 @Observable
 public final class SyncQueryPublisher<Model: PersistentModel> {

--- a/SwiftSync/Tests/SwiftSyncTests/SyncModelPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncModelPublisherTests.swift
@@ -1,7 +1,8 @@
 import Observation
 import SwiftData
-import SwiftSync
 import XCTest
+
+@testable import SwiftSync
 
 @Syncable
 @Model
@@ -155,6 +156,30 @@ final class SyncModelPublisherTests: XCTestCase {
             spy.values.contains(where: { $0 == [2, 3] }),
             "spy values: \(spy.values)"
         )
+    }
+
+    @MainActor
+    func testReloadFetchesByIdentityRatherThanScanningTheWholeTable() async throws {
+        let syncContainer = try makeContainer(modelTypes: ModelPubTask.self, ModelPubUser.self)
+        try await syncContainer.sync(
+            payload: [
+                ["id": "t1", "title": "One", "assignee_id": NSNull()],
+                ["id": "t2", "title": "Two", "assignee_id": NSNull()],
+                ["id": "t3", "title": "Three", "assignee_id": NSNull()],
+            ],
+            as: ModelPubTask.self
+        )
+
+        let (_, profile) = await SwiftSync.withMainActorPerformanceProfiling {
+            _ = SyncModelPublisher(ModelPubTask.self, id: "t2", in: syncContainer)
+        }
+
+        XCTAssertTrue(
+            profile.entered(.fetchExistingByIdentity),
+            "a single-row publisher should reload via an identity-targeted fetch")
+        XCTAssertFalse(
+            profile.entered(.fetchExisting),
+            "should not full-table scan when the model has a generated identity predicate")
     }
 
     @MainActor


### PR DESCRIPTION
Stacked on #656 (base will retarget to `master` when #656 merges).

Came out of asking whether `SyncModelPublisher` should *absorb* boilerplate from `ScreenMachines`. It shouldn't — that boilerplate (load/submission state machines, content-state resolution) is app UI architecture in `DemoCore`, and pulling it into the sync library is the exact leak #654 cleaned up. The real wins were the *opposite* direction:

### 1. Library — `SyncModelPublisher` was secretly O(table)
`reload()` fetched the whole table and linear-scanned for the observed id on every relevant save. Now it fetches via `Model.syncIdentityPredicate(matching:)` with `fetchLimit 1` (mirroring `SyncQueryPublisher`), falling back to the scan only for hand-written conformances with no synthesized predicate. Behavior-preserving; guarded by a profiler-probe test (red→green) in the repo's fetch-strategy style.

### 2. Consumer — `ProjectViewMachine` under-used the tool
It held a `SyncQueryPublisher<Project>` of *all* projects and did `rows.first(where: id)` — replaced with `SyncModelPublisher<Project>(id:)` (what `TaskViewMachine` already does).

Behavior-neutral: SwiftSync 173 (+1 new test), DemoCore 43/43 green. Touches `SyncModelPublisher` (reactive layer) → marking ready runs the simulator tier.