### PR TITLE
docs(roadmap): drop concluded observability item

### DIFF
--- a/docs/planning/world-class-roadmap.md
+++ b/docs/planning/world-class-roadmap.md
@@ -34,12 +34,6 @@ _Nothing actively committed — open work is evidence-gated below or deferred to
       conflict is a client racing its own retry of the *same* row, which is impossible in the
       single-threaded demo where sequential update-else-create already converges. Revisit with
       `INSERT ... ON CONFLICT(public_id) DO UPDATE` (or one-transaction conflict recovery) then.
-- [ ] Add sync lifecycle observability (a multi-consumer `events()` stream) only when a real *out-of-band*
-      consumer needs it — an autonomous background drain, or a status view spanning many concurrent syncs.
-      For the current explicit-`await` model the call boundary already gives the caller start, completion,
-      duration, and failure (`throws`); counts are a `fetch` away. The predecessor `3lvis/Sync` shipped for
-      years on an `error`-only completion and never surfaced counts/duration. Don't build a stream until a
-      consumer genuinely can't get the same by awaiting the call.
 
 ## First release
 


### PR DESCRIPTION
Follow-up to #667. We *concluded against* sync observability rather than deferring it — so an open `- [ ]` checkbox in evidence-gated misrepresents a settled decision as pending work. Per the roadmap's own rule ('keep only work that is still actionable'), removing it; the rationale lives in #667 + commit `fced5145`, and the abandoned impl is at `36d463ea` if a real consumer ever surfaces.

Doc-only.