### PR TITLE
demo: real JSON wire boundary (backend speaks Data, client decodes)

### DIFF
--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -99,7 +99,7 @@ public final class DemoServerSimulator {
         )
     }
 
-    public func getUsersPayload() throws -> [[String: Any]] {
+    public func getUsersPayload() throws -> Data {
         let rows = try self.sqlite.query(
             """
             SELECT id, display_name, created_at, updated_at
@@ -107,19 +107,20 @@ public final class DemoServerSimulator {
             ORDER BY id ASC
             """
         )
-        return rows.map { row in
-            [
-                "id": row.string("id"),
-                "display_name": row.string("display_name"),
-                "created_at": iso8601(row.double("created_at")),
-                "updated_at": iso8601(row.double("updated_at")),
-            ]
-        }
+        return try Self.responseData(
+            rows.map { row in
+                [
+                    "id": row.string("id"),
+                    "display_name": row.string("display_name"),
+                    "created_at": iso8601(row.double("created_at")),
+                    "updated_at": iso8601(row.double("updated_at")),
+                ]
+            })
     }
 
-    public func getTaskStateOptionsPayload() throws -> [[String: Any]] {
+    public func getTaskStateOptionsPayload() throws -> Data {
         let timestamp = iso8601(0)
-        return [
+        return try Self.responseData([
             [
                 "id": "todo",
                 "label": "To Do",
@@ -141,7 +142,7 @@ public final class DemoServerSimulator {
                 "created_at": timestamp,
                 "updated_at": timestamp,
             ],
-        ]
+        ])
     }
 
     public func getTaskDetailPayload(publicID: String) throws -> [String: Any]? {

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -52,7 +52,7 @@ public final class DemoServerSimulator {
         try Self.prepareSchema(self.sqlite, seedData: seedData)
     }
 
-    public func getProjectsPayload() throws -> [[String: Any]] {
+    public func getProjectsPayload() throws -> Data {
         let rows = try self.sqlite.query(
             """
             SELECT
@@ -67,15 +67,16 @@ public final class DemoServerSimulator {
             ORDER BY projects.id ASC
             """
         )
-        return rows.map { row in
-            [
-                "id": row.string("id"),
-                "name": row.string("name"),
-                "task_count": Int(row.int64("task_count")),
-                "created_at": iso8601(row.double("created_at")),
-                "updated_at": iso8601(row.double("updated_at")),
-            ]
-        }
+        return try Self.responseData(
+            rows.map { row in
+                [
+                    "id": row.string("id"),
+                    "name": row.string("name"),
+                    "task_count": Int(row.int64("task_count")),
+                    "created_at": iso8601(row.double("created_at")),
+                    "updated_at": iso8601(row.double("updated_at")),
+                ]
+            })
     }
 
     public func getProjectTasksPayload(projectID: String) throws -> [[String: Any]] {
@@ -1148,6 +1149,12 @@ public final class DemoServerSimulator {
 
     private func iso8601(_ secondsSince1970: Double) -> String {
         formatter.string(from: Date(timeIntervalSince1970: secondsSince1970))
+    }
+
+    /// Serializes a response body to JSON bytes — the server's side of the wire. The client decodes
+    /// these bytes back into values, exactly as it would over a network.
+    static func responseData(_ object: Any) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object)
     }
 
     private func shouldApplyAmbientProjectMutationOnRead() -> Bool {

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -79,7 +79,7 @@ public final class DemoServerSimulator {
             })
     }
 
-    public func getProjectTasksPayload(projectID: String) throws -> [[String: Any]] {
+    public func getProjectTasksPayload(projectID: String) throws -> Data {
         if enableAmbientProjectMutationsOnRead, shouldApplyAmbientProjectMutationOnRead() {
             let next = (ambientProjectReadCounters[projectID] ?? 0) + 1
             ambientProjectReadCounters[projectID] = next
@@ -89,7 +89,7 @@ public final class DemoServerSimulator {
             }
         }
 
-        return try getProjectTasksPayloadRaw(projectID: projectID)
+        return try Self.responseData(getProjectTasksPayloadRaw(projectID: projectID))
     }
 
     private func getProjectTasksPayloadRaw(projectID: String) throws -> [[String: Any]] {
@@ -145,9 +145,9 @@ public final class DemoServerSimulator {
         ])
     }
 
-    public func getTaskDetailPayload(publicID: String) throws -> [String: Any]? {
+    public func getTaskDetailPayload(publicID: String) throws -> Data? {
         guard let rowID = try taskRowID(forPublicID: publicID, includeTombstoned: true) else { return nil }
-        return try taskDetailPayload(rowID: rowID)
+        return try taskDetailPayload(rowID: rowID).map { try Self.responseData($0) }
     }
 
     private func taskDetailPayload(rowID: Int) throws -> [String: Any]? {
@@ -167,7 +167,7 @@ public final class DemoServerSimulator {
     }
 
     @discardableResult
-    public func patchTaskState(publicID: String, state: String) throws -> [String: Any]? {
+    public func patchTaskState(publicID: String, state: String) throws -> Data? {
         _ = try validatedTaskState(state)
         guard let rowID = try taskRowID(forPublicID: publicID),
             let current = try taskDetailPayload(rowID: rowID)
@@ -188,11 +188,11 @@ public final class DemoServerSimulator {
                 self.sqlite.bind(int: rowID, at: 3, in: stmt)
             }
         )
-        return try taskDetailPayload(rowID: rowID)
+        return try taskDetailPayload(rowID: rowID).map { try Self.responseData($0) }
     }
 
     @discardableResult
-    public func patchTaskAssignee(publicID: String, assigneeID: String?) throws -> [String: Any]? {
+    public func patchTaskAssignee(publicID: String, assigneeID: String?) throws -> Data? {
         if let assigneeID, !(try exists(in: "users", id: assigneeID)) {
             throw DemoBackendError.invalidReference(entity: "assignee_id", id: assigneeID)
         }
@@ -215,13 +215,13 @@ public final class DemoServerSimulator {
                 self.sqlite.bind(int: rowID, at: 3, in: stmt)
             }
         )
-        return try taskDetailPayload(rowID: rowID)
+        return try taskDetailPayload(rowID: rowID).map { try Self.responseData($0) }
     }
 
     @discardableResult
-    public func replaceTaskReviewers(publicID: String, reviewerIDs: [String]) throws -> [String: Any]? {
+    public func replaceTaskReviewers(publicID: String, reviewerIDs: [String]) throws -> Data? {
         guard let rowID = try taskRowID(forPublicID: publicID, includeTombstoned: true) else { return nil }
-        return try replaceReviewers(rowID: rowID, reviewerIDs: reviewerIDs)
+        return try replaceReviewers(rowID: rowID, reviewerIDs: reviewerIDs).map { try Self.responseData($0) }
     }
 
     /// Int-keyed internal so callers that already resolved the row (e.g. `uploadUpsert`) don't re-resolve
@@ -282,9 +282,9 @@ public final class DemoServerSimulator {
     }
 
     @discardableResult
-    public func replaceTaskWatchers(publicID: String, watcherIDs: [String]) throws -> [String: Any]? {
+    public func replaceTaskWatchers(publicID: String, watcherIDs: [String]) throws -> Data? {
         guard let rowID = try taskRowID(forPublicID: publicID, includeTombstoned: true) else { return nil }
-        return try replaceWatchers(rowID: rowID, watcherIDs: watcherIDs)
+        return try replaceWatchers(rowID: rowID, watcherIDs: watcherIDs).map { try Self.responseData($0) }
     }
 
     @discardableResult
@@ -342,7 +342,8 @@ public final class DemoServerSimulator {
         return try taskDetailPayload(rowID: rowID)
     }
 
-    public func createTask(body: [String: Any]) throws -> [String: Any] {
+    public func createTask(body bodyData: Data) throws -> Data {
+        let body = try Self.requestObject(bodyData)
         // Client-originated rows adopt the body's `id` as public_id; server-origin rows (no `id`)
         // get a freshly minted lowercased UUID.
         let publicID = (body["id"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? UUID().uuidString.lowercased()
@@ -402,14 +403,14 @@ public final class DemoServerSimulator {
 
         guard body["reviewer_ids"] is [String] || body["watcher_ids"] is [String],
             let rowID = try taskRowID(forPublicID: publicID, includeTombstoned: true)
-        else { return created }
+        else { return try Self.responseData(created) }
         if let reviewerIDs = body["reviewer_ids"] as? [String] {
             _ = try replaceReviewers(rowID: rowID, reviewerIDs: reviewerIDs)
         }
         if let watcherIDs = body["watcher_ids"] as? [String] {
             _ = try replaceWatchers(rowID: rowID, watcherIDs: watcherIDs)
         }
-        return try taskDetailPayload(rowID: rowID) ?? created
+        return try Self.responseData(taskDetailPayload(rowID: rowID) ?? created)
     }
 
     @discardableResult
@@ -484,11 +485,12 @@ public final class DemoServerSimulator {
     /// id, project_id, author_id, and created_at are immutable; they are validated for consistency
     /// but not updated. updated_at is always advanced by the server regardless of the incoming value.
     @discardableResult
-    public func updateTask(publicID: String, body: [String: Any]) throws -> [String: Any] {
+    public func updateTask(publicID: String, body bodyData: Data) throws -> Data {
+        let body = try Self.requestObject(bodyData)
         guard let rowID = try taskRowID(forPublicID: publicID) else {
             throw DemoBackendError.notFound(entity: "task", id: publicID)
         }
-        return try updateTaskInternal(rowID: rowID, body: body)
+        return try Self.responseData(updateTaskInternal(rowID: rowID, body: body))
     }
 
     @discardableResult
@@ -655,9 +657,10 @@ public final class DemoServerSimulator {
     // row's public_id. The internal int id never leaves the server. `upsert` is find-by-public_id →
     // update-else-create, `delete` tombstones by public_id. Both are idempotent.
 
-    public func upload(operations: [[String: Any]]) throws -> [String: Any] {
+    public func upload(operations operationsData: Data) throws -> Data {
+        let operations = try Self.requestArray(operationsData)
         let results = operations.map(applyUploadOperation(_:))
-        return ["results": results, "cursor": iso8601(Date().timeIntervalSince1970)]
+        return try Self.responseData(["results": results, "cursor": iso8601(Date().timeIntervalSince1970)])
     }
 
     private func applyUploadOperation(_ payload: [String: Any]) -> [String: Any] {
@@ -705,7 +708,7 @@ public final class DemoServerSimulator {
             )
             _ = try updateTaskInternal(rowID: existingID, body: body)
         } else {
-            _ = try createTask(body: body)
+            _ = try createTask(body: Self.responseData(body))
         }
         return ["operation": "upsert", "id": id, "status": "applied"]
     }
@@ -1156,6 +1159,21 @@ public final class DemoServerSimulator {
     /// these bytes back into values, exactly as it would over a network.
     static func responseData(_ object: Any) throws -> Data {
         try JSONSerialization.data(withJSONObject: object)
+    }
+
+    /// Parses a JSON request body off the wire — the server's side of decoding the client's bytes.
+    static func requestObject(_ data: Data) throws -> [String: Any] {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DemoBackendError.validation(message: "request body must be a JSON object")
+        }
+        return object
+    }
+
+    static func requestArray(_ data: Data) throws -> [[String: Any]] {
+        guard let array = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw DemoBackendError.validation(message: "request body must be a JSON array")
+        }
+        return array
     }
 
     private func shouldApplyAmbientProjectMutationOnRead() -> Bool {

--- a/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
@@ -17,7 +17,7 @@ final class DemoBackendTests: XCTestCase {
 
         let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
 
-        let projects = try backend.getProjectsPayload()
+        let projects = try decodeArray(backend.getProjectsPayload())
         let users = try backend.getUsersPayload()
         let taskStates = try backend.getTaskStateOptionsPayload()
         let projectTasks = try backend.getProjectTasksPayload(projectID: projectID)
@@ -60,7 +60,7 @@ final class DemoBackendTests: XCTestCase {
         let seed = DemoSeedData.generate()
         let backend = try DemoServerSimulator(databaseURL: url, seedData: seed)
 
-        let projects = try backend.getProjectsPayload()
+        let projects = try decodeArray(backend.getProjectsPayload())
         let users = try backend.getUsersPayload()
         let tasks = try backend.getProjectTasksPayload(projectID: seed.projects[0].id)
         let firstTaskID = try XCTUnwrap(tasks.first?["id"] as? String)
@@ -935,6 +935,15 @@ final class DemoBackendTests: XCTestCase {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f.string(from: date)
+    }
+
+    /// Decodes a JSON `Data` response from the backend back into a dictionary, as a real client would.
+    private func decodeArray(_ data: Data) throws -> [[String: Any]] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+    }
+
+    private func decodeObject(_ data: Data) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
     private func makeTemporaryDatabaseURL() -> URL {

--- a/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
@@ -20,7 +20,7 @@ final class DemoBackendTests: XCTestCase {
         let projects = try decodeArray(backend.getProjectsPayload())
         let users = try decodeArray(backend.getUsersPayload())
         let taskStates = try decodeArray(backend.getTaskStateOptionsPayload())
-        let projectTasks = try backend.getProjectTasksPayload(projectID: projectID)
+        let projectTasks = try decodeArray(backend.getProjectTasksPayload(projectID: projectID))
 
         XCTAssertEqual(projects.count, 1)
         XCTAssertEqual(users.count, 1)
@@ -62,9 +62,9 @@ final class DemoBackendTests: XCTestCase {
 
         let projects = try decodeArray(backend.getProjectsPayload())
         let users = try decodeArray(backend.getUsersPayload())
-        let tasks = try backend.getProjectTasksPayload(projectID: seed.projects[0].id)
+        let tasks = try decodeArray(backend.getProjectTasksPayload(projectID: seed.projects[0].id))
         let firstTaskID = try XCTUnwrap(tasks.first?["id"] as? String)
-        let detail = try backend.getTaskDetailPayload(publicID: firstTaskID)
+        let detail = try decodeObject(backend.getTaskDetailPayload(publicID: firstTaskID))
         let taskItems = items(in: detail)
 
         // Reference data (projects/users) keeps TEXT UUID ids.
@@ -145,26 +145,26 @@ final class DemoBackendTests: XCTestCase {
 
         let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
 
-        let patchedState = try backend.patchTaskState(publicID: taskID, state: "done")
+        let patchedState = try decodeObject(backend.patchTaskState(publicID: taskID, state: "done"))
         XCTAssertEqual(stateID(in: patchedState), "done")
         XCTAssertEqual(stateLabel(in: patchedState), "Done")
 
-        let clearedAssignee = try backend.patchTaskAssignee(publicID: taskID, assigneeID: nil)
+        let clearedAssignee = try decodeObject(backend.patchTaskAssignee(publicID: taskID, assigneeID: nil))
         XCTAssertTrue((clearedAssignee?["assignee_id"] is NSNull))
 
-        let reassigned = try backend.patchTaskAssignee(publicID: taskID, assigneeID: userID)
+        let reassigned = try decodeObject(backend.patchTaskAssignee(publicID: taskID, assigneeID: userID))
         XCTAssertEqual(reassigned?["assignee_id"] as? String, userID)
 
-        let clearedReviewers = try backend.replaceTaskReviewers(publicID: taskID, reviewerIDs: [])
+        let clearedReviewers = try decodeObject(backend.replaceTaskReviewers(publicID: taskID, reviewerIDs: []))
         XCTAssertEqual(clearedReviewers?["reviewer_ids"] as? [String], [])
 
-        let reReviewed = try backend.replaceTaskReviewers(publicID: taskID, reviewerIDs: [userID])
+        let reReviewed = try decodeObject(backend.replaceTaskReviewers(publicID: taskID, reviewerIDs: [userID]))
         XCTAssertEqual(reReviewed?["reviewer_ids"] as? [String], [userID])
 
-        let rewatched = try backend.replaceTaskWatchers(publicID: taskID, watcherIDs: [userID])
+        let rewatched = try decodeObject(backend.replaceTaskWatchers(publicID: taskID, watcherIDs: [userID]))
         XCTAssertEqual(rewatched?["watcher_ids"] as? [String], [userID])
 
-        let clearedWatchers = try backend.replaceTaskWatchers(publicID: taskID, watcherIDs: [])
+        let clearedWatchers = try decodeObject(backend.replaceTaskWatchers(publicID: taskID, watcherIDs: []))
         XCTAssertEqual(clearedWatchers?["watcher_ids"] as? [String], [])
     }
 
@@ -350,7 +350,7 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertEqual(createdItems.map { $0["position"] as? Int }, [0, 1])
         XCTAssertEqual(createdItems.map { $0["task_id"] as? String }, [serverID, serverID])
 
-        let detail = try backend.getTaskDetailPayload(publicID: serverID)
+        let detail = try decodeObject(backend.getTaskDetailPayload(publicID: serverID))
         let detailItems = items(in: detail)
         XCTAssertEqual(detailItems.count, 2)
         XCTAssertEqual(detailItems.map { $0["id"] as? String }, ["item-1", "item-2"])
@@ -638,10 +638,10 @@ final class DemoBackendTests: XCTestCase {
                 ],
             ])
 
-        let detail = try backend.getTaskDetailPayload(publicID: serverID)
+        let detail = try decodeObject(backend.getTaskDetailPayload(publicID: serverID))
         XCTAssertEqual(items(in: detail).map { $0["id"] as? String }, ["item-b", "item-a"])
 
-        let projectTasks = try backend.getProjectTasksPayload(projectID: projectID)
+        let projectTasks = try decodeArray(backend.getProjectTasksPayload(projectID: projectID))
         let persistedTask = projectTasks.first { ($0["id"] as? String) == serverID }
         XCTAssertEqual(items(in: persistedTask).map { $0["id"] as? String }, ["item-b", "item-a"])
     }
@@ -679,15 +679,15 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertEqual(stateID(in: created), "todo")
         XCTAssertEqual(stateLabel(in: created), "To Do")
 
-        let projectTasksAfterCreate = try backend.getProjectTasksPayload(projectID: projectID)
+        let projectTasksAfterCreate = try decodeArray(backend.getProjectTasksPayload(projectID: projectID))
         XCTAssertEqual(projectTasksAfterCreate.count, 2)
         XCTAssertTrue(projectTasksAfterCreate.contains { ($0["id"] as? String) == serverID })
 
         try backend.deleteTask(publicID: serverID)
 
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: serverID))
+        XCTAssertNil(try decodeObject(backend.getTaskDetailPayload(publicID: serverID)))
 
-        let projectTasksAfterDelete = try backend.getProjectTasksPayload(projectID: projectID)
+        let projectTasksAfterDelete = try decodeArray(backend.getProjectTasksPayload(projectID: projectID))
         XCTAssertEqual(projectTasksAfterDelete.count, 1)
         XCTAssertEqual(projectTasksAfterDelete[0]["id"] as? String, taskID)
     }
@@ -698,7 +698,7 @@ final class DemoBackendTests: XCTestCase {
 
         let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
 
-        let before = try backend.getTaskDetailPayload(publicID: taskID)
+        let before = try decodeObject(backend.getTaskDetailPayload(publicID: taskID))
         let beforeUpdatedAt = before?["updated_at"] as? String
 
         // Build a body that mirrors the shape SwiftSync's exportObject produces:
@@ -733,7 +733,7 @@ final class DemoBackendTests: XCTestCase {
 
         let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
 
-        let before = try XCTUnwrap(backend.getTaskDetailPayload(publicID: taskID))
+        let before = try XCTUnwrap(decodeObject(backend.getTaskDetailPayload(publicID: taskID)))
         XCTAssertEqual(before["reviewer_ids"] as? [String], [userID])
         XCTAssertEqual(before["watcher_ids"] as? [String], [userID])
 
@@ -902,10 +902,10 @@ final class DemoBackendTests: XCTestCase {
         )
 
         for _ in 1...8 {
-            _ = try backend.getProjectTasksPayload(projectID: projectID)
+            _ = try decodeArray(backend.getProjectTasksPayload(projectID: projectID))
         }
 
-        let projectTasks = try backend.getProjectTasksPayload(projectID: projectID)
+        let projectTasks = try decodeArray(backend.getProjectTasksPayload(projectID: projectID))
         XCTAssertFalse(projectTasks.isEmpty)
         XCTAssertTrue(projectTasks.allSatisfy { ($0["project_id"] as? String) == projectID })
 
@@ -935,15 +935,6 @@ final class DemoBackendTests: XCTestCase {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f.string(from: date)
-    }
-
-    /// Decodes a JSON `Data` response from the backend back into a dictionary, as a real client would.
-    private func decodeArray(_ data: Data) throws -> [[String: Any]] {
-        try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
-    }
-
-    private func decodeObject(_ data: Data) throws -> [String: Any] {
-        try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
     private func makeTemporaryDatabaseURL() -> URL {
@@ -992,4 +983,42 @@ final class DemoBackendTests: XCTestCase {
             ]
         )
     }
+}
+
+// Test-only dict-in/dict-out bridges over the real JSON-`Data` wire methods, so existing dict-based
+// backend tests keep working without re-encoding/decoding at every call site. These overload by
+// parameter type (`[String: Any]` vs `Data`), so the compiler picks them for dict literals.
+extension DemoServerSimulator {
+    func createTask(body: [String: Any]) throws -> [String: Any] {
+        try JSONSerialization.jsonObject(with: createTask(body: JSONSerialization.data(withJSONObject: body)))
+            as! [String: Any]
+    }
+
+    func updateTask(publicID: String, body: [String: Any]) throws -> [String: Any] {
+        try JSONSerialization.jsonObject(
+            with: updateTask(publicID: publicID, body: JSONSerialization.data(withJSONObject: body))) as! [String: Any]
+    }
+
+    func upload(operations: [[String: Any]]) throws -> [String: Any] {
+        try JSONSerialization.jsonObject(with: upload(operations: JSONSerialization.data(withJSONObject: operations)))
+            as! [String: Any]
+    }
+}
+
+// Shared test helpers: decode the backend's JSON `Data` responses / encode request bodies, as a client would.
+func decodeArray(_ data: Data) throws -> [[String: Any]] {
+    try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+}
+
+func decodeObject(_ data: Data) throws -> [String: Any] {
+    try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+func decodeObject(_ data: Data?) throws -> [String: Any]? {
+    guard let data else { return nil }
+    return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+}
+
+func encodeData(_ object: Any) throws -> Data {
+    try JSONSerialization.data(withJSONObject: object)
 }

--- a/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
@@ -18,8 +18,8 @@ final class DemoBackendTests: XCTestCase {
         let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
 
         let projects = try decodeArray(backend.getProjectsPayload())
-        let users = try backend.getUsersPayload()
-        let taskStates = try backend.getTaskStateOptionsPayload()
+        let users = try decodeArray(backend.getUsersPayload())
+        let taskStates = try decodeArray(backend.getTaskStateOptionsPayload())
         let projectTasks = try backend.getProjectTasksPayload(projectID: projectID)
 
         XCTAssertEqual(projects.count, 1)
@@ -61,7 +61,7 @@ final class DemoBackendTests: XCTestCase {
         let backend = try DemoServerSimulator(databaseURL: url, seedData: seed)
 
         let projects = try decodeArray(backend.getProjectsPayload())
-        let users = try backend.getUsersPayload()
+        let users = try decodeArray(backend.getUsersPayload())
         let tasks = try backend.getProjectTasksPayload(projectID: seed.projects[0].id)
         let firstTaskID = try XCTUnwrap(tasks.first?["id"] as? String)
         let detail = try backend.getTaskDetailPayload(publicID: firstTaskID)

--- a/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
@@ -10,7 +10,7 @@ final class UploadEndpointTests: XCTestCase {
     func testUploadUpsertAdoptsPublicIDAndIsIdempotent() throws {
         let backend = try makeBackend()
         let id = "11111111-1111-1111-1111-111111111111"
-        let before = try backend.getProjectTasksPayload(projectID: projectID).count
+        let before = try decodeArray(backend.getProjectTasksPayload(projectID: projectID)).count
 
         let first = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
         XCTAssertEqual(first["status"] as? String, "applied")
@@ -18,7 +18,7 @@ final class UploadEndpointTests: XCTestCase {
         // The internal int id never leaves the server — no remoteId in the response.
         XCTAssertNil(first["remoteId"])
 
-        let tasks = try backend.getProjectTasksPayload(projectID: projectID)
+        let tasks = try decodeArray(backend.getProjectTasksPayload(projectID: projectID))
         XCTAssertEqual(tasks.count, before + 1)
         // The client's id is adopted as the row's public_id (its sole identity).
         let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == id })
@@ -29,7 +29,7 @@ final class UploadEndpointTests: XCTestCase {
         let retry = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
         XCTAssertNotEqual(retry["status"] as? String, "rejected")
         XCTAssertNil(retry["remoteId"])
-        XCTAssertEqual(try backend.getProjectTasksPayload(projectID: projectID).count, before + 1)
+        XCTAssertEqual(try decodeArray(backend.getProjectTasksPayload(projectID: projectID)).count, before + 1)
     }
 
     func testUploadUpsertIsLastWriterWins() throws {
@@ -58,7 +58,7 @@ final class UploadEndpointTests: XCTestCase {
                 upsertOp(id: id, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(applied["status"] as? String, "applied")
-        let detail = try XCTUnwrap(backend.getTaskDetailPayload(publicID: id))
+        let detail = try XCTUnwrap(decodeObject(backend.getTaskDetailPayload(publicID: id)))
         XCTAssertEqual(detail["title"] as? String, "Fresh edit")
     }
 
@@ -73,9 +73,9 @@ final class UploadEndpointTests: XCTestCase {
             ]))
         XCTAssertEqual(deleted["status"] as? String, "applied")
 
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: id), "tombstoned row is hidden from detail")
+        XCTAssertNil(try decodeObject(backend.getTaskDetailPayload(publicID: id)), "tombstoned row is hidden from detail")
         XCTAssertFalse(
-            try backend.getProjectTasksPayload(projectID: projectID).contains {
+            try decodeArray(backend.getProjectTasksPayload(projectID: projectID)).contains {
                 ($0["id"] as? String) == id
             },
             "tombstoned row is hidden from the list")
@@ -97,7 +97,7 @@ final class UploadEndpointTests: XCTestCase {
         XCTAssertEqual(stale["status"] as? String, "stale")
         XCTAssertNotNil(stale["server"] as? [String: Any])
         XCTAssertNotNil(
-            try backend.getTaskDetailPayload(publicID: id), "a stale delete must not tombstone the row")
+            try decodeObject(backend.getTaskDetailPayload(publicID: id)), "a stale delete must not tombstone the row")
 
         // A newer delete wins.
         let applied = try result(
@@ -105,7 +105,7 @@ final class UploadEndpointTests: XCTestCase {
                 deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(applied["status"] as? String, "applied")
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: id))
+        XCTAssertNil(try decodeObject(backend.getTaskDetailPayload(publicID: id)))
     }
 
     func testUploadUpsertRevivesTombstonedRowWhenEditIsNewer() throws {
@@ -119,7 +119,7 @@ final class UploadEndpointTests: XCTestCase {
             of: backend.upload(operations: [
                 deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
             ]))
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: id), "precondition: tombstoned")
+        XCTAssertNil(try decodeObject(backend.getTaskDetailPayload(publicID: id)), "precondition: tombstoned")
 
         // An edit newer than the delete wins LWW: it revives the row, not a phantom "applied".
         let revived = try result(
@@ -128,7 +128,7 @@ final class UploadEndpointTests: XCTestCase {
             ]))
         XCTAssertEqual(revived["status"] as? String, "applied")
         let detail = try XCTUnwrap(
-            backend.getTaskDetailPayload(publicID: id), "a newer edit must resurrect the tombstoned row")
+            decodeObject(backend.getTaskDetailPayload(publicID: id)), "a newer edit must resurrect the tombstoned row")
         XCTAssertEqual(detail["title"] as? String, "Revived")
         XCTAssertEqual(detail["id"] as? String, id, "revival keeps the same public_id")
     }
@@ -151,7 +151,7 @@ final class UploadEndpointTests: XCTestCase {
                 upsertOp(id: id, title: "Too late", updatedAt: "2035-01-01T00:00:00.000Z")
             ]))
         XCTAssertEqual(stale["status"] as? String, "stale")
-        XCTAssertNil(try backend.getTaskDetailPayload(publicID: id), "the row stays deleted")
+        XCTAssertNil(try decodeObject(backend.getTaskDetailPayload(publicID: id)), "the row stays deleted")
     }
 
     func testUploadFailsClosedOnMissingOrUnknownOperation() throws {

--- a/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
+++ b/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
@@ -90,7 +90,7 @@ public final class FakeDemoAPIClient {
 
     public func getProjectTasks(projectID: String) async throws -> [DemoSyncPayload] {
         try await networkGate(endpoint: "GET /projects/{id}/tasks")
-        return try backend.getProjectTasksPayload(projectID: projectID).map(Self.makePayload)
+        return try Self.parseArray(backend.getProjectTasksPayload(projectID: projectID)).map(Self.makePayload)
     }
 
     public func getUsers() async throws -> [DemoSyncPayload] {
@@ -100,8 +100,8 @@ public final class FakeDemoAPIClient {
 
     public func getTaskDetail(taskID: String) async throws -> DemoSyncPayload? {
         try await networkGate(endpoint: "GET /tasks/{id}")
-        guard let payload = try backend.getTaskDetailPayload(publicID: taskID) else { return nil }
-        return try Self.makePayload(payload)
+        guard let data = try backend.getTaskDetailPayload(publicID: taskID) else { return nil }
+        return try Self.makePayload(Self.parseObject(data))
     }
 
     public func getTaskStateOptions() async throws -> [DemoSyncPayload] {
@@ -111,42 +111,42 @@ public final class FakeDemoAPIClient {
 
     public func patchTaskState(taskID: String, state: String) async throws -> DemoSyncPayload? {
         try await networkGate(endpoint: "PATCH /tasks/{id} (state)")
-        guard let payload = try backend.patchTaskState(publicID: taskID, state: state) else { return nil }
-        return try Self.makePayload(payload)
+        guard let data = try backend.patchTaskState(publicID: taskID, state: state) else { return nil }
+        return try Self.makePayload(Self.parseObject(data))
     }
 
     public func patchTaskAssignee(taskID: String, assigneeID: String?) async throws -> DemoSyncPayload? {
         try await networkGate(endpoint: "PATCH /tasks/{id} (assignee_id)")
-        guard let payload = try backend.patchTaskAssignee(publicID: taskID, assigneeID: assigneeID) else { return nil }
-        return try Self.makePayload(payload)
+        guard let data = try backend.patchTaskAssignee(publicID: taskID, assigneeID: assigneeID) else { return nil }
+        return try Self.makePayload(Self.parseObject(data))
     }
 
     public func replaceTaskReviewers(taskID: String, reviewerIDs: [String]) async throws -> DemoSyncPayload? {
         try await networkGate(endpoint: "PUT /tasks/{id}/reviewers")
-        guard let payload = try backend.replaceTaskReviewers(publicID: taskID, reviewerIDs: reviewerIDs) else {
+        guard let data = try backend.replaceTaskReviewers(publicID: taskID, reviewerIDs: reviewerIDs) else {
             return nil
         }
-        return try Self.makePayload(payload)
+        return try Self.makePayload(Self.parseObject(data))
     }
 
     public func replaceTaskWatchers(taskID: String, watcherIDs: [String]) async throws -> DemoSyncPayload? {
         try await networkGate(endpoint: "PUT /tasks/{id}/watchers")
-        guard let payload = try backend.replaceTaskWatchers(publicID: taskID, watcherIDs: watcherIDs) else {
+        guard let data = try backend.replaceTaskWatchers(publicID: taskID, watcherIDs: watcherIDs) else {
             return nil
         }
-        return try Self.makePayload(payload)
+        return try Self.makePayload(Self.parseObject(data))
     }
 
     public func createTask(body: DemoSyncPayload) async throws -> DemoSyncPayload {
         try await networkGate(endpoint: "POST /tasks")
-        let created = try backend.createTask(body: body.toSyncPayloadDictionary())
-        return try Self.makePayload(created)
+        let created = try backend.createTask(body: Self.encodeData(body.toSyncPayloadDictionary()))
+        return try Self.makePayload(Self.parseObject(created))
     }
 
     public func updateTask(taskID: String, body: DemoSyncPayload) async throws -> DemoSyncPayload? {
         try await networkGate(endpoint: "PUT /tasks/{id}")
-        let updated = try backend.updateTask(publicID: taskID, body: body.toSyncPayloadDictionary())
-        return try Self.makePayload(updated)
+        let updated = try backend.updateTask(publicID: taskID, body: Self.encodeData(body.toSyncPayloadDictionary()))
+        return try Self.makePayload(Self.parseObject(updated))
     }
 
     public func deleteTask(taskID: String) async throws {
@@ -163,7 +163,7 @@ public final class FakeDemoAPIClient {
     public func upload(operations: [[String: Any]]) async throws -> [[String: Any]] {
         await beforeUpload?()
         try await networkGate(endpoint: "POST /sync/upload")
-        let response = try backend.upload(operations: operations)
+        let response = try Self.parseObject(backend.upload(operations: Self.encodeData(operations)))
         return (response["results"] as? [[String: Any]]) ?? []
     }
 
@@ -217,6 +217,15 @@ public final class FakeDemoAPIClient {
             throw DemoAPIError.invalidPayload("Expected a JSON object response")
         }
         return object
+    }
+
+    /// Encodes a request body to JSON bytes — the client side of the wire (what gets "sent").
+    private static func encodeData(_ object: Any) throws -> Data {
+        do {
+            return try JSONSerialization.data(withJSONObject: object)
+        } catch {
+            throw DemoAPIError.invalidPayload("\(error)")
+        }
     }
 
     private static func makePayload(_ dictionary: [String: Any]) throws -> DemoSyncPayload {

--- a/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
+++ b/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
@@ -85,7 +85,7 @@ public final class FakeDemoAPIClient {
 
     public func getProjects() async throws -> [DemoSyncPayload] {
         try await networkGate(endpoint: "GET /projects")
-        return try backend.getProjectsPayload().map(Self.makePayload)
+        return try Self.parseArray(backend.getProjectsPayload()).map(Self.makePayload)
     }
 
     public func getProjectTasks(projectID: String) async throws -> [DemoSyncPayload] {
@@ -201,6 +201,22 @@ public final class FakeDemoAPIClient {
         let hash = endpoint.unicodeScalars.reduce(0) { ($0 * 31 + Int($1.value)) % 10_000 }
         let jitter = UInt64((hash + callIndex * 17) % 250)
         try await _Concurrency.Task.sleep(nanoseconds: (baseDelayMS + jitter + mutationExtra) * 1_000_000)
+    }
+
+    /// Parses JSON response bytes from the backend — the client side of the wire (`JSONSerialization`
+    /// preserves `null` as `NSNull` and raw value shapes, which is what inbound sync needs).
+    private static func parseArray(_ data: Data) throws -> [[String: Any]] {
+        guard let array = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw DemoAPIError.invalidPayload("Expected a JSON array response")
+        }
+        return array
+    }
+
+    private static func parseObject(_ data: Data) throws -> [String: Any] {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw DemoAPIError.invalidPayload("Expected a JSON object response")
+        }
+        return object
     }
 
     private static func makePayload(_ dictionary: [String: Any]) throws -> DemoSyncPayload {

--- a/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
+++ b/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
@@ -95,7 +95,7 @@ public final class FakeDemoAPIClient {
 
     public func getUsers() async throws -> [DemoSyncPayload] {
         try await networkGate(endpoint: "GET /users")
-        return try backend.getUsersPayload().map(Self.makePayload)
+        return try Self.parseArray(backend.getUsersPayload()).map(Self.makePayload)
     }
 
     public func getTaskDetail(taskID: String) async throws -> DemoSyncPayload? {
@@ -106,7 +106,7 @@ public final class FakeDemoAPIClient {
 
     public func getTaskStateOptions() async throws -> [DemoSyncPayload] {
         try await networkGate(endpoint: "GET /task-state-options")
-        return try backend.getTaskStateOptionsPayload().map(Self.makePayload)
+        return try Self.parseArray(backend.getTaskStateOptionsPayload()).map(Self.makePayload)
     }
 
     public func patchTaskState(taskID: String, state: String) async throws -> DemoSyncPayload? {

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -748,3 +748,12 @@ final class OfflinePushTests: XCTestCase {
         try context.fetch(FetchDescriptor<Task>(predicate: #Predicate { $0.id == id })).first
     }
 }
+
+// Test-only dict bridge over the real JSON-`Data` upload wire (overloads by parameter type).
+extension DemoServerSimulator {
+    @discardableResult
+    func upload(operations: [[String: Any]]) throws -> [String: Any] {
+        try JSONSerialization.jsonObject(with: upload(operations: JSONSerialization.data(withJSONObject: operations)))
+            as! [String: Any]
+    }
+}


### PR DESCRIPTION
## What & why

The fake backend handed the client `[String: Any]` directly — skipping the boundary every real app crosses: the server sends JSON **bytes**, the client decodes them. Now the demo models that real wire, so it shows how apps actually integrate SwiftSync.

**Approach (after ruling out typed DTOs, #670):** the client decodes the wire into a **dictionary** (`JSONSerialization`), not Codable structs. The dict round-trip is faithful — preserves `NSNull` (null→clear) and raw date strings — so sync correctness holds. (Typed DTOs lost both; proven by failing tests, so #670 was dropped.) It's also on-message: SwiftSync's value is *no DTO/mapping layer*.

## Shape

- **Backend** (`DemoServerSimulator`): every endpoint returns/accepts JSON `Data` — `responseData(...)` serializes responses; `requestObject`/`requestArray` parse request bodies. The server side of the wire.
- **Client** (`DemoAPI`): `parseArray`/`parseObject` decode responses; `encodeData` encodes request bodies. The client side.
- **Tests:** shared decode helpers for reads; dict-in/dict-out overloads (overload by param type) bridge the write/upload endpoints with zero call-site churn.

## Status — complete (13/13 endpoints)

All green: **DemoBackend 32, DemoCore 43, SwiftSync 175.**

`getProjects`, `getProjectTasks`, `getUsers`, `getTaskStateOptions`, `getTaskDetail`, `patchTaskState`, `patchTaskAssignee`, `replaceTaskReviewers`, `replaceTaskWatchers`, `createTask`, `updateTask`, `upload`.

Date round-trips handled (backend wire + DemoAPI request encoder both use fractional-second ISO 8601; the inbound sync parser accepts it). Draft — ready for your review; marking it ready will run the simulator tier (it touches DemoCore/DemoBackend, which the UI tests exercise).