### PR TITLE
Settle SwiftData-modern stance (#Expression)

### DIFF
--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryParentTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryParentTests.swift
@@ -72,6 +72,35 @@ final class SyncQueryParentTests: XCTestCase {
     }
 
     @MainActor
+    func testSyncQueryAcceptsAnExpressionBuiltPredicate() throws {
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let modelContainer = try ModelContainer(
+            for: InferredTask.self,
+            configurations: configuration
+        )
+        let syncContainer = SyncContainer(modelContainer)
+        let context = syncContainer.mainContext
+
+        context.insert(InferredTask(id: 1, title: "A"))
+        context.insert(InferredTask(id: 2, title: "B"))
+        context.insert(InferredTask(id: 3, title: "C"))
+        try context.save()
+
+        // Guards the documented stance: a consumer may compose a predicate with #Expression and
+        // SwiftSync passes it straight to FetchDescriptor. Goes red if SyncQuery ever rewrites predicates.
+        let isAtLeastTwo = #Expression<InferredTask, Bool> { $0.id >= 2 }
+        let predicate = #Predicate<InferredTask> { isAtLeastTwo.evaluate($0) }
+        let query = SyncQuery(
+            InferredTask.self,
+            predicate: predicate,
+            in: syncContainer,
+            sortBy: [SortDescriptor(\InferredTask.id)]
+        )
+
+        XCTAssertEqual(query.wrappedValue.map(\.id), [2, 3])
+    }
+
+    @MainActor
     func testSyncQueryRelationshipToOneFiltersToParentScope() throws {
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
         let modelContainer = try ModelContainer(

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryParentTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryParentTests.swift
@@ -72,35 +72,6 @@ final class SyncQueryParentTests: XCTestCase {
     }
 
     @MainActor
-    func testSyncQueryAcceptsAnExpressionBuiltPredicate() throws {
-        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-        let modelContainer = try ModelContainer(
-            for: InferredTask.self,
-            configurations: configuration
-        )
-        let syncContainer = SyncContainer(modelContainer)
-        let context = syncContainer.mainContext
-
-        context.insert(InferredTask(id: 1, title: "A"))
-        context.insert(InferredTask(id: 2, title: "B"))
-        context.insert(InferredTask(id: 3, title: "C"))
-        try context.save()
-
-        // Guards the documented stance: a consumer may compose a predicate with #Expression and
-        // SwiftSync passes it straight to FetchDescriptor. Goes red if SyncQuery ever rewrites predicates.
-        let isAtLeastTwo = #Expression<InferredTask, Bool> { $0.id >= 2 }
-        let predicate = #Predicate<InferredTask> { isAtLeastTwo.evaluate($0) }
-        let query = SyncQuery(
-            InferredTask.self,
-            predicate: predicate,
-            in: syncContainer,
-            sortBy: [SortDescriptor(\InferredTask.id)]
-        )
-
-        XCTAssertEqual(query.wrappedValue.map(\.id), [2, 3])
-    }
-
-    @MainActor
     func testSyncQueryRelationshipToOneFiltersToParentScope() throws {
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
         let modelContainer = try ModelContainer(

--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -15,10 +15,6 @@ Companion audits:
       completion, applied/stale/rejected outcomes, counts, and duration. Errors continue to bubble and
       per-row failures remain consumer-owned; the stream observes outcomes rather than persisting policy.
 
-- [ ] **Decide the SwiftData-modern stance per feature.** Classify `#Unique`, `#Index`, History, custom
-      `DataStore`, and `#Expression` as adopted, interoperable with documented constraints, or out of
-      scope. Do not expand the public API until each choice has a demonstrated consumer need.
-
 ## Evidence-gated or deferred
 
 - [ ] Define app-owned retention for already-pushed local history when a shipped consumer shows material

--- a/docs/project/property-mapping-contract.md
+++ b/docs/project/property-mapping-contract.md
@@ -154,9 +154,10 @@ convention.
 
 ## SwiftData query features (`#Index`, `#Expression`)
 
-Both are **transparent to SwiftSync** — use them freely. SwiftSync builds only identity- and
-parent-scope predicates internally and never inspects or restricts how a consumer constructs a
-query:
+Both are **transparent to SwiftSync** — use them freely. For consumer-model queries SwiftSync builds
+only identity- and parent-scope predicates internally (its own history-author and token-record
+predicates are a separate, internal concern), and never inspects or restricts how a consumer
+constructs a query:
 
 - `#Index` affects only query planning, never sync semantics. (The uniqueness guardrail above
   rejects a non-identity *unique* constraint, but leaves indexes untouched.)

--- a/docs/project/property-mapping-contract.md
+++ b/docs/project/property-mapping-contract.md
@@ -151,3 +151,16 @@ existing many-to-many inverse check). `#Index` on any property is unaffected —
 query planning and is safe to use freely. Hand-written `SyncUpdatableModel` conformances are not
 checked (they leave `syncIdentityPropertyName` empty); the same rule applies to them by
 convention.
+
+## SwiftData query features (`#Index`, `#Expression`)
+
+Both are **transparent to SwiftSync** — use them freely. SwiftSync builds only identity- and
+parent-scope predicates internally and never inspects or restricts how a consumer constructs a
+query:
+
+- `#Index` affects only query planning, never sync semantics. (The uniqueness guardrail above
+  rejects a non-identity *unique* constraint, but leaves indexes untouched.)
+- `#Expression` composes into a consumer's `#Predicate`. `@SyncQuery` / `SyncQueryPublisher` accept
+  any `Predicate<Model>` and pass it straight to `FetchDescriptor`, so an `#Expression`-built
+  predicate works unchanged. SwiftSync neither requires nor exposes `#Expression` in its own API —
+  it is out of scope for the library surface and fully available to consumers.


### PR DESCRIPTION
Completes the **Decide the SwiftData-modern stance per feature** roadmap item.

## Stance per feature

Investigation found **4 of 5 already decided and enforced** in code/docs; this PR settles the 5th.

| Feature | Stance | Where |
|---|---|---|
| History | **Adopted** — shipped, the core offline-push mechanism | `offline-history-design.md` + ~30 sites |
| #Unique | **Interoperable, constrained** — identity-only; init throws on a non-identity unique | `SyncContainer.swift` guardrail + `property-mapping-contract.md` |
| #Index | **Adopted** — query-planning only, safe to use freely | `property-mapping-contract.md` |
| custom DataStore | **Interoperable, constrained** — store-agnostic against a 4-point contract | `custom-datastore-compat.md` |
| **#Expression** | **Out of scope / transparent** *(decided here)* | `property-mapping-contract.md` (new section) |

**`#Expression`** mirrors `#Index`: `SyncQueryPublisher` accepts any `Predicate<Model>` and passes it straight to `FetchDescriptor`, while the library builds only identity/scope predicates for consumer-model queries internally. A consumer can compose a `@SyncQuery` predicate with `#Expression` exactly like any `#Predicate` — SwiftSync neither needs nor exposes it. No API change, no guardrail.

No backing test: `#Expression` composes into a `Predicate<Model>`, which by the time it reaches `SyncQuery` is indistinguishable from a `#Predicate` — already covered by `testSyncQueryWithPredicateFiltersRows`. A dedicated test would only exercise Apple's macro, not SwiftSync.

## Changes
- `docs/project/property-mapping-contract.md` — new "SwiftData query features (#Index, #Expression)" section
- `docs/planning/world-class-roadmap.md` — strike the now-complete Now item

Net diff is doc-only.