### PR TITLE
docs(roadmap): defer sync observability (speculative)

### DIFF
--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -11,9 +11,7 @@ Companion audits:
 
 ## Now
 
-- [ ] **Add sync lifecycle observability.** Provide a multi-consumer `events()` stream for sync start and
-      completion, applied/stale/rejected outcomes, counts, and duration. Errors continue to bubble and
-      per-row failures remain consumer-owned; the stream observes outcomes rather than persisting policy.
+_Nothing actively committed — open work is evidence-gated below or deferred to first release._
 
 ## Evidence-gated or deferred
 
@@ -36,6 +34,12 @@ Companion audits:
       conflict is a client racing its own retry of the *same* row, which is impossible in the
       single-threaded demo where sequential update-else-create already converges. Revisit with
       `INSERT ... ON CONFLICT(public_id) DO UPDATE` (or one-transaction conflict recovery) then.
+- [ ] Add sync lifecycle observability (a multi-consumer `events()` stream) only when a real *out-of-band*
+      consumer needs it — an autonomous background drain, or a status view spanning many concurrent syncs.
+      For the current explicit-`await` model the call boundary already gives the caller start, completion,
+      duration, and failure (`throws`); counts are a `fetch` away. The predecessor `3lvis/Sync` shipped for
+      years on an `error`-only completion and never surfaced counts/duration. Don't build a stream until a
+      consumer genuinely can't get the same by awaiting the call.
 
 ## First release
 


### PR DESCRIPTION
Abandoned the sync-lifecycle `events()` feature after checking our own history.

**Finding:** `func events`/`AsyncStream` appear in `.swift` code only on the (now-deleted) feature branch. Every other reference across history is a *docs* roadmap aspiration — it was never implemented. The predecessor `3lvis/Sync` shipped for years on an `error`-only completion and never surfaced counts or duration.

**Why it's not worth building now:** for the current explicit-`await` model, the call boundary already hands the caller start (before), completion (after the await), duration (wrap it), and failure (`throws`); counts are a `fetch` away. A stream only adds value for observing sync triggered *out-of-band* (an autonomous background drain, or status across many concurrent syncs) — none of which exists today. Building it would have meant manufacturing a consumer to justify the seam, violating 'no abstraction without a consumer'.

Moves the item from **Now** to **evidence-gated** with that rationale; **Now** is now empty (nothing actively committed). The abandoned implementation is recoverable at `36d463ea` if a real consumer ever appears.

Doc-only.