### PR TITLE
refactor: collapse SwiftUI reactive wrappers onto the publishers

### DIFF
--- a/SwiftSync/Sources/SwiftSync/ReactiveQuery.swift
+++ b/SwiftSync/Sources/SwiftSync/ReactiveQuery.swift
@@ -1,147 +1,32 @@
 import Foundation
-import Observation
 import SwiftData
 import SwiftUI
 
-@MainActor
-@Observable
-private final class SyncQueryObserver<Model: PersistentModel> {
-    var rows: [Model] = []
-
-    @ObservationIgnored private let syncContainer: SyncContainer
-    @ObservationIgnored private let predicate: Predicate<Model>?
-    @ObservationIgnored private let sortBy: [SortDescriptor<Model>]
-    @ObservationIgnored private let postFetchFilter: ((Model) -> Bool)?
-    @ObservationIgnored private let observedModelTypeNames: Set<String>
-    @ObservationIgnored private let animation: Animation?
-    @ObservationIgnored nonisolated(unsafe) private var notificationToken: NSObjectProtocol?
-
-    init(
-        syncContainer: SyncContainer,
-        predicate: Predicate<Model>?,
-        sortBy: [SortDescriptor<Model>],
-        postFetchFilter: ((Model) -> Bool)?,
-        observedModelTypeNames: Set<String>,
-        animation: Animation?
-    ) {
-        self.syncContainer = syncContainer
-        self.predicate = predicate
-        self.sortBy = sortBy
-        self.postFetchFilter = postFetchFilter
-        self.observedModelTypeNames = observedModelTypeNames
-        self.animation = animation
-        installObserver()
-        reload()
-    }
-
-    deinit {
-        if let notificationToken {
-            NotificationCenter.default.removeObserver(notificationToken)
-        }
-    }
-
-    private func installObserver() {
-        notificationToken = NotificationCenter.default.addObserver(
-            forName: SyncContainer.didSaveChangesNotification,
-            object: syncContainer,
-            queue: .main
-        ) { [weak self] notification in
-            guard let self else { return }
-            let changedModelTypeNames = SyncContainer.changedModelTypeNames(from: notification.userInfo)
-            let changedIDs = SyncContainer.changedIdentifiers(from: notification.userInfo)
-            MainActor.assumeIsolated {
-                guard self.shouldReload(changedModelTypeNames: changedModelTypeNames, changedIDs: changedIDs) else {
-                    return
-                }
-                self.reload()
-            }
-        }
-    }
-
-    private func shouldReload(
-        changedModelTypeNames: Set<String>,
-        changedIDs: Set<PersistentIdentifier>
-    ) -> Bool {
-        if changedModelTypeNames.isEmpty {
-            return true
-        }
-
-        if !observedModelTypeNames.isDisjoint(with: changedModelTypeNames) {
-            return true
-        }
-
-        if changedIDs.isEmpty {
-            return false
-        }
-        let loadedIDs = Set(rows.map(\.persistentModelID))
-        return !loadedIDs.isDisjoint(with: changedIDs)
-    }
-
-    private func reload() {
-        do {
-            let descriptor: FetchDescriptor<Model>
-            if let predicate {
-                descriptor = FetchDescriptor(predicate: predicate, sortBy: sortBy)
-            } else {
-                descriptor = FetchDescriptor(sortBy: sortBy)
-            }
-            var resolved = try syncContainer.mainContext.fetch(descriptor)
-            if let postFetchFilter {
-                resolved = resolved.filter(postFetchFilter)
-            }
-            if let animation {
-                withAnimation(animation) {
-                    rows = resolved
-                }
-            } else {
-                rows = resolved
-            }
-        } catch {
-            rows = []
-        }
-    }
-}
-
-/// SwiftUI property wrapper observing a **collection**; the UIKit/plain-Swift equivalent is
-/// `SyncQueryPublisher`. For a single row by id, use `@SyncModel`.
+/// SwiftUI property wrapper observing a **collection** (`rows`); the UIKit/plain-Swift equivalent is
+/// `SyncQueryPublisher`, which it wraps. For a single row by id, use `@SyncModel`.
 @MainActor
 @propertyWrapper
 public struct SyncQuery<Model: PersistentModel>: DynamicProperty {
-    @State private var observer: SyncQueryObserver<Model>
+    @State private var publisher: SyncQueryPublisher<Model>
 
-    public var wrappedValue: [Model] { observer.rows }
+    public var wrappedValue: [Model] { publisher.rows }
 
     public init(
         _ _: Model.Type,
         in syncContainer: SyncContainer,
-        sortBy: [SortDescriptor<Model>] = [],
-        animation: Animation? = nil
+        sortBy: [SortDescriptor<Model>] = []
     ) {
-        self.init(
-            syncContainer: syncContainer,
-            predicate: nil,
-            sortBy: sortBy,
-            postFetchFilter: nil,
-            observedModelTypeNames: Self.defaultObservedModelTypeNames(),
-            animation: animation
-        )
+        _publisher = State(initialValue: SyncQueryPublisher(Model.self, in: syncContainer, sortBy: sortBy))
     }
 
     public init(
         _ _: Model.Type,
         predicate: Predicate<Model>,
         in syncContainer: SyncContainer,
-        sortBy: [SortDescriptor<Model>] = [],
-        animation: Animation? = nil
+        sortBy: [SortDescriptor<Model>] = []
     ) {
-        self.init(
-            syncContainer: syncContainer,
-            predicate: predicate,
-            sortBy: sortBy,
-            postFetchFilter: nil,
-            observedModelTypeNames: Self.defaultObservedModelTypeNames(),
-            animation: animation
-        )
+        _publisher = State(
+            initialValue: SyncQueryPublisher(Model.self, predicate: predicate, in: syncContainer, sortBy: sortBy))
     }
 
     public init<Related: SyncModelable>(
@@ -149,18 +34,12 @@ public struct SyncQuery<Model: PersistentModel>: DynamicProperty {
         relationship: ReferenceWritableKeyPath<Model, Related?>,
         relationshipID: Related.SyncID,
         in syncContainer: SyncContainer,
-        sortBy: [SortDescriptor<Model>] = [],
-        animation: Animation? = nil
+        sortBy: [SortDescriptor<Model>] = []
     ) {
-        self.init(
-            syncContainer: syncContainer,
-            predicate: nil,
-            sortBy: sortBy,
-            postFetchFilter: Self.explicitToOneRelationshipIDFilter(
-                relationshipID: relationshipID, relationship: relationship),
-            observedModelTypeNames: Self.defaultObservedModelTypeNames(),
-            animation: animation
-        )
+        _publisher = State(
+            initialValue: SyncQueryPublisher(
+                Model.self, relationship: relationship, relationshipID: relationshipID, in: syncContainer,
+                sortBy: sortBy))
     }
 
     public init<Related: SyncModelable>(
@@ -168,261 +47,29 @@ public struct SyncQuery<Model: PersistentModel>: DynamicProperty {
         relationship: ReferenceWritableKeyPath<Model, [Related]>,
         relationshipID: Related.SyncID,
         in syncContainer: SyncContainer,
-        sortBy: [SortDescriptor<Model>] = [],
-        animation: Animation? = nil
+        sortBy: [SortDescriptor<Model>] = []
     ) {
-        self.init(
-            syncContainer: syncContainer,
-            predicate: nil,
-            sortBy: sortBy,
-            postFetchFilter: Self.explicitToManyRelationshipIDFilter(
-                relationshipID: relationshipID, relationship: relationship),
-            observedModelTypeNames: Self.defaultObservedModelTypeNames(),
-            animation: animation
-        )
-    }
-
-    private init(
-        syncContainer: SyncContainer,
-        predicate: Predicate<Model>?,
-        sortBy: [SortDescriptor<Model>],
-        postFetchFilter: ((Model) -> Bool)?,
-        observedModelTypeNames: Set<String>,
-        animation: Animation?
-    ) {
-        _observer = State(
-            initialValue: SyncQueryObserver(
-                syncContainer: syncContainer,
-                predicate: predicate,
-                sortBy: sortBy,
-                postFetchFilter: postFetchFilter,
-                observedModelTypeNames: observedModelTypeNames,
-                animation: animation
-            )
-        )
-    }
-
-    private static func defaultObservedModelTypeNames() -> Set<String> {
-        var names: Set<String> = [String(reflecting: Model.self)]
-        if let syncModelType = Model.self as? any SyncModelable.Type {
-            names.formUnion(syncModelType.syncDefaultRefreshModelTypeNames)
-        }
-        return names
-    }
-
-    private static func explicitToOneRelationshipIDFilter<Related: SyncModelable>(
-        relationshipID: Related.SyncID,
-        relationship: ReferenceWritableKeyPath<Model, Related?>
-    ) -> (Model) -> Bool {
-        return { row in
-            guard let relatedRow = row[keyPath: relationship] else { return false }
-            return relatedRow[keyPath: Related.syncIdentity] == relationshipID
-        }
-    }
-
-    private static func explicitToManyRelationshipIDFilter<Related: SyncModelable>(
-        relationshipID: Related.SyncID,
-        relationship: ReferenceWritableKeyPath<Model, [Related]>
-    ) -> (Model) -> Bool {
-        return { row in
-            row[keyPath: relationship].contains { relatedRow in
-                relatedRow[keyPath: Related.syncIdentity] == relationshipID
-            }
-        }
-    }
-
-}
-
-extension SyncQuery where Model: SyncModelable {
-    public init(
-        _ _: Model.Type,
-        in syncContainer: SyncContainer,
-        sortBy: [SortDescriptor<Model>] = [],
-        refreshOn: [PartialKeyPath<Model>] = [],
-        animation: Animation? = nil
-    ) {
-        self.init(
-            syncContainer: syncContainer,
-            predicate: nil,
-            sortBy: sortBy,
-            postFetchFilter: nil,
-            observedModelTypeNames: Self.observedModelTypeNames(refreshOn: refreshOn),
-            animation: animation
-        )
-    }
-
-    public init(
-        _ _: Model.Type,
-        predicate: Predicate<Model>,
-        in syncContainer: SyncContainer,
-        sortBy: [SortDescriptor<Model>] = [],
-        refreshOn: [PartialKeyPath<Model>] = [],
-        animation: Animation? = nil
-    ) {
-        self.init(
-            syncContainer: syncContainer,
-            predicate: predicate,
-            sortBy: sortBy,
-            postFetchFilter: nil,
-            observedModelTypeNames: Self.observedModelTypeNames(refreshOn: refreshOn),
-            animation: animation
-        )
-    }
-
-    public init<Related: SyncModelable>(
-        _ _: Model.Type,
-        relationship: ReferenceWritableKeyPath<Model, Related?>,
-        relationshipID: Related.SyncID,
-        in syncContainer: SyncContainer,
-        sortBy: [SortDescriptor<Model>] = [],
-        refreshOn: [PartialKeyPath<Model>] = [],
-        animation: Animation? = nil
-    ) {
-        self.init(
-            syncContainer: syncContainer,
-            predicate: nil,
-            sortBy: sortBy,
-            postFetchFilter: Self.explicitToOneRelationshipIDFilter(
-                relationshipID: relationshipID, relationship: relationship),
-            observedModelTypeNames: Self.observedModelTypeNames(refreshOn: refreshOn),
-            animation: animation
-        )
-    }
-
-    public init<Related: SyncModelable>(
-        _ _: Model.Type,
-        relationship: ReferenceWritableKeyPath<Model, [Related]>,
-        relationshipID: Related.SyncID,
-        in syncContainer: SyncContainer,
-        sortBy: [SortDescriptor<Model>] = [],
-        refreshOn: [PartialKeyPath<Model>] = [],
-        animation: Animation? = nil
-    ) {
-        self.init(
-            syncContainer: syncContainer,
-            predicate: nil,
-            sortBy: sortBy,
-            postFetchFilter: Self.explicitToManyRelationshipIDFilter(
-                relationshipID: relationshipID, relationship: relationship),
-            observedModelTypeNames: Self.observedModelTypeNames(refreshOn: refreshOn),
-            animation: animation
-        )
-    }
-
-    private static func observedModelTypeNames(refreshOn: [PartialKeyPath<Model>]) -> Set<String> {
-        var names = Self.defaultObservedModelTypeNames()
-        names.formUnion(Model.syncRefreshModelTypeNames(for: refreshOn))
-        return names
+        _publisher = State(
+            initialValue: SyncQueryPublisher(
+                Model.self, relationship: relationship, relationshipID: relationshipID, in: syncContainer,
+                sortBy: sortBy))
     }
 }
 
-@MainActor
-@Observable
-private final class SyncModelObserver<Model: PersistentModel & SyncModelable> {
-    var model: Model?
-
-    @ObservationIgnored private let syncContainer: SyncContainer
-    @ObservationIgnored private let id: Model.SyncID
-    @ObservationIgnored private let observedModelTypeNames: Set<String>
-    @ObservationIgnored private let animation: Animation?
-    @ObservationIgnored nonisolated(unsafe) private var notificationToken: NSObjectProtocol?
-
-    init(
-        syncContainer: SyncContainer,
-        id: Model.SyncID,
-        observedModelTypeNames: Set<String>,
-        animation: Animation?
-    ) {
-        self.syncContainer = syncContainer
-        self.id = id
-        self.observedModelTypeNames = observedModelTypeNames
-        self.animation = animation
-        installObserver()
-        reload()
-    }
-
-    deinit {
-        if let notificationToken {
-            NotificationCenter.default.removeObserver(notificationToken)
-        }
-    }
-
-    private func installObserver() {
-        notificationToken = NotificationCenter.default.addObserver(
-            forName: SyncContainer.didSaveChangesNotification,
-            object: syncContainer,
-            queue: .main
-        ) { [weak self] notification in
-            guard let self else { return }
-            let changedTypeNames = SyncContainer.changedModelTypeNames(from: notification.userInfo)
-            let changedIDs = SyncContainer.changedIdentifiers(from: notification.userInfo)
-            MainActor.assumeIsolated {
-                guard self.shouldReload(changedTypeNames: changedTypeNames, changedIDs: changedIDs) else { return }
-                self.reload()
-            }
-        }
-    }
-
-    private func shouldReload(
-        changedTypeNames: Set<String>,
-        changedIDs: Set<PersistentIdentifier>
-    ) -> Bool {
-        if changedTypeNames.isEmpty {
-            return true
-        }
-        if !observedModelTypeNames.isDisjoint(with: changedTypeNames) {
-            return true
-        }
-
-        guard let loadedModel = model else { return false }
-        return changedIDs.contains(loadedModel.persistentModelID)
-    }
-
-    private func reload() {
-        do {
-            let rows = try syncContainer.mainContext.fetch(FetchDescriptor<Model>())
-            let matched = rows.first { $0[keyPath: Model.syncIdentity] == id }
-            if let animation {
-                withAnimation(animation) {
-                    model = matched
-                }
-            } else {
-                model = matched
-            }
-        } catch {
-            model = nil
-        }
-    }
-}
-
-/// SwiftUI property wrapper observing the **single row** matching an id; the UIKit/plain-Swift equivalent
-/// is `SyncModelPublisher`. For a collection, use `@SyncQuery`.
+/// SwiftUI property wrapper observing the **single row** matching an id (`row`); the UIKit/plain-Swift
+/// equivalent is `SyncModelPublisher`, which it wraps. For a collection, use `@SyncQuery`.
 @MainActor
 @propertyWrapper
 public struct SyncModel<Model: PersistentModel & SyncModelable>: DynamicProperty {
-    @State private var observer: SyncModelObserver<Model>
+    @State private var publisher: SyncModelPublisher<Model>
 
-    public var wrappedValue: Model? { observer.model }
+    public var wrappedValue: Model? { publisher.row }
 
     public init(
         _ _: Model.Type,
         id: Model.SyncID,
-        in syncContainer: SyncContainer,
-        animation: Animation? = nil
+        in syncContainer: SyncContainer
     ) {
-        _observer = State(
-            initialValue: SyncModelObserver(
-                syncContainer: syncContainer,
-                id: id,
-                observedModelTypeNames: Self.defaultObservedModelTypeNames(),
-                animation: animation
-            )
-        )
-    }
-
-    private static func defaultObservedModelTypeNames() -> Set<String> {
-        var names = Model.syncDefaultRefreshModelTypeNames
-        names.insert(String(reflecting: Model.self))
-        return names
+        _publisher = State(initialValue: SyncModelPublisher(Model.self, id: id, in: syncContainer))
     }
 }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryParentTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryParentTests.swift
@@ -28,6 +28,24 @@ final class SyncQueryParentTests: XCTestCase {
     }
 
     @MainActor
+    func testSyncModelReturnsTheRowMatchingTheID() throws {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let modelContainer = try ModelContainer(for: InferredTask.self, configurations: configuration)
+        let syncContainer = SyncContainer(modelContainer)
+        let context = syncContainer.mainContext
+
+        context.insert(InferredTask(id: 1, title: "A"))
+        context.insert(InferredTask(id: 2, title: "B"))
+        context.insert(InferredTask(id: 3, title: "C"))
+        try context.save()
+
+        let model = SyncModel(InferredTask.self, id: 2, in: syncContainer)
+
+        XCTAssertEqual(model.wrappedValue?.id, 2)
+        XCTAssertEqual(model.wrappedValue?.title, "B")
+    }
+
+    @MainActor
     func testSyncQueryWithPredicateFiltersRows() throws {
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
         let modelContainer = try ModelContainer(


### PR DESCRIPTION
Continuing the publisher-family thread (#656/#657).

`@SyncQuery`/`@SyncModel` each owned a private `@Observable` observer that **duplicated** the observe→shouldReload→reload engine of `SyncQueryPublisher`/`SyncModelPublisher`. The duplication let a bug survive: #656 fixed `SyncModelPublisher`'s full-table reload, but `SyncModelObserver` kept the O(table) scan — so **`@SyncModel` still shipped the slow path**.

### Fix — make the wrappers thin adapters over the publishers
- Delete `SyncQueryObserver` + `SyncModelObserver` and their duplicated relationship-filter helpers (~180 lines).
- `@SyncQuery`/`@SyncModel` now hold a `SyncQueryPublisher`/`SyncModelPublisher` (both already `@Observable @MainActor`); `wrappedValue` returns `.rows`/`.row`.
- `@SyncModel` **inherits the publisher's identity-targeted fetch** — bug fixed, and covered by the publisher's existing test (one source of truth).
- `ReactiveQuery.swift`: **428 → 75 lines.**

### Dropped two unused, redundant params (verified: no consumer passes either)
- **`animation`** — superseded by the idiomatic view-level `.animation(_:value:)`, which the demo already uses for list changes.
- **`refreshOn`** — redundant: `@Syncable` auto-generates `syncDefaultRefreshModelTypes` with every relationship type, which the publishers already observe, so a query already refreshes on related-type changes. (Both were *used* historically, then orphaned when the demo moved to the publisher/machine pattern; `refreshOn` was additionally superseded by the macro auto-default.)

Behavior-neutral: SwiftSync 173 (+30), DemoCore 43/43 green; `SyncQueryParentTests` covers `@SyncQuery` via the publisher. Touches the reactive layer → marking ready runs the simulator tier (`DemoUITests` exercise `@SyncQuery`/`@SyncModel`).