### PR TITLE
[codex] preserve demo item identity

### DIFF
--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -588,16 +588,15 @@ public final class DemoServerSimulator {
                     try self.sqlite.execute(
                         """
                         UPDATE items
-                        SET title = ?, position = ?, created_at = ?, updated_at = ?
+                        SET title = ?, position = ?, updated_at = ?
                         WHERE task_id = ? AND public_id = ?
                         """,
                         bind: { stmt in
                             self.sqlite.bind(text: item.title, at: 1, in: stmt)
                             sqlite3_bind_int64(stmt, 2, Int64(item.position))
-                            self.sqlite.bind(double: item.createdAt.timeIntervalSince1970, at: 3, in: stmt)
-                            self.sqlite.bind(double: item.updatedAt.timeIntervalSince1970, at: 4, in: stmt)
-                            self.sqlite.bind(int: taskID, at: 5, in: stmt)
-                            self.sqlite.bind(text: item.publicID, at: 6, in: stmt)
+                            self.sqlite.bind(double: item.updatedAt.timeIntervalSince1970, at: 3, in: stmt)
+                            self.sqlite.bind(int: taskID, at: 4, in: stmt)
+                            self.sqlite.bind(text: item.publicID, at: 5, in: stmt)
                         }
                     )
                 }

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -521,13 +521,12 @@ public final class DemoServerSimulator {
         let normalizedTitle = try validatedNonEmpty(title, field: "title")
         let normalizedDescription = description?.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedState = try validatedTaskState(stateID)
-        let itemsToReplace: [ItemInput]?
+        let itemsToReconcile: [ItemInput]?
+        let existingItemPublicIDs: Set<String>
         if body.keys.contains("items") {
             guard let rawItems = body["items"] as? [[String: Any]] else {
                 throw DemoBackendError.validation(message: "items must be an array of objects")
             }
-            // Carry an unchanged item's title forward when the client omits it, matched by the item's
-            // public_id (the payload `id`).
             let existingRows = try itemsPayload(taskID: taskID)
             let existingTitlesByPublicID = Dictionary(
                 uniqueKeysWithValues: existingRows.compactMap { row -> (String, String)? in
@@ -537,9 +536,11 @@ public final class DemoServerSimulator {
                     return (publicID, title)
                 }
             )
-            itemsToReplace = try parseItems(rawItems, existingTitlesByID: existingTitlesByPublicID)
+            existingItemPublicIDs = Set(existingTitlesByPublicID.keys)
+            itemsToReconcile = try parseItems(rawItems, existingTitlesByID: existingTitlesByPublicID)
         } else {
-            itemsToReplace = nil
+            existingItemPublicIDs = []
+            itemsToReconcile = nil
         }
 
         // assignee_id: present key means update (NSNull clears, String sets)
@@ -577,14 +578,42 @@ public final class DemoServerSimulator {
                 }
             )
 
-            if let itemsToReplace {
-                try self.sqlite.execute(
-                    "DELETE FROM items WHERE task_id = ?",
-                    bind: { stmt in
-                        self.sqlite.bind(int: taskID, at: 1, in: stmt)
-                    }
-                )
-                try insertItems(itemsToReplace, forTaskID: taskID)
+            if let itemsToReconcile {
+                let incomingItemPublicIDs = Set(itemsToReconcile.map(\.publicID))
+                guard incomingItemPublicIDs.count == itemsToReconcile.count else {
+                    throw DemoBackendError.validation(message: "item ids must be unique")
+                }
+
+                for item in itemsToReconcile where existingItemPublicIDs.contains(item.publicID) {
+                    try self.sqlite.execute(
+                        """
+                        UPDATE items
+                        SET title = ?, position = ?, created_at = ?, updated_at = ?
+                        WHERE task_id = ? AND public_id = ?
+                        """,
+                        bind: { stmt in
+                            self.sqlite.bind(text: item.title, at: 1, in: stmt)
+                            sqlite3_bind_int64(stmt, 2, Int64(item.position))
+                            self.sqlite.bind(double: item.createdAt.timeIntervalSince1970, at: 3, in: stmt)
+                            self.sqlite.bind(double: item.updatedAt.timeIntervalSince1970, at: 4, in: stmt)
+                            self.sqlite.bind(int: taskID, at: 5, in: stmt)
+                            self.sqlite.bind(text: item.publicID, at: 6, in: stmt)
+                        }
+                    )
+                }
+
+                let newItems = itemsToReconcile.filter { !existingItemPublicIDs.contains($0.publicID) }
+                try insertItems(newItems, forTaskID: taskID)
+
+                for publicID in existingItemPublicIDs.subtracting(incomingItemPublicIDs) {
+                    try self.sqlite.execute(
+                        "DELETE FROM items WHERE task_id = ? AND public_id = ?",
+                        bind: { stmt in
+                            self.sqlite.bind(int: taskID, at: 1, in: stmt)
+                            self.sqlite.bind(text: publicID, at: 2, in: stmt)
+                        }
+                    )
+                }
             }
 
             try self.sqlite.execute("COMMIT;")

--- a/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import XCTest
 
 @testable import DemoBackend
@@ -396,6 +397,71 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertEqual(updatedItems.map { $0["id"] as? String }, ["item-b", "item-a"])
         XCTAssertTrue(updatedItems.allSatisfy { $0["done"] == nil })
         XCTAssertFalse(updatedItems.contains { ($0["id"] as? String) == "initial-item" })
+    }
+
+    func testUpdateTaskPreservesDatabaseIdentityForExistingItems() throws {
+        let url = makeTemporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
+        let now = iso8601(Date())
+        let targetTaskID = UUID().uuidString
+        _ = try backend.createTask(body: [
+            "id": targetTaskID,
+            "project_id": projectID,
+            "title": "Target task",
+            "description": "Initial",
+            "state": ["id": "todo"],
+            "author_id": userID,
+            "created_at": now,
+            "updated_at": now,
+            "items": [["id": "stable-item", "title": "Before", "position": 0]],
+        ])
+        _ = try backend.createTask(body: [
+            "id": UUID().uuidString,
+            "project_id": projectID,
+            "title": "Later task",
+            "description": "Keeps the row ID sequence ahead",
+            "state": ["id": "todo"],
+            "author_id": userID,
+            "created_at": now,
+            "updated_at": now,
+            "items": [["id": "later-item", "title": "Later", "position": 0]],
+        ])
+
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil), SQLITE_OK)
+        defer { sqlite3_close(database) }
+
+        var statement: OpaquePointer?
+        XCTAssertEqual(
+            sqlite3_prepare_v2(database, "SELECT id FROM items WHERE public_id = 'stable-item'", -1, &statement, nil),
+            SQLITE_OK
+        )
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_ROW)
+        let originalDatabaseID = sqlite3_column_int64(statement, 0)
+        sqlite3_finalize(statement)
+
+        _ = try backend.updateTask(
+            publicID: targetTaskID,
+            body: [
+                "id": targetTaskID,
+                "title": "Target task",
+                "description": "Updated",
+                "state": ["id": "todo"],
+                "items": [["id": "stable-item", "title": "After", "position": 0]],
+            ])
+
+        statement = nil
+        XCTAssertEqual(
+            sqlite3_prepare_v2(database, "SELECT id FROM items WHERE public_id = 'stable-item'", -1, &statement, nil),
+            SQLITE_OK
+        )
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_ROW)
+        let updatedDatabaseID = sqlite3_column_int64(statement, 0)
+        sqlite3_finalize(statement)
+
+        XCTAssertEqual(updatedDatabaseID, originalDatabaseID)
     }
 
     func testUpdateTaskFromBodyDictItemsKeyAbsentPreservesItems() throws {

--- a/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
@@ -464,6 +464,63 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertEqual(updatedDatabaseID, originalDatabaseID)
     }
 
+    func testUpdateTaskPreservesCreatedAtForExistingItems() throws {
+        let url = makeTemporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
+        let now = iso8601(Date())
+        let targetTaskID = UUID().uuidString
+        let pinnedCreatedAt = iso8601(Date(timeIntervalSince1970: 1_000_000_000))
+        _ = try backend.createTask(body: [
+            "id": targetTaskID,
+            "project_id": projectID,
+            "title": "Target task",
+            "description": "Initial",
+            "state": ["id": "todo"],
+            "author_id": userID,
+            "created_at": now,
+            "updated_at": now,
+            "items": [["id": "stable-item", "title": "Before", "position": 0, "created_at": pinnedCreatedAt]],
+        ])
+
+        var database: OpaquePointer?
+        XCTAssertEqual(sqlite3_open_v2(url.path, &database, SQLITE_OPEN_READONLY, nil), SQLITE_OK)
+        defer { sqlite3_close(database) }
+
+        var statement: OpaquePointer?
+        XCTAssertEqual(
+            sqlite3_prepare_v2(database, "SELECT created_at FROM items WHERE public_id = 'stable-item'", -1, &statement, nil),
+            SQLITE_OK
+        )
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_ROW)
+        let originalCreatedAt = sqlite3_column_double(statement, 0)
+        sqlite3_finalize(statement)
+
+        XCTAssertEqual(originalCreatedAt, 1_000_000_000, accuracy: 0.001)
+
+        _ = try backend.updateTask(
+            publicID: targetTaskID,
+            body: [
+                "id": targetTaskID,
+                "title": "Target task",
+                "description": "Updated",
+                "state": ["id": "todo"],
+                "items": [["id": "stable-item", "title": "After", "position": 0]],
+            ])
+
+        statement = nil
+        XCTAssertEqual(
+            sqlite3_prepare_v2(database, "SELECT created_at FROM items WHERE public_id = 'stable-item'", -1, &statement, nil),
+            SQLITE_OK
+        )
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_ROW)
+        let updatedCreatedAt = sqlite3_column_double(statement, 0)
+        sqlite3_finalize(statement)
+
+        XCTAssertEqual(updatedCreatedAt, originalCreatedAt, accuracy: 0.001)
+    }
+
     func testUpdateTaskFromBodyDictItemsKeyAbsentPreservesItems() throws {
         let url = makeTemporaryDatabaseURL()
         defer { try? FileManager.default.removeItem(at: url) }

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -11,10 +11,6 @@ Companion audits:
 
 ## Now
 
-- [ ] **Preserve item identity during demo-backend updates.** Task updates currently replace the entire
-      item collection by deleting and reinserting it. Reconcile by `public_id`: update existing items,
-      insert new items, and delete missing items. Unchanged items must retain their internal database id.
-
 - [ ] **Make demo-backend upload upserts atomic.** `/sync/upload` currently looks up `public_id` and then
       chooses insert or update. Replace that race with `INSERT ... ON CONFLICT(public_id) DO UPDATE`, or
       recover a uniqueness conflict inside one transaction. The demo is single-threaded today, but the


### PR DESCRIPTION
## What changed

- reconcile task items by `public_id` during demo-backend task updates
- update existing items in place, insert new items, and delete omitted items
- add a regression test that verifies an existing item's internal SQLite ID remains stable
- remove the completed item from the world-class roadmap

## Why

The update path deleted every item and inserted the submitted collection again. Even when an item kept the same public identity, its internal database identity could change, which is unsafe for relationships and any future state keyed to that row.

## Root cause

Item collections were treated as replace-all payloads at the storage layer instead of reconciling the replace-all API representation against stable `public_id` values.

## Validation

- red-first `DemoBackendTests.testUpdateTaskPreservesDatabaseIdentityForExistingItems` (ID changed from 3 to 5 before the fix)
- `swift test` — DemoBackend: 31 tests, green
- `swift test` — DemoCore: 43 tests, green
- `git diff --check`
