### PR TITLE
docs(roadmap): defer upload-upsert hardening (race is a non-scenario)

### DIFF
--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -15,11 +15,6 @@ Companion audits:
       item collection by deleting and reinserting it. Reconcile by `public_id`: update existing items,
       insert new items, and delete missing items. Unchanged items must retain their internal database id.
 
-- [ ] **Make demo-backend upload upserts atomic.** `/sync/upload` currently looks up `public_id` and then
-      chooses insert or update. Replace that race with `INSERT ... ON CONFLICT(public_id) DO UPDATE`, or
-      recover a uniqueness conflict inside one transaction. The demo is single-threaded today, but the
-      endpoint contract promises idempotent upserts and should model the concurrency-safe shape.
-
 - [ ] **Add sync lifecycle observability.** Provide a multi-consumer `events()` stream for sync start and
       completion, applied/stale/rejected outcomes, counts, and duration. Errors continue to bubble and
       per-row failures remain consumer-owned; the stream observes outcomes rather than persisting policy.
@@ -44,6 +39,11 @@ Companion audits:
       an attribute to an existing stored property. Runtime validation is the current contract.
 - [ ] Add authorization and ownership checks in a real authenticated backend. The demo has no principals;
       client-minted ids are not an authorization boundary.
+- [ ] Harden `/sync/upload` upserts against a same-`public_id` write race only once a real concurrent
+      backend exists. Distinct rows can't collide — client-minted UUIDs are unique per row — so the only
+      conflict is a client racing its own retry of the *same* row, which is impossible in the
+      single-threaded demo where sequential update-else-create already converges. Revisit with
+      `INSERT ... ON CONFLICT(public_id) DO UPDATE` (or one-transaction conflict recovery) then.
 
 ## First release
 


### PR DESCRIPTION
Concluded against building the 'make demo-backend upload upserts atomic' Now item.

The `UNIQUE(public_id)` conflict it targets **cannot occur in the single-threaded demo**:
- distinct rows never collide — client-minted UUIDs are unique per row (the core SwiftSync identity contract);
- the only conflict is a client racing *its own* retry of the *same* row, which needs real concurrency the demo doesn't have — and there, sequential update-else-create already converges.

So there's no observable behavior to fix and no honest red-first test without an artificial injection seam. Moved to the evidence-gated bucket next to the other 'real backend' items, with the `ON CONFLICT(public_id) DO UPDATE` shape preserved as the revisit note for when concurrency is real.

Doc-only.