### PR TITLE
chore: brutal comment audit — obliterate restatement, narration, decoration

### DIFF
--- a/Demo/Demo/App/ContentView.swift
+++ b/Demo/Demo/App/ContentView.swift
@@ -11,12 +11,11 @@ struct ContentView: View {
 
     var body: some View {
         ProjectsView(syncEngine: runtime.syncEngine)
-            // A safe-area inset, not a `.bottomBar` toolbar: the toolbar would attach outside
-            // ProjectsView's own NavigationStack and drop out on re-render. This stays put.
+            // Not a `.bottomBar` toolbar: that attaches outside ProjectsView's NavigationStack and
+            // drops out on re-render.
             .safeAreaInset(edge: .bottom) { offlineBar }
             .toolbar {
-                // The scenario picker is dev chrome with non-deterministic network behavior, so it
-                // stays hidden under UI testing. The offline bar above is a real feature (and tested).
+                // Hidden under UI testing: the scenario picker's network behavior is non-deterministic.
                 if !runtime.isUITesting {
                     ToolbarItem(placement: .topBarTrailing) {
                         Picker("Scenario", selection: $runtime.scenario) {

--- a/Demo/Demo/DemoApp.swift
+++ b/Demo/Demo/DemoApp.swift
@@ -1,9 +1,10 @@
-import SwiftUI
-import SwiftData
 import DemoCore
+import SwiftData
 import SwiftSync
+import SwiftUI
+
 #if canImport(UIKit)
-import UIKit
+    import UIKit
 #endif
 
 @main
@@ -11,11 +12,11 @@ struct DemoApp: App {
     @State private var runtime = DemoRuntime()
 
     init() {
-#if canImport(UIKit)
-        if ProcessInfo.processInfo.environment["SWIFTSYNC_UI_TESTING"] == "1" {
-            UIView.setAnimationsEnabled(false)
-        }
-#endif
+        #if canImport(UIKit)
+            if ProcessInfo.processInfo.environment["SWIFTSYNC_UI_TESTING"] == "1" {
+                UIView.setAnimationsEnabled(false)
+            }
+        #endif
     }
 
     var body: some Scene {

--- a/Demo/Demo/Features/Failures/FailuresSheet.swift
+++ b/Demo/Demo/Features/Failures/FailuresSheet.swift
@@ -3,9 +3,6 @@ import SwiftData
 import SwiftSync
 import SwiftUI
 
-/// The failures inbox: rows the server rejected (a `syncFailureReason` is set). The user resolves each
-/// by editing the task (fix → re-syncs) or discarding the change (restores the server's version). The
-/// list is a reactive store query, so it updates itself as failures appear and clear.
 struct FailuresSheet: View {
     let syncEngine: DemoSyncEngine
 

--- a/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
+++ b/Demo/Demo/Features/TaskForm/TaskFormSheet.swift
@@ -9,14 +9,11 @@ struct TaskFormSheet: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    // Throwaway context — autosave disabled. Never saved to the store.
-    // On cancel it is simply released; on save we export the values and call the API.
+    // Isolated context, never saved to the store: on save we export the draft's values and call the API.
     let editContext: ModelContext
 
-    // The draft lives in editContext. For create it is a freshly-inserted Task.
-    // For edit it is the same row fetched into this isolated context.
-    // Relationship arrays (reviewers, watchers) are real [User] objects from editContext,
-    // so the pickers can assign them directly without cross-context crashes.
+    // The draft and its relationship arrays (reviewers, watchers) live in editContext, so the pickers
+    // assign [User] objects from the same context — assigning cross-context would crash.
     @State private var draft: Task
 
     @State private var machine: TaskFormSheetMachine
@@ -45,9 +42,8 @@ struct TaskFormSheet: View {
             let taskID = task.id
             let descriptor = FetchDescriptor<Task>(predicate: #Predicate { $0.id == taskID })
             let fetched = (try? ctx.fetch(descriptor))?.first
-            // Fallback should never be reached in practice — the row is always in the store.
-            // If it somehow is, we fall back to the passed object (which lives in mainContext,
-            // so edits won't reach the store either, preserving the no-save guarantee).
+            // Fallback is unreachable in practice; the passed object lives in mainContext, so its edits
+            // also won't reach the store — the no-save guarantee holds either way.
             _draft = State(initialValue: fetched ?? task)
         }
     }
@@ -267,8 +263,6 @@ extension TaskFormSheet {
         }
     }
 
-    // Required fields are marked; only Title, State, and Author gate Create (see isSaveDisabled).
-    // Assignee, Description, Reviewers, Watchers, and Items are optional.
     @ViewBuilder
     var requiredPill: some View {
         Text("Required")

--- a/Demo/DemoUITests/DemoUITests.swift
+++ b/Demo/DemoUITests/DemoUITests.swift
@@ -72,7 +72,7 @@ final class DemoUITests: XCTestCase {
         let app = configuredApp()
         app.launch()
 
-        // Online: the home screen warms reference data (users + task states) into the cache.
+        // Opening online first warms reference data (users + task states) into the cache.
         openProject(app, id: DemoSeedProjectID.accountSecurity)
         XCTAssertTrue(
             app.staticTexts["Add session timeout controls to account settings"].waitForExistence(timeout: 2))
@@ -83,7 +83,7 @@ final class DemoUITests: XCTestCase {
         toggle.tap()
         XCTAssertEqual(app.buttons["offline-toggle"].label, "Offline")
 
-        // Create a task offline. With reference data cached, the form fills its defaults and Create enables.
+        // Cached reference data lets the offline form fill defaults so Create enables.
         openProject(app, id: DemoSeedProjectID.accountSecurity)
         openCreateTaskForm(app)
         let title = uniqueTitle(prefix: "Offline Created")
@@ -92,18 +92,16 @@ final class DemoUITests: XCTestCase {
         app.buttons["task-form.save"].tap()
         XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 3))
 
-        // It appears locally and is queued.
         XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
         goBack(app)
         XCTAssertTrue(app.staticTexts["pending-count"].waitForExistence(timeout: 2), "the create is queued")
 
-        // Reconnect: the queue syncs automatically — no button tap.
+        // Reconnecting auto-syncs the queue — no button tap.
         app.buttons["offline-toggle"].tap()
         XCTAssertTrue(
             app.staticTexts["pending-count"].waitForNonExistence(timeout: 5),
             "reconnecting auto-syncs the queue")
 
-        // It survived the sync: reopening online (a real refresh) still shows it.
         openProject(app, id: DemoSeedProjectID.accountSecurity)
         XCTAssertTrue(findAfterScrolling(app.staticTexts[title], in: app))
     }
@@ -118,14 +116,13 @@ final class DemoUITests: XCTestCase {
         openTaskDetail(
             app, projectID: DemoSeedProjectID.accountSecurity, taskID: DemoSeedTaskID.sessionTimeout)
 
-        // Offline: rename the task to a title the server will reject (too long).
+        // Rename to a title the server will reject (too long) so the offline push fails on sync.
         app.buttons["offline-toggle"].tap()
         openEditTaskForm(app)
         replaceText(in: app.textFields["task-form.title"], with: String(repeating: "A", count: 100), app: app)
         app.buttons["task-form.save"].tap()
         XCTAssertTrue(app.buttons["task-form.save"].waitForNonExistence(timeout: 3))
 
-        // Reconnect: auto-sync pushes it, the server rejects it, and it surfaces in the inbox.
         app.buttons["offline-toggle"].tap()
         let failuresButton = app.buttons["failures-button"]
         XCTAssertTrue(
@@ -137,7 +134,6 @@ final class DemoUITests: XCTestCase {
 
         discard.tap()
 
-        // Discarding resolves the failure: the row leaves the inbox.
         XCTAssertTrue(discard.waitForNonExistence(timeout: 5), "discard clears the failure")
     }
 

--- a/DemoBackend/Sources/DemoBackend/DemoSeedData.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoSeedData.swift
@@ -113,8 +113,7 @@ public struct DemoSeedData {
         self.items = items
     }
 
-    // Stable UUID constants for the canonical seed dataset.
-    // These are fixed — not random — so the demo loads consistent data across fresh installs.
+    // Fixed, not random, so the demo loads consistent data across fresh installs.
     public enum SeedIDs {
         public enum Projects {
             public static let accountSecurity = "C3E7A1B2-1001-0000-0000-000000000001"

--- a/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
+++ b/DemoBackend/Sources/DemoBackend/DemoServerSimulator.swift
@@ -222,8 +222,7 @@ public final class DemoServerSimulator {
         return try replaceReviewers(rowID: rowID, reviewerIDs: reviewerIDs)
     }
 
-    /// Int-keyed internal so callers that already resolved the row (e.g. `uploadUpsert`) don't re-resolve
-    /// the public_id.
+    /// Int-keyed so callers that already resolved the row (e.g. `uploadUpsert`) don't re-resolve the public_id.
     @discardableResult
     private func replaceReviewers(rowID: Int, reviewerIDs: [String]) throws -> [String: Any]? {
         let uniqueReviewerIDs = Array(Set(reviewerIDs)).sorted()
@@ -341,8 +340,7 @@ public final class DemoServerSimulator {
     }
 
     public func createTask(body: [String: Any]) throws -> [String: Any] {
-        // Client-originated rows adopt the body's `id` as public_id; server-origin rows (no `id`)
-        // get a freshly minted lowercased UUID.
+        // Client-originated rows adopt the body's `id` as public_id; server-origin rows (no `id`) mint one.
         let publicID = (body["id"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? UUID().uuidString.lowercased()
         guard let projectID = body["project_id"] as? String else {
             throw DemoBackendError.validation(message: "project_id is required")
@@ -477,10 +475,8 @@ public final class DemoServerSimulator {
         return payload
     }
 
-    /// PUT /tasks/:publicID — full-object update. Accepts the same field shape that createTask produces
-    /// (exported via SwiftSync's exportObject), reads all mutable scalar fields, and applies them.
-    /// id, project_id, author_id, and created_at are immutable; they are validated for consistency
-    /// but not updated. updated_at is always advanced by the server regardless of the incoming value.
+    /// PUT /tasks/:publicID full-object update. id, project_id, author_id, created_at are immutable
+    /// (validated, not updated); updated_at is always advanced by the server regardless of the incoming value.
     @discardableResult
     public func updateTask(publicID: String, body: [String: Any]) throws -> [String: Any] {
         guard let rowID = try taskRowID(forPublicID: publicID) else {
@@ -495,7 +491,7 @@ public final class DemoServerSimulator {
             throw DemoBackendError.notFound(entity: "task", id: String(taskID))
         }
 
-        // Validate immutable identity consistency: the client's `id` is the row's public_id.
+        // The client's `id` is the row's public_id and is immutable.
         if let incomingID = body["id"] as? String {
             let currentPublicID = current["id"] as? String
             if incomingID != currentPublicID {
@@ -543,12 +539,11 @@ public final class DemoServerSimulator {
             itemsToReconcile = nil
         }
 
-        // assignee_id: present key means update (NSNull clears, String sets)
+        // Payload contract: absent key preserves, NSNull clears, String sets.
         let assigneeID: String?
         if body.keys.contains("assignee_id") {
-            assigneeID = body["assignee_id"] as? String  // nil if NSNull
+            assigneeID = body["assignee_id"] as? String
         } else {
-            // Preserve current value if key is absent
             assigneeID = current["assignee_id"] as? String
         }
 
@@ -647,11 +642,9 @@ public final class DemoServerSimulator {
         )
     }
 
-    // MARK: - POST /sync/upload (offline batch push)
-    // See docs/project/upload-endpoint-contract.md. A flat, op-tagged operation list; per-operation
-    // results (no all-or-nothing). Operations are keyed by the client's stable `id`, which is the
-    // row's public_id. The internal int id never leaves the server. `upsert` is find-by-public_id →
-    // update-else-create, `delete` tombstones by public_id. Both are idempotent.
+    // See docs/project/upload-endpoint-contract.md. Op-tagged operation list with per-operation results
+    // (no all-or-nothing), keyed by the client's stable `id` (the row's public_id). `upsert` is
+    // find-by-public_id → update-else-create, `delete` tombstones by public_id. Both are idempotent.
 
     public func upload(operations: [[String: Any]]) throws -> [String: Any] {
         let results = operations.map(applyUploadOperation(_:))
@@ -675,9 +668,6 @@ public final class DemoServerSimulator {
         }
     }
 
-    /// Insert-or-update keyed by the client's stable `id` (the row's public_id). Found ⇒ update
-    /// (last-writer-wins); absent ⇒ create, adopting that public_id. The internal int id never leaves
-    /// the server. Idempotent: re-sending converges, no duplicate row.
     private func uploadUpsert(_ payload: [String: Any]) throws -> [String: Any] {
         try requireTasksType(payload)
         let id = try requireID(payload)
@@ -695,8 +685,7 @@ public final class DemoServerSimulator {
                     "server": try taskDetailPayload(rowID: existingID) ?? NSNull(),
                 ]
             }
-            // An edit newer than a delete wins LWW: revive the tombstoned row before updating it
-            // (updateTask ignores tombstoned rows). A no-op for a live row.
+            // Revive a tombstoned row before updating it — updateTask ignores tombstoned rows. No-op when live.
             try self.sqlite.execute(
                 "UPDATE tasks SET deleted_at = NULL WHERE id = ?",
                 bind: { stmt in self.sqlite.bind(int: existingID, at: 1, in: stmt) }
@@ -716,7 +705,7 @@ public final class DemoServerSimulator {
             // Already absent (or never synced) ⇒ idempotent success.
             return ["operation": "delete", "id": id, "status": "applied"]
         }
-        // Last-writer-wins applies to deletes too: an older delete must not erase a newer server edit.
+        // An older delete must not erase a newer server edit (LWW).
         if try isStale(rowID: rowID, incoming: incoming) {
             return [
                 "operation": "delete", "id": id, "status": "stale",
@@ -724,8 +713,8 @@ public final class DemoServerSimulator {
             ]
         }
         suspendAmbientMutationsAfterWrite()
-        // Record the delete's logical timestamp in updated_at too, so a later upsert that targets this
-        // (now tombstoned) row compares LWW against *the delete*, not the pre-delete edit.
+        // Record the delete's timestamp in updated_at so a later upsert compares LWW against the delete,
+        // not the pre-delete edit.
         try self.sqlite.execute(
             "UPDATE tasks SET deleted_at = ?, updated_at = ? WHERE id = ?",
             bind: { stmt in
@@ -757,8 +746,7 @@ public final class DemoServerSimulator {
         return date
     }
 
-    /// The internal int id for the row with this `public_id`, or nil if none exists. With
-    /// `includeTombstoned`, also matches tombstoned rows so a delete/revive can find its target.
+    /// With `includeTombstoned`, also matches tombstoned rows so a delete/revive can find its target.
     private func taskRowID(forPublicID publicID: String, includeTombstoned: Bool = false) throws -> Int? {
         let scope = includeTombstoned ? "" : " AND deleted_at IS NULL"
         let rows = try self.sqlite.query(
@@ -775,7 +763,7 @@ public final class DemoServerSimulator {
             bind: { stmt in self.sqlite.bind(int: rowID, at: 1, in: stmt) }
         )
         guard let stored = rows.first?.double("updated_at") else { return false }
-        // Contract: an incoming write older *or equal* loses (server wins ties).
+        // An incoming write older *or equal* loses — server wins ties.
         return incoming.timeIntervalSince1970 <= stored
     }
 
@@ -1266,8 +1254,8 @@ public final class DemoServerSimulator {
                 )
             }
 
-            // Seeds carry a stable public_id; the DB auto-assigns the internal int id, which we capture
-            // to wire up relationships and child items (whose seed parent reference is a public_id).
+            // Capture each row's auto-assigned int id to wire up reviewers/watchers and child items
+            // (whose seed parent reference is a public_id).
             var taskRowIDByPublicID: [String: Int] = [:]
             for task in seedData.tasks {
                 try sqlite.execute(

--- a/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/DemoBackendTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 @testable import DemoBackend
 
-// Stable constants for the test fixture — deterministic across runs.
 // projectID/userID are reference data (TEXT ids); the task's identity is its public_id (a UUID).
 private let projectID = "A1B2C3D4-0000-0000-0000-000000000001"
 private let userID = "A1B2C3D4-0000-0000-0000-000000000002"
@@ -67,7 +66,6 @@ final class DemoBackendTests: XCTestCase {
         let detail = try backend.getTaskDetailPayload(publicID: firstTaskID)
         let taskItems = items(in: detail)
 
-        // Reference data (projects/users) keeps TEXT UUID ids.
         for project in projects {
             let id = project["id"] as? String ?? ""
             XCTAssertNotNil(UUID(uuidString: id), "project id '\(id)' is not a UUID")
@@ -76,13 +74,12 @@ final class DemoBackendTests: XCTestCase {
             let id = user["id"] as? String ?? ""
             XCTAssertNotNil(UUID(uuidString: id), "user id '\(id)' is not a UUID")
         }
-        // The task's only external identity is its public_id (a UUID); the int id never leaks.
+        // The task's only external identity is its public_id; the int id never leaks.
         for task in tasks {
             let id = task["id"] as? String ?? ""
             XCTAssertNotNil(UUID(uuidString: id), "task id '\(id)' is not a UUID")
             XCTAssertNil(task["local_id"], "there is no separate local_id key — id IS the public_id")
         }
-        // Items expose their public_id as `id` and the parent's public_id as `task_id`.
         for item in taskItems {
             let id = item["id"] as? String ?? ""
             XCTAssertNotNil(UUID(uuidString: id), "item id '\(id)' is not a UUID")
@@ -112,7 +109,6 @@ final class DemoBackendTests: XCTestCase {
         ]
         let created = try backend.createTask(body: body)
 
-        // The client's id is adopted as public_id and is the only identity returned.
         XCTAssertEqual(created["id"] as? String, clientID)
         XCTAssertNil(created["local_id"])
     }
@@ -192,7 +188,6 @@ final class DemoBackendTests: XCTestCase {
 
         let created = try backend.createTask(body: body)
 
-        // The client id is adopted as the public_id (the sole identity); no separate local_id.
         XCTAssertEqual(created["id"] as? String, newID)
         XCTAssertNil(created["local_id"])
         XCTAssertEqual(created["project_id"] as? String, projectID)
@@ -204,7 +199,6 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertEqual(stateLabel(in: created), "In Progress")
         XCTAssertEqual(created["reviewer_ids"] as? [String], [])
         XCTAssertEqual(created["watcher_ids"] as? [String], [])
-        // timestamps round-trip
         XCTAssertEqual(created["created_at"] as? String, createdAtString)
         XCTAssertEqual(created["updated_at"] as? String, updatedAtString)
     }
@@ -249,62 +243,51 @@ final class DemoBackendTests: XCTestCase {
             "updated_at": now,
         ]
 
-        // missing id is allowed: a server-origin row mints its own public_id
+        // A server-origin row (no id) mints its own public_id, so a missing id must not throw.
         var missingID = base
         missingID.removeValue(forKey: "id")
         XCTAssertNoThrow(try backend.createTask(body: missingID))
 
-        // missing project_id
         var missingProject = base
         missingProject.removeValue(forKey: "project_id")
         XCTAssertThrowsError(try backend.createTask(body: missingProject))
 
-        // unknown project_id
         var badProject = base
         badProject["project_id"] = "00000000-0000-0000-0000-000000000000"
         XCTAssertThrowsError(try backend.createTask(body: badProject))
 
-        // missing title
         var missingTitle = base
         missingTitle.removeValue(forKey: "title")
         XCTAssertThrowsError(try backend.createTask(body: missingTitle))
 
-        // empty title
         var emptyTitle = base
         emptyTitle["title"] = "   "
         XCTAssertThrowsError(try backend.createTask(body: emptyTitle))
 
-        // missing author_id
         var missingAuthor = base
         missingAuthor.removeValue(forKey: "author_id")
         XCTAssertThrowsError(try backend.createTask(body: missingAuthor))
 
-        // unknown author_id
         var badAuthor = base
         badAuthor["author_id"] = "00000000-0000-0000-0000-000000000000"
         XCTAssertThrowsError(try backend.createTask(body: badAuthor))
 
-        // invalid state value
         var badState = base
         badState["state"] = ["id": "flying"]
         XCTAssertThrowsError(try backend.createTask(body: badState))
 
-        // missing state dict
         var noState = base
         noState.removeValue(forKey: "state")
         XCTAssertThrowsError(try backend.createTask(body: noState))
 
-        // missing created_at
         var missingCreatedAt = base
         missingCreatedAt.removeValue(forKey: "created_at")
         XCTAssertThrowsError(try backend.createTask(body: missingCreatedAt))
 
-        // missing updated_at
         var missingUpdatedAt = base
         missingUpdatedAt.removeValue(forKey: "updated_at")
         XCTAssertThrowsError(try backend.createTask(body: missingUpdatedAt))
 
-        // duplicate public_id (client id)
         var firstBody = base
         let sharedID = UUID().uuidString
         firstBody["id"] = sharedID
@@ -701,9 +684,8 @@ final class DemoBackendTests: XCTestCase {
         let before = try backend.getTaskDetailPayload(publicID: taskID)
         let beforeUpdatedAt = before?["updated_at"] as? String
 
-        // Build a body that mirrors the shape SwiftSync's exportObject produces:
-        // - description (not description_text) from @RemoteKey("description")
-        // - state as a nested dict with id+label from @RemoteKey("state.id") / @RemoteKey("state.label")
+        // Mirrors the body shape SwiftSync's exportObject produces: `description` (not description_text)
+        // and `state` as a nested id+label dict.
         let body: [String: Any] = [
             "title": "Updated title via PUT",
             "description": "Updated description via PUT",
@@ -721,9 +703,7 @@ final class DemoBackendTests: XCTestCase {
         XCTAssertTrue(
             updated["assignee_id"] is NSNull || updated["assignee_id"] == nil,
             "NSNull assignee_id must clear the assignee")
-        // updated_at must advance
         XCTAssertNotEqual(updated["updated_at"] as? String, beforeUpdatedAt)
-        // created_at must not change
         XCTAssertEqual(updated["created_at"] as? String, before?["created_at"] as? String)
     }
 
@@ -879,7 +859,6 @@ final class DemoBackendTests: XCTestCase {
 
         let backend = try DemoServerSimulator(databaseURL: url, seedData: smallSeedData())
 
-        // The seeded task has assigneeID = userID. Omitting assignee_id from body must preserve it.
         let body: [String: Any] = [
             "title": "No assignee key",
             "description": "Preserve existing assignee",
@@ -916,8 +895,6 @@ final class DemoBackendTests: XCTestCase {
             XCTAssertNotNil(task["created_at"])
         }
     }
-
-    // MARK: - Helpers
 
     private func stateID(in task: [String: Any]?) -> String? {
         (task?["state"] as? [String: Any])?["id"] as? String

--- a/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
+++ b/DemoBackend/Tests/DemoBackendTests/UploadEndpointTests.swift
@@ -15,17 +15,16 @@ final class UploadEndpointTests: XCTestCase {
         let first = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
         XCTAssertEqual(first["status"] as? String, "applied")
         XCTAssertEqual(first["id"] as? String, id)
-        // The internal int id never leaves the server — no remoteId in the response.
+        // The internal int id never leaves the server.
         XCTAssertNil(first["remoteId"])
 
         let tasks = try backend.getProjectTasksPayload(projectID: projectID)
         XCTAssertEqual(tasks.count, before + 1)
-        // The client's id is adopted as the row's public_id (its sole identity).
         let inserted = try XCTUnwrap(tasks.first { ($0["id"] as? String) == id })
         XCTAssertNil(inserted["local_id"])
 
-        // Re-upsert the same public_id (lost-response retry): no duplicate row. The identical updatedAt
-        // loses the LWW tie, so it's a converged no-op — not a failure.
+        // Lost-response retry: an identical updatedAt loses the LWW tie, so it's a converged no-op,
+        // not a duplicate row or a failure.
         let retry = try result(of: backend.upload(operations: [upsertOp(id: id, title: "Offline task")]))
         XCTAssertNotEqual(retry["status"] as? String, "rejected")
         XCTAssertNil(retry["remoteId"])
@@ -41,7 +40,6 @@ final class UploadEndpointTests: XCTestCase {
             ]))
         XCTAssertEqual(created["status"] as? String, "applied")
 
-        // Older write loses: kept server state returned, title unchanged.
         let stale = try result(
             of: backend.upload(operations: [
                 upsertOp(id: id, title: "Stale edit", updatedAt: "2020-01-01T00:00:00.000Z")
@@ -52,7 +50,6 @@ final class UploadEndpointTests: XCTestCase {
         XCTAssertEqual(server["title"] as? String, "Original")
         XCTAssertEqual(server["id"] as? String, id)
 
-        // Newer write wins.
         let applied = try result(
             of: backend.upload(operations: [
                 upsertOp(id: id, title: "Fresh edit", updatedAt: "2030-01-01T00:00:00.000Z")
@@ -89,7 +86,6 @@ final class UploadEndpointTests: XCTestCase {
                 upsertOp(id: id, title: "Live", updatedAt: "2030-01-01T00:00:00.000Z")
             ]))
 
-        // A delete older than the server's version must lose: stale + server state, not a tombstone.
         let stale = try result(
             of: backend.upload(operations: [
                 deleteOp(id: id, updatedAt: "2020-01-01T00:00:00.000Z")
@@ -99,7 +95,6 @@ final class UploadEndpointTests: XCTestCase {
         XCTAssertNotNil(
             try backend.getTaskDetailPayload(publicID: id), "a stale delete must not tombstone the row")
 
-        // A newer delete wins.
         let applied = try result(
             of: backend.upload(operations: [
                 deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
@@ -121,7 +116,6 @@ final class UploadEndpointTests: XCTestCase {
             ]))
         XCTAssertNil(try backend.getTaskDetailPayload(publicID: id), "precondition: tombstoned")
 
-        // An edit newer than the delete wins LWW: it revives the row, not a phantom "applied".
         let revived = try result(
             of: backend.upload(operations: [
                 upsertOp(id: id, title: "Revived", updatedAt: "2050-01-01T00:00:00.000Z")
@@ -145,7 +139,6 @@ final class UploadEndpointTests: XCTestCase {
                 deleteOp(id: id, updatedAt: "2040-01-01T00:00:00.000Z")
             ]))
 
-        // An edit older than the delete loses LWW: stale, and the row stays deleted (no phantom apply).
         let stale = try result(
             of: backend.upload(operations: [
                 upsertOp(id: id, title: "Too late", updatedAt: "2035-01-01T00:00:00.000Z")
@@ -157,16 +150,14 @@ final class UploadEndpointTests: XCTestCase {
     func testUploadFailsClosedOnMissingOrUnknownOperation() throws {
         let backend = try makeBackend()
         let response = try backend.upload(operations: [
-            ["type": "tasks", "id": "x", "data": [:]],  // no operation
-            ["operation": "destroy", "type": "tasks", "id": "y"],  // unknown
+            ["type": "tasks", "id": "x", "data": [:]],
+            ["operation": "destroy", "type": "tasks", "id": "y"],
         ])
         let results = try XCTUnwrap(response["results"] as? [[String: Any]])
         XCTAssertEqual(results.allSatisfy { ($0["status"] as? String) == "rejected" }, true)
         XCTAssertEqual(results[0]["code"] as? String, "missing_operation")
         XCTAssertEqual(results[1]["code"] as? String, "unknown_operation")
     }
-
-    // MARK: - Helpers
 
     private func makeBackend() throws -> DemoServerSimulator {
         let url = FileManager.default.temporaryDirectory

--- a/DemoCore/Sources/DemoCore/App/DemoRuntime.swift
+++ b/DemoCore/Sources/DemoCore/App/DemoRuntime.swift
@@ -51,9 +51,11 @@ public final class DemoRuntime {
     }
 
     nonisolated private static func localStoreURL() -> URL {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        let appSupport =
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? FileManager.default.temporaryDirectory
-        return appSupport
+        return
+            appSupport
             .appendingPathComponent("SwiftSyncDemo", isDirectory: true)
             .appendingPathComponent("client-cache.store")
     }
@@ -64,8 +66,8 @@ public final class DemoRuntime {
     }
 }
 
-private extension DemoRuntime {
-    struct LaunchConfiguration {
+extension DemoRuntime {
+    fileprivate struct LaunchConfiguration {
         let scenario: DemoNetworkScenario
         let seedData: DemoSeedData?
         let storeURL: URL

--- a/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
+++ b/DemoCore/Sources/DemoCore/Features/ScreenMachines.swift
@@ -89,7 +89,7 @@ public final class ProjectsViewMachine {
             fallbackMessage: "Could not load projects."
         ) { [syncEngine] in
             try await syncEngine.syncProjects()
-            // Warm reference data (users + task states) so the new-task form has options offline.
+            // Warm reference data so the new-task form has options offline.
             try await syncEngine.syncTaskFormMetadata()
         }
     }

--- a/DemoCore/Sources/DemoCore/Models/DemoModels.swift
+++ b/DemoCore/Sources/DemoCore/Models/DemoModels.swift
@@ -87,8 +87,7 @@ public final class Task {
     public var createdAt: Date
     public var updatedAt: Date
 
-    // Demo-owned (not a SwiftSync concept): the engine stamps this from the failures `push` returns and
-    // clears it on a later success, so the failures inbox is a query for rows where it's set.
+    // Demo-owned (not a SwiftSync concept): the failures inbox is a query for rows where it's set.
     @NotExport
     public var syncFailureReason: String?
 

--- a/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
+++ b/DemoCore/Sources/DemoCore/Networking/DemoAPI.swift
@@ -47,10 +47,8 @@ public final class FakeDemoAPIClient {
 
     public var scenario: DemoNetworkScenario
 
-    /// Simulated airplane mode at the transport: when on, every endpoint is unreachable (throws
-    /// `.offline`), exactly like a device with no connectivity. This is where "offline" lives — the
-    /// link between app and server — not in business logic. The sync engine reacts to it (reads keep
-    /// serving the local cache, writes queue).
+    /// Simulated airplane mode at the transport: when on, every endpoint throws `.offline`. Offline lives
+    /// at the link between app and server, not in business logic.
     public var isOffline = false
 
     private let backend: DemoServerSimulator
@@ -155,12 +153,11 @@ public final class FakeDemoAPIClient {
         try backend.deleteTask(publicID: taskID)
     }
 
-    /// Test-only seam: awaited at the start of every `upload(operations:)`, before the network gate, so a
-    /// test can deterministically park or observe each individual drain upload. `internal` so it never
-    /// becomes part of the public surface — tests reach it via `@testable import`. Nil in production (inert).
+    /// Test-only seam awaited at the start of every `upload`, before the network gate, so a test can
+    /// deterministically park or observe each drain upload. `internal` so it stays off the public surface.
     var beforeUpload: (@MainActor () async -> Void)?
 
-    /// POST /sync/upload — the batched offline push. Returns the per-operation `results` array.
+    /// POST /sync/upload — the batched offline push.
     public func upload(operations: [[String: Any]]) async throws -> [[String: Any]] {
         await beforeUpload?()
         try await networkGate(endpoint: "POST /sync/upload")

--- a/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
+++ b/DemoCore/Sources/DemoCore/Sync/DemoSyncEngine.swift
@@ -27,7 +27,7 @@ public final class DemoSyncEngine {
 
     public private(set) var isSyncing = false
 
-    /// Simulated airplane mode the UI binds to. Flipping back online drains the offline queue.
+    /// Simulated airplane mode. Flipping back online drains the offline queue.
     public var isOffline = false {
         didSet {
             apiClient.isOffline = isOffline
@@ -91,13 +91,12 @@ public final class DemoSyncEngine {
         }
     }
 
-    /// Run an inbound pull, tolerating a dead transport: while offline the refresh is skipped and the
-    /// UI keeps reading the local cache (a failed refresh is a non-event, never a surfaced error).
+    /// Run an inbound pull, tolerating a dead transport: a failed refresh is a non-event, never surfaced.
     private func pull(_ key: String, _ operation: () async throws -> Void) async throws {
         do {
             try await runOperation(key, operation)
         } catch DemoAPIError.offline {
-            // Offline: keep serving what's already in the local store.
+            // Offline: keep serving the local cache.
         }
     }
 
@@ -126,7 +125,7 @@ public final class DemoSyncEngine {
             try applyLocalTask(body)
             if let task = try task(withID: taskID) {
                 task.updatedAt = Date()
-                task.syncFailureReason = nil  // the corrected edit gets a fresh attempt
+                task.syncFailureReason = nil  // the correction gets a fresh attempt
                 try syncContainer.mainContext.save()
             }
             if !isOffline {
@@ -275,9 +274,8 @@ public final class DemoSyncEngine {
             case ("upsert", "applied"), ("delete", "applied"):
                 break
             default:
-                // Bubble the backend's rejection up as this app's own error. SwiftSync returns the
-                // failures verbatim without interpreting them; the engine reads them back to annotate
-                // the inbox.
+                // Bubble the backend's rejection up as this app's own error; SwiftSync returns failures
+                // verbatim without interpreting them.
                 failures.append(
                     SyncPendingChangesFailure(
                         id: id ?? "",
@@ -321,14 +319,12 @@ public final class DemoSyncEngine {
         try context.save()
     }
 
-    /// A task whose only history is a never-pushed local insert (it's in the pending-insert set).
     private func isNeverPushed(_ taskID: String) -> Bool {
         let pending = try? SwiftSync.pendingChanges(for: Task.self, in: syncContainer.mainContext)
         return pending?.inserts.contains(taskID) ?? false
     }
 
-    /// Reflect a push's outcome onto the inbox: stamp `syncFailureReason` on each rejected row and
-    /// clear it from any row that no longer fails (it succeeded, or its corrected edit went through).
+    /// Stamp `syncFailureReason` on each rejected row and clear it from any row that no longer fails.
     /// SwiftSync persists nothing — the failures inbox is entirely this app's concern.
     private func annotateFailures(_ failures: [SyncPendingChangesFailure]) throws {
         let reasonsByID = Dictionary(
@@ -343,7 +339,6 @@ public final class DemoSyncEngine {
         try syncContainer.mainContext.save()
     }
 
-    /// Tasks the server rejected (a failure reason is set), newest first — the failures inbox.
     public func failedTasks() -> [Task] {
         (try? syncContainer.mainContext.fetch(
             FetchDescriptor<Task>(
@@ -351,8 +346,6 @@ public final class DemoSyncEngine {
                 sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]))) ?? []
     }
 
-    /// Resolve a rejected change: drop a never-synced row, or restore the server's version of an
-    /// edited row (abandoning the local edit) and clear its failure.
     public func discardFailedChange(taskID: String) async throws {
         guard let task = try task(withID: taskID) else { return }
         if isNeverPushed(taskID) {

--- a/DemoCore/Tests/DemoCoreTests/ConvergingDrainTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/ConvergingDrainTests.swift
@@ -7,13 +7,9 @@ import XCTest
 
 final class ConvergingDrainTests: XCTestCase {
 
-    /// P1 strand: an edit that lands *after* a drain reads its pending snapshot but *before* that drain
-    /// finishes must still reach the server. A coalescing drain covers only its original snapshot and
-    /// never re-reads, so the late edit is stranded; a converging drain re-reads until pending is empty.
-    ///
-    /// Deterministic by construction: the drain is driven with an explicit handle (no reconnect `didSet`),
-    /// only the first upload parks, and convergence's later uploads flow through — so the test never
-    /// assumes how many uploads a correct drain performs.
+    /// An edit that lands *after* a drain reads its pending snapshot but *before* that drain finishes must
+    /// still reach the server. A coalescing drain covers only its original snapshot and never re-reads, so
+    /// the late edit is stranded; a converging drain re-reads until pending is empty.
     @MainActor
     func testLateEditDuringDrainReachesServer() async throws {
         let seed = DemoSeedData.generate()
@@ -42,8 +38,8 @@ final class ConvergingDrainTests: XCTestCase {
         syncContainer.mainContext.insert(row)
         try syncContainer.mainContext.save()
 
-        // Park only the first upload mid-flight; convergence's later uploads flow straight through, so the
-        // test never assumes how many uploads a correct drain performs.
+        // Park only the first upload; convergence's later uploads flow through, so the test never assumes
+        // how many uploads a correct drain performs.
         nonisolated(unsafe) var uploadStarted: CheckedContinuation<Void, Never>?
         nonisolated(unsafe) var releaseGate: CheckedContinuation<Void, Never>?
         nonisolated(unsafe) var didPark = false

--- a/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/OfflinePushTests.swift
@@ -172,7 +172,6 @@ final class OfflinePushTests: XCTestCase {
         try await engine.updateTask(
             taskID: taskID, projectID: projectID, body: try SyncJSON(dictionary: dictionary))
 
-        // Reconnect + push: the server rejects, and the failure is recorded on the row.
         engine.isOffline = false
         let pushResult = try await engine.pushPendingChanges()
         let failures = try XCTUnwrap(pushResult)
@@ -212,7 +211,6 @@ final class OfflinePushTests: XCTestCase {
         _ = try await engine.pushPendingChanges()
         XCTAssertNotNil(try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext)).syncFailureReason)
 
-        // Discard: restores the server's title and clears the failure.
         try await engine.discardFailedChange(taskID: taskID)
         let discarded = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
         XCTAssertNil(discarded.syncFailureReason, "discard clears the failure")
@@ -289,7 +287,6 @@ final class OfflinePushTests: XCTestCase {
         XCTAssertNotNil(failed.syncFailureReason, "the rejected edit is flagged")
         XCTAssertEqual(engine.failedChangeCount, 1)
 
-        // Fix it with a valid title while online: the corrected save must resolve the failure.
         var fixDictionary = syncContainer.export(failed)
         fixDictionary["title"] = "Fixed online"
         fixDictionary.removeValue(forKey: "items")
@@ -344,7 +341,6 @@ final class OfflinePushTests: XCTestCase {
         engine.isOffline = false
         _ = try await engine.pushPendingChanges()
 
-        // The held row must show the adopted server value at once — not the stale local edit.
         XCTAssertEqual(held.title, serverTitle, "conflict resolution must reflect on the live row immediately")
     }
 
@@ -446,7 +442,6 @@ final class OfflinePushTests: XCTestCase {
 
         let newReviewers = [DemoSeedData.SeedIDs.Users.miaPatel, DemoSeedData.SeedIDs.Users.ethanLee]
 
-        // Offline: assign people. Mutates the Task (its reviewers + updatedAt) → a pending Task update.
         engine.isOffline = true
         try await engine.replaceTaskReviewers(taskID: taskID, projectID: projectID, reviewerIDs: newReviewers)
         let offline = try XCTUnwrap(fetchTask(id: taskID, in: syncContainer.mainContext))
@@ -530,13 +525,11 @@ final class OfflinePushTests: XCTestCase {
             ]
         ])
 
-        // Offline: a pull must not reach the server — no error, and no new data.
         engine.isOffline = true
         try await engine.syncProjectTasks(projectID: projectID)
         let offlineCount = try syncContainer.mainContext.fetch(FetchDescriptor<Task>()).count
         XCTAssertEqual(offlineCount, onlineCount, "offline pull serves the local cache, never the server")
 
-        // Reconnect: the server task is pulled in.
         engine.isOffline = false
         try await engine.syncProjectTasks(projectID: projectID)
         let refreshedCount = try syncContainer.mainContext.fetch(FetchDescriptor<Task>()).count

--- a/DemoCore/Tests/DemoCoreTests/TaskFormPeopleMutationTests.swift
+++ b/DemoCore/Tests/DemoCoreTests/TaskFormPeopleMutationTests.swift
@@ -38,12 +38,6 @@ final class TaskFormPeopleMutationTests: XCTestCase {
 
         let draft = try XCTUnwrap(fetchTask(id: taskID, in: editContext))
 
-        // Match the UI flow:
-        // assignee -> Mia
-        // reviewer Noah off
-        // reviewer Sofia on
-        // watcher Ethan off
-        // watcher Sofia on
         draft.assigneeID = DemoSeedData.SeedIDs.Users.miaPatel
         draft.reviewers.removeAll(where: { $0.id == DemoSeedData.SeedIDs.Users.noahKim })
         if !draft.reviewers.contains(where: { $0.id == DemoSeedData.SeedIDs.Users.sofiaGarcia }) {

--- a/SwiftSync/Sources/MacrosImplementation/SyncableMacro.swift
+++ b/SwiftSync/Sources/MacrosImplementation/SyncableMacro.swift
@@ -308,7 +308,7 @@ public struct SyncableMacro: ExtensionMacro {
                 }
             }
 
-            // Marker without explicit remote key defaults to local property name.
+            // Empty string is the sentinel for "marker present, no explicit remote key" → use local name.
             return ""
         }
         return nil

--- a/SwiftSync/Sources/SwiftSync/MacroRuntimeSupport.swift
+++ b/SwiftSync/Sources/SwiftSync/MacroRuntimeSupport.swift
@@ -52,7 +52,7 @@ extension SwiftSync {
 
             let relatedByID = try context.syncFetchRelatedRowsByIdentity(Related.self, matching: [nextID])
             guard let nextRelated = relatedByID[SwiftSync.identityKey(from: nextID)] else {
-                // Old Sync parity: unknown FK row is a soft no-op.
+                // An unknown FK is intentionally a no-op, not an error.
                 return false
             }
 
@@ -180,7 +180,6 @@ extension SwiftSync {
                 return false
             }
 
-            // Old Sync behavior avoids duplicate membership.
             let desiredIDs = rawIDs.syncDedupedPreservingOrder()
             let relatedByID = try context.syncFetchRelatedRowsByIdentity(Related.self, matching: desiredIDs)
             let desiredRelated = desiredIDs.compactMap { relatedByID[SwiftSync.identityKey(from: $0)] }
@@ -494,13 +493,11 @@ extension SwiftSync {
     }
 }
 
-/// Cycle-detection state for recursive relationship export.
-/// This type is an implementation detail of `@Syncable`-generated code.
-/// Do not instantiate or reference it directly.
+/// Cycle-detection state for recursive relationship export; an implementation detail of
+/// `@Syncable`-generated code — do not reference it directly.
 public enum ExportState {
     private static let threadDictionaryKey = "SwiftSync.ExportState"
 
-    /// Returns false if already visiting (cycle detected).
     public static func enter<Model: PersistentModel>(_ model: Model) -> Bool {
         let key = String(describing: model.persistentModelID)
         var visiting = currentVisiting()

--- a/SwiftSync/Sources/SwiftSync/PendingChanges.swift
+++ b/SwiftSync/Sources/SwiftSync/PendingChanges.swift
@@ -1,10 +1,8 @@
 import Foundation
 import SwiftData
 
-// MARK: - Pending changes
-
 /// Each array holds row `id`s (strings), not objects, so SwiftData objects never cross into your network
-/// call: `withPendingChanges` hands you the ids and you map each to your own request payload.
+/// call.
 public struct SyncPendingChanges: Sendable {
     public let inserts: [String]
     public let updates: [String]
@@ -65,10 +63,8 @@ extension SwiftSync {
             return SyncPendingChanges(inserts: [], updates: [], deletes: [])
         }
 
-        // Resolve every changed persistent id to its id. Live rows come from a fetch; deleted
-        // rows are gone from the store, so their (now-invalidated) insert/update changes can't be read
-        // — their id comes from the delete tombstone instead (mark the identity `.preserveValueOnDeletion`).
-        // Resolving deleted rows lets us recognise an insert-then-delete that never reached the server.
+        // Deleted rows are gone from the store, so their id comes from the delete tombstone (needs the
+        // identity marked `.preserveValueOnDeletion`); resolving them catches a never-pushed insert+delete.
         var idByPID: [PersistentIdentifier: String] = Dictionary(
             try context.fetch(FetchDescriptor<Model>()).map { ($0.persistentModelID, $0[keyPath: Model.syncIdentity]) },
             uniquingKeysWith: { lhs, _ in lhs })
@@ -221,8 +217,6 @@ extension SwiftSync {
         }
     }
 }
-
-// MARK: - Push
 
 extension SwiftSync {
     /// Hands your `process` closure the rows changed since the last-pushed token; you own the network call

--- a/SwiftSync/Sources/SwiftSync/SyncContainer.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncContainer.swift
@@ -340,7 +340,7 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
                 $0.ownerTypeName == relationship.relatedTypeName && $0.relatedTypeName == relationship.ownerTypeName
                     && $0.isToMany
             }
-            guard !reciprocalToMany.isEmpty else { continue }  // not many-to-many
+            guard !reciprocalToMany.isEmpty else { continue }
 
             let hasAnchor =
                 relationship.hasExplicitInverseAnchor || reciprocalToMany.contains(where: \.hasExplicitInverseAnchor)
@@ -420,8 +420,7 @@ public final class SyncContainer: NSObject, @unchecked Sendable {
         let changedModelTypeNames: Set<String>
         if sourceContext == mainContext {
             // A local (immediate) write already landed in the main context, so its rows are current
-            // here — don't re-touch the context during its own did-save (avoid reentrancy); just notify
-            // publishers to re-fetch. Type names come from the source (main) context: a safe read.
+            // here — don't re-touch the context during its own did-save (avoid reentrancy); just notify.
             changedModelTypeNames = Set(
                 changedIDs.map { String(reflecting: type(of: sourceContext.model(for: $0))) })
         } else {

--- a/SwiftSync/Sources/SwiftSync/SyncError.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncError.swift
@@ -6,8 +6,6 @@ import Foundation
 public enum SyncError: Error, Sendable, Equatable {
     case invalidPayload(model: String, reason: String)
     case cancelled
-    /// A model's schema is invalid for sync (e.g. an unanchored many-to-many, or a uniqueness
-    /// constraint off the sync identity).
     case schemaValidation(reason: String)
     case containerInitialization(reason: String)
 }

--- a/SwiftSync/Sources/SwiftSync/SyncJSON.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncJSON.swift
@@ -1,11 +1,7 @@
 import Foundation
 
-/// A `Sendable`, structured JSON value.
-///
-/// `sync(...)` runs off the main actor, so a payload crossing into it must be `Sendable` — which a raw
-/// `[String: Any]` is not. `SyncJSON` is the carrier: box your JSON once with `init(dictionary:)`, hand it
-/// to `sync` across actor boundaries, and read it back with the keyed accessors. It conforms to
-/// `SyncPayloadConvertible`, so it feeds `sync(payload:)` / `sync(item:)` directly.
+/// A `Sendable`, structured JSON value. `sync(...)` runs off the main actor, so a payload crossing into
+/// it must be `Sendable` — which a raw `[String: Any]` is not. `SyncJSON` is the carrier.
 public enum SyncJSON: Sendable, SyncPayloadConvertible {
     case string(String)
     case int(Int)
@@ -43,7 +39,6 @@ public enum SyncJSON: Sendable, SyncPayloadConvertible {
         }
     }
 
-    /// Boxes a JSON object.
     public init(dictionary: [String: Any]) throws {
         self = .object(try dictionary.mapValues { try SyncJSON($0) })
     }
@@ -53,13 +48,11 @@ public enum SyncJSON: Sendable, SyncPayloadConvertible {
         return members.mapValues(\.foundationValue)
     }
 
-    /// The string at `key` when this is an object whose value there is a string.
     public func string(_ key: String) -> String? {
         guard case .object(let members) = self, case .string(let value)? = members[key] else { return nil }
         return value
     }
 
-    /// The object elements of the array at `key` when this is an object.
     public func objectArray(_ key: String) -> [SyncJSON]? {
         guard case .object(let members) = self, case .array(let elements)? = members[key] else { return nil }
         return elements.filter { if case .object = $0 { return true } else { return false } }

--- a/SwiftSync/Sources/SwiftSync/SyncModelable.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncModelable.swift
@@ -4,8 +4,8 @@ import SwiftData
 public protocol SyncModelable: PersistentModel {
     associatedtype SyncID: Hashable & Codable & Sendable
     static var syncIdentity: KeyPath<Self, SyncID> { get }
-    /// Swift property name of the identity (synthesised by `@Syncable`). Empty for hand-written
-    /// conformances; used by `SyncContainer` to reject uniqueness constraints on non-identity fields.
+    /// Swift property name of the identity (synthesised by `@Syncable`); empty for hand-written
+    /// conformances.
     static var syncIdentityPropertyName: String { get }
     static func syncIdentityPredicate(matching identity: SyncID) -> Predicate<Self>?
     static func syncIdentityPredicate(matchingAny identities: [SyncID]) -> Predicate<Self>?

--- a/SwiftSync/Sources/SwiftSync/SyncPerformanceProfiler.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncPerformanceProfiler.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-/// A measured step of a sync operation. The raw value is the key under which `SyncPerformanceProfiler`
-/// accumulates the step's duration — and the label shown in the benchmark's per-phase report.
+/// The raw value is both the accumulation key and the label shown in the benchmark's per-phase report.
 enum SyncPhase: String {
     case normalizePayload = "normalize-payload"
     case fetchExisting = "fetch-existing"

--- a/SwiftSync/Sources/SwiftSync/SyncUpdatableModel.swift
+++ b/SwiftSync/Sources/SwiftSync/SyncUpdatableModel.swift
@@ -18,8 +18,8 @@ public protocol SyncUpdatableModel: SyncModelable {
     func export(keyStyle: KeyStyle, dateFormatter: DateFormatter) -> [String: Any]
 
     /// Forces a scalar write so iOS CoreData marks the owning row dirty after a to-many change.
-    /// `@Syncable` generates `self.id = self.id`. Hand-written conformances get a no-op default
-    /// — override if your model has to-many relationships. See docs/project/ios-dirty-tracking-gap.md.
+    /// Hand-written conformances get a no-op default — override if your model has to-many relationships.
+    /// See docs/project/ios-dirty-tracking-gap.md.
     func syncMarkChanged()
 }
 
@@ -48,7 +48,6 @@ extension SyncUpdatableModel {
     }
 }
 
-/// Which relationship mutations a `applyRelationships(_:in:operations:)` pass is allowed to perform.
 public struct SyncRelationshipOperations: OptionSet, Sendable {
     public let rawValue: Int
 

--- a/SwiftSync/Sources/SwiftSync/UI/ObservationTracking.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/ObservationTracking.swift
@@ -2,9 +2,8 @@ import Dispatch
 import Observation
 
 extension SwiftSync {
-    /// Run `update`, tracking the `@Observable` values it reads, then re-run it on the next change —
-    /// continuously. Bridges Observation to imperative callers (a UIKit controller, or a machine mirroring
-    /// observable state) that can't lean on SwiftUI's automatic view-body tracking.
+    /// Re-runs `update` on every change to the `@Observable` values it reads — bridging Observation to
+    /// imperative callers (a UIKit controller, a machine) that can't lean on SwiftUI's view-body tracking.
     @MainActor
     public static func observeContinuously(_ update: @escaping @MainActor () -> Void) {
         withObservationTracking {

--- a/SwiftSync/Sources/SwiftSync/UI/PendingChangesPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/PendingChangesPublisher.swift
@@ -2,11 +2,8 @@ import Foundation
 import Observation
 import SwiftData
 
-/// Observes the local store and exposes the **pending changes** for `Model` — the un-pushed inserts/
-/// updates/deletes since the last push — the reactive counterpart of `SwiftSync.pendingChanges(for:in:)`.
-/// `pendingChanges` is computed against the live store on each read (so a synchronous read right after a
-/// save is current); reading it inside an observation also re-evaluates whenever the store saves.
-/// Plain-Swift and `@Observable`.
+/// The reactive counterpart of `SwiftSync.pendingChanges(for:in:)`: exposes the un-pushed changes for
+/// `Model`, re-evaluated whenever the store saves. Plain-Swift and `@Observable`.
 @MainActor
 @Observable
 public final class PendingChangesPublisher<Model: SyncUpdatableModel> where Model.SyncID == String {

--- a/SwiftSync/Sources/SwiftSync/UI/SyncLoadPhase.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/SyncLoadPhase.swift
@@ -1,22 +1,18 @@
 import Foundation
 import Observation
 
-/// The lifecycle of the sync that backs a synced read.
 public enum SyncLoadPhase: Equatable, Sendable {
     case idle
     case loading
     case loaded
     case failed(message: String)
 
-    /// The failure message, if this phase is `.failed`.
     public var failureMessage: String? {
         if case .failed(let message) = self { return message }
         return nil
     }
 }
 
-/// Drives one load action through the phases. Shared by the synced publishers so the load logic lives in
-/// exactly one place.
 @MainActor
 @Observable
 final class SyncLoadDriver {

--- a/SwiftSync/Sources/SwiftSync/UI/SyncModel.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/SyncModel.swift
@@ -2,8 +2,6 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-/// SwiftUI property wrapper observing the **single row** matching an id (`row`); the plain-Swift
-/// equivalent is `SyncModelPublisher`, which it wraps. For a collection, use `@SyncQuery`.
 @MainActor
 @propertyWrapper
 public struct SyncModel<Model: PersistentModel & SyncModelable>: DynamicProperty {

--- a/SwiftSync/Sources/SwiftSync/UI/SyncModelPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/SyncModelPublisher.swift
@@ -2,9 +2,7 @@ import Foundation
 import Observation
 import SwiftData
 
-/// Observes the **single row** matching `id` (`row`), kept current as the store syncs — the single-row
-/// counterpart of `SyncQueryPublisher` (collection); in SwiftUI, `@SyncModel`. Requires `SyncModelable`
-/// (not just `PersistentModel`) because it fetches by sync identity.
+/// Requires `SyncModelable` (not just `PersistentModel`): it fetches by sync identity.
 @MainActor
 @Observable
 public final class SyncModelPublisher<Model: PersistentModel & SyncModelable> {

--- a/SwiftSync/Sources/SwiftSync/UI/SyncQuery.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/SyncQuery.swift
@@ -2,8 +2,6 @@ import Foundation
 import SwiftData
 import SwiftUI
 
-/// SwiftUI property wrapper observing a **collection** (`rows`); the plain-Swift equivalent is
-/// `SyncQueryPublisher`, which it wraps. For a single row by id, use `@SyncModel`.
 @MainActor
 @propertyWrapper
 public struct SyncQuery<Model: PersistentModel>: DynamicProperty {

--- a/SwiftSync/Sources/SwiftSync/UI/SyncQueryPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/SyncQueryPublisher.swift
@@ -2,8 +2,6 @@ import Foundation
 import Observation
 import SwiftData
 
-/// Observes a **collection** (`rows`), kept current as the store syncs — all rows, a `predicate`, or a
-/// relationship scope. For the single row matching an id use `SyncModelPublisher`; in SwiftUI, `@SyncQuery`.
 @MainActor
 @Observable
 public final class SyncQueryPublisher<Model: PersistentModel> {

--- a/SwiftSync/Sources/SwiftSync/UI/SyncSubmissionDriver.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/SyncSubmissionDriver.swift
@@ -1,23 +1,19 @@
 import Foundation
 import Observation
 
-/// The lifecycle of a one-shot submission (save, delete, send) — the write-side counterpart of
-/// `SyncLoadPhase`.
 public enum SyncSubmissionPhase: Equatable, Sendable {
     case idle
     case submitting
     case failed(message: String)
 
-    /// The failure message, if this phase is `.failed`.
     public var failureMessage: String? {
         if case .failed(let message) = self { return message }
         return nil
     }
 }
 
-/// Runs a single in-flight submission through its phases. A submit while one is already in flight is
-/// ignored (the double-submit guard a screen otherwise hand-wires); success returns to `.idle`, a throw
-/// becomes `.failed`. Plain-Swift and `@Observable`, the write-side counterpart of the synced read drivers.
+/// A submit while one is already in flight is ignored (the double-submit guard a screen otherwise
+/// hand-wires); success returns to `.idle`, a throw becomes `.failed`. Plain-Swift and `@Observable`.
 @MainActor
 @Observable
 public final class SyncSubmissionDriver {
@@ -42,7 +38,6 @@ public final class SyncSubmissionDriver {
         }
     }
 
-    /// Clear a `.failed` phase back to `.idle` (e.g. the user dismissed the error). A no-op otherwise.
     public func dismissFailure() {
         if case .failed = phase { phase = .idle }
     }

--- a/SwiftSync/Sources/SwiftSync/UI/SyncedModelPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/SyncedModelPublisher.swift
@@ -2,8 +2,6 @@ import Foundation
 import Observation
 import SwiftData
 
-/// Pairs a reactive **single-row** read (by id) with the sync that populates it — the single-row
-/// counterpart of `SyncedQueryPublisher`. Plain-Swift and `@Observable`.
 @MainActor
 @Observable
 public final class SyncedModelPublisher<Model: PersistentModel & SyncModelable> {

--- a/SwiftSync/Sources/SwiftSync/UI/SyncedQueryPublisher.swift
+++ b/SwiftSync/Sources/SwiftSync/UI/SyncedQueryPublisher.swift
@@ -2,9 +2,6 @@ import Foundation
 import Observation
 import SwiftData
 
-/// Pairs a reactive **collection** query with the sync that populates it — the load-state machine +
-/// observation a screen otherwise hand-wires. Declare *what* to read and *how* to load it; read back
-/// live `rows` plus a `phase`. Plain-Swift and `@Observable`.
 @MainActor
 @Observable
 public final class SyncedQueryPublisher<Model: PersistentModel> {

--- a/SwiftSync/Tests/SwiftSyncTests/FetchStrategyBenchmarkTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/FetchStrategyBenchmarkTests.swift
@@ -878,9 +878,7 @@ private struct BenchmarkEnvironment {
     let scopeSize: Int
     let sampleCount: Int
     let phaseProfilingEnabled: Bool
-    /// Optional CI regression ceiling: if set, a benchmark whose median exceeds this many
-    /// milliseconds fails the test. Set generously — this is a catastrophic/algorithmic
-    /// regression guard, not precise perf tracking (CI hardware varies and is noisy).
+    /// Set generously — a catastrophic/algorithmic-regression guard, not perf tracking (CI hardware is noisy).
     let maxMedianMilliseconds: Double?
 
     static var current: BenchmarkEnvironment {

--- a/SwiftSync/Tests/SwiftSyncTests/InboundPrunePreservesPendingTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/InboundPrunePreservesPendingTests.swift
@@ -17,7 +17,7 @@ final class PruneProject {
 @Syncable
 @Model
 final class PruneTask {
-    // Offline opt-in: identity preserved on deletion → this model gets dirty-set pull semantics.
+    // .preserveValueOnDeletion is the offline opt-in: it gives this model dirty-set pull semantics.
     @Attribute(.unique, .preserveValueOnDeletion) var id: String
     var title: String
     @NotExport var project: PruneProject?
@@ -29,9 +29,8 @@ final class PruneTask {
     }
 }
 
-/// The #625 guarantee, rebuilt on SwiftData history: an inbound pull preserves a never-pushed local
-/// insert (it's in the history dirty-set) but still prunes a row the server genuinely deleted (which
-/// arrived via an inbound pull and so isn't dirty).
+/// An inbound pull preserves a never-pushed local insert (it's in the history dirty-set) but still
+/// prunes a server-deleted row (which arrived via a pull and so isn't dirty).
 @MainActor
 final class InboundPrunePreservesPendingTests: XCTestCase {
     private func makeContainer() throws -> SyncContainer {
@@ -49,7 +48,6 @@ final class InboundPrunePreservesPendingTests: XCTestCase {
         let context = container.mainContext
         let project = PruneProject(id: "p1")
         context.insert(project)
-        // A local-only insert the server has never seen (offline-created).
         context.insert(PruneTask(id: "t-local", title: "offline created", project: project))
         try context.save()
 
@@ -69,11 +67,11 @@ final class InboundPrunePreservesPendingTests: XCTestCase {
         context.insert(project)
         try context.save()
 
-        // The row arrives via an inbound pull (server-known, not dirty)…
+        // Arrives via a pull, so it's server-known and not dirty…
         try await container.sync(
             payload: [["id": "t-synced", "title": "synced"]],
             as: PruneTask.self, parent: project, relationship: \PruneTask.project)
-        // …then the server omits it → genuinely deleted server-side, so the prune must remove it.
+        // …then an empty pull omits it, meaning server-side deletion, so the prune must remove it.
         try await container.sync(
             payload: [], as: PruneTask.self, parent: project, relationship: \PruneTask.project)
 

--- a/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflineHistoryTests.swift
@@ -19,9 +19,8 @@ final class HistoryRow {
 
 @MainActor
 final class OfflineHistoryTests: XCTestCase {
-    /// The core of the SwiftData-History design: `pendingChanges` reads the store's change history,
-    /// counts only locally-authored changes (ignoring inbound/pull writes), and recovers a deleted
-    /// row's id from the history tombstone — with zero offline fields on the model.
+    /// `pendingChanges` reads local history (ignoring inbound writes) and recovers a deleted row's id
+    /// from the tombstone — with zero offline fields on the model.
     func testPendingChangesReadsLocalHistoryAndIgnoresInbound() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("offline-history-\(UUID().uuidString)", isDirectory: true)
@@ -31,13 +30,13 @@ final class OfflineHistoryTests: XCTestCase {
         let container = try SyncContainer(for: HistoryRow.self, configurations: configuration)
         let now = Date()
 
-        // Inbound (pull) write — author = inboundAuthor. Must be ignored by pendingChanges.
+        // inboundAuthor marks this as a pull write, which pendingChanges must ignore.
         let inbound = ModelContext(container.modelContainer)
         inbound.author = SwiftSync.inboundAuthor
         inbound.insert(HistoryRow(id: "server-1", title: "From server", updatedAt: now))
         try inbound.save()
 
-        // Local write — default author. Must be detected as a pending insert.
+        // Default author marks a local write, detected as pending.
         let local = container.mainContext
         local.insert(HistoryRow(id: "local-1", title: "Made offline", updatedAt: now))
         try local.save()
@@ -47,11 +46,11 @@ final class OfflineHistoryTests: XCTestCase {
         XCTAssertTrue(pending.updates.isEmpty)
         XCTAssertTrue(pending.deletes.isEmpty)
 
-        // Push it so it's "synced" (token advances past its insert); now a later delete is a genuine
-        // pending deletion rather than an insert-then-delete the server never saw.
+        // Push first so the row is synced; the later delete is then a genuine pending deletion,
+        // not an insert-then-delete the server never saw.
         _ = try await SwiftSync.withPendingChanges(for: HistoryRow.self, in: local) { _ in [] }
 
-        // Delete the synced row with a plain context.delete — the tombstone must yield its id.
+        // Plain context.delete — no special API; the id must still come back from the tombstone.
         let row = try XCTUnwrap(
             try local.fetch(FetchDescriptor<HistoryRow>(predicate: #Predicate { $0.id == "local-1" })).first)
         local.delete(row)
@@ -97,9 +96,8 @@ final class OfflineHistoryTests: XCTestCase {
         XCTAssertEqual(Set(pending.inserts), Set(["local-1", "widget-1"]))
     }
 
-    /// Opt-in overhead benchmark: how much does a large pull cost under the History design?
-    /// Expectation: ~baseline, because the pull writes no extra rows — offline tracking is a *read*
-    /// of history at push time, not a write on the pull path.
+    /// Opt-in benchmark. Expectation: ~baseline, because offline tracking reads history at push time
+    /// rather than writing extra rows on the pull path.
     ///   SWIFTSYNC_RUN_BENCHMARKS=1 SWIFTSYNC_BENCHMARK_TIERS=100000 \
     ///     swift test --filter OfflineHistoryTests/testBulkPullOverhead
     func testBulkPullOverhead() async throws {
@@ -134,7 +132,7 @@ final class OfflineHistoryTests: XCTestCase {
             try context.trimSwiftSyncInboundHistory()
             let cleanupMs = cleanupStart.duration(to: clock.now).msValue
 
-            // Push-side detection over the same store: should be ~empty (all inbound-authored) and fast.
+            // Push-side detection should be ~empty and fast: every row was inbound-authored.
             let detectStart = clock.now
             let pending = try SwiftSync.pendingChanges(for: HistoryRow.self, in: context, since: nil)
             let detectMs = detectStart.duration(to: clock.now).msValue

--- a/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/OfflinePushTests.swift
@@ -43,9 +43,9 @@ final class OfflinePushTests: XCTestCase {
         // Baseline push: a, b, d become synced (token advances past their inserts).
         _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: noFailures)
 
-        try mutate(context) { $0.first { $0.id == "b" }?.title = "edited" }  // update
-        try delete("d", in: context)  // delete
-        context.insert(PushNote(id: "c", title: "new"))  // insert
+        try mutate(context) { $0.first { $0.id == "b" }?.title = "edited" }
+        try delete("d", in: context)
+        context.insert(PushNote(id: "c", title: "new"))
         let e = PushNote(id: "e", title: "ephemeral")  // insert-then-delete → dropped
         context.insert(e)
         try context.save()
@@ -97,7 +97,7 @@ final class OfflinePushTests: XCTestCase {
         let context = container.mainContext
         context.insert(PushNote(id: "u1", title: "v1"))
         try context.save()
-        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: noFailures)  // synced
+        _ = try await SwiftSync.withPendingChanges(for: PushNote.self, in: context, process: noFailures)
 
         try mutate(context) { $0.first { $0.id == "u1" }?.title = "v2" }
         try context.save()
@@ -254,9 +254,7 @@ final class OfflinePushTests: XCTestCase {
                 return []
             }
             XCTFail("expected push to throw when the bookkeeping model is not registered")
-        } catch {
-            // Expected: push throws rather than completing a stranded upload.
-        }
+        } catch {}
         XCTAssertFalse(
             uploadCalled, "push must fail before uploading, so an acknowledged server write is never stranded")
     }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncExportTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncExportTests.swift
@@ -228,9 +228,6 @@ final class CycleNode {
     }
 }
 
-/// A Task-like model used to test that update bodies via export
-/// correctly honor @RemoteKey("description") and @RemoteKey("state.id/label"),
-/// matching the gap that existed before update adopted the export pattern.
 @Syncable
 @Model
 final class UpdateTaskLike {
@@ -247,9 +244,7 @@ final class UpdateTaskLike {
     }
 }
 
-// Compile-time regression: export must be a requirement of SyncUpdatableModel,
-// not a separate ExportModel protocol. This function would not compile if export
-// were missing from SyncUpdatableModel.
+// Compile-time regression: fails to compile if `export` stops being a `SyncUpdatableModel` requirement.
 private func _assertExportIsOnSyncUpdatableModel<M: SyncUpdatableModel>(
     _ model: M,
     keyStyle: KeyStyle,
@@ -443,10 +438,6 @@ final class ExportTests: XCTestCase {
         XCTAssertTrue(body["nickname"] is NSNull, "Nil optional scalar must always emit NSNull")
     }
 
-    /// Scenario A — PATCH with explicit null to clear a field.
-    /// exportObject always emits NSNull for nil optionals. Callers can then overwrite specific
-    /// fields with NSNull() to signal "clear this field", or overwrite with a new value.
-    /// Both result in the key being present in the body — the intended behavior for partial-update APIs.
     @MainActor
     func testExportNilFieldCanBeExplicitlyClearedAfterExport() throws {
         let schema = Schema([ExportTask.self])
@@ -455,18 +446,15 @@ final class ExportTests: XCTestCase {
         let syncContainer = SyncContainer(modelContainer)
         let context = syncContainer.mainContext
 
-        // A task with nickname already nil in the model
         context.insert(ExportTask(id: 10, completed: false, createdAt: Date(timeIntervalSince1970: 0), nickname: nil))
         try context.save()
         let task = try context.fetch(FetchDescriptor<ExportTask>()).first!
 
-        // Export produces NSNull for nickname automatically — no manual NSNull() needed
         let body = syncContainer.export(task)
         XCTAssertTrue(
             body["nickname"] is NSNull,
             "Nil optional must appear as NSNull in body so server clears the field")
 
-        // Caller can still override any key after export (e.g. to set a new value)
         var mutableBody = body
         mutableBody["nickname"] = "new-name"
         XCTAssertEqual(mutableBody["nickname"] as? String, "new-name")
@@ -506,15 +494,8 @@ final class ExportTests: XCTestCase {
         XCTAssertEqual(childBody["id"] as? Int, 2)
     }
 
-    // MARK: - Update body via export
-
-    /// Regression: buildUpdateBody must use @RemoteKey mappings,
-    /// not raw Swift property names. This mirrors the pattern used in DemoSyncEngine
-    /// for createTask and must apply equally to updateTask.
     @MainActor
     func testBuildUpdateBodyUsesRemoteKeyMappings() throws {
-        // ExportMappedFields has @RemoteKey("type") on userType and @RemoteKey("profile.contact.email") on email.
-        // Simulate the buildUpdateBody pattern: transient model → exportObject → inspect keys.
         let schema = Schema([ExportMappedFields.self])
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: config)
@@ -528,11 +509,9 @@ final class ExportTests: XCTestCase {
             dateFormatter: DateFormatter.syncDefault()
         )
 
-        // @RemoteKey("type") must appear as "type", not "user_type"
         XCTAssertEqual(body["type"] as? String, "editor", "Expected @RemoteKey(\"type\") to map userType → \"type\"")
         XCTAssertNil(body["user_type"], "Raw snake_case key must not appear when @RemoteKey overrides it")
 
-        // @RemoteKey("profile.contact.email") must appear nested
         let profile = body["profile"] as? [String: Any]
         let contact = profile?["contact"] as? [String: Any]
         XCTAssertEqual(
@@ -540,14 +519,10 @@ final class ExportTests: XCTestCase {
             "Expected @RemoteKey(\"profile.contact.email\") to produce nested structure")
         XCTAssertNil(body["email"], "Flat key must not appear when nested @RemoteKey overrides it")
 
-        // @NotExport field must be absent
         XCTAssertNil(body["local_only"], "@NotExport field must be excluded from update body")
         XCTAssertNil(body["localOnly"], "@NotExport field must be excluded from update body (camelCase variant)")
     }
 
-    /// Regression: buildUpdateBody for a Task-like model must use @RemoteKey("description")
-    /// for descriptionText and nested state dict for @RemoteKey("state.id") / @RemoteKey("state.label").
-    /// This is the exact mapping gap that existed before update adopted export.
     @MainActor
     func testBuildUpdateBodyUsesRemoteKeyForTaskLikeModel() throws {
         let schema = Schema([UpdateTaskLike.self])
@@ -568,7 +543,6 @@ final class ExportTests: XCTestCase {
             dateFormatter: DateFormatter.syncDefault()
         )
 
-        // descriptionText → @RemoteKey("description") → must appear as "description"
         XCTAssertEqual(
             body["description"] as? String, "Updated body text",
             "Expected @RemoteKey(\"description\") to map descriptionText → \"description\"")
@@ -579,7 +553,6 @@ final class ExportTests: XCTestCase {
             body["descriptionText"],
             "Camel-case key must not appear when @RemoteKey overrides it")
 
-        // state → @RemoteKey("state.id") → must appear nested under "state" dict
         let stateDict = body["state"] as? [String: Any]
         XCTAssertEqual(
             stateDict?["id"] as? String, "inProgress",
@@ -590,8 +563,6 @@ final class ExportTests: XCTestCase {
         XCTAssertNil(body["state_id"], "Flat state_id key must not appear")
         XCTAssertNil(body["state_label"], "Flat state_label key must not appear")
     }
-
-    // MARK: - SyncContainer.export(_:) derives keyStyle and dateFormatter from SyncContainer
 
     @MainActor
     func testExportForContainerDerivesKeyStyleFromContainer() throws {
@@ -607,7 +578,6 @@ final class ExportTests: XCTestCase {
         let task = try context.fetch(FetchDescriptor<ExportTask>()).first!
         let body = syncContainer.export(task)
 
-        // camelCase keyStyle from container: createdAt, not created_at
         XCTAssertNotNil(body["createdAt"], "Expected camelCase key from container.keyStyle")
         XCTAssertNil(body["created_at"], "Snake_case key must not appear when container uses camelCase")
     }

--- a/SwiftSync/Tests/SwiftSyncTests/SyncFeatureInteropTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncFeatureInteropTests.swift
@@ -6,7 +6,6 @@ import XCTest
 // Models that bolt modern SwiftData features onto an otherwise-correct @Syncable model,
 // to characterise how those features interact with SwiftSync's identity/upsert patterns.
 
-// `#Index` on a non-identity field.
 @Syncable
 @Model
 final class InteropIndexedNote {
@@ -21,7 +20,6 @@ final class InteropIndexedNote {
     }
 }
 
-// `@Attribute(.unique)` on a non-identity field.
 @Syncable
 @Model
 final class InteropUniqueEmailUser {
@@ -35,7 +33,6 @@ final class InteropUniqueEmailUser {
     }
 }
 
-// Compound `#Unique` across non-identity fields.
 @Syncable
 @Model
 final class InteropCompoundUniqueEvent {
@@ -52,8 +49,7 @@ final class InteropCompoundUniqueEvent {
 
 final class SyncFeatureInteropTests: XCTestCase {
 
-    /// `#Index` on a non-identity property is transparent to SwiftSync: it only affects query
-    /// planning, so identity-based upsert is unaffected. This is the "safe to use freely" case.
+    /// `#Index` only affects query planning, so identity-based upsert is unaffected — safe to use freely.
     @MainActor
     func testIndexOnNonIdentityFieldIsTransparentToSync() async throws {
         let context = ModelContext(
@@ -67,7 +63,6 @@ final class SyncFeatureInteropTests: XCTestCase {
                 ["id": 2, "title": "B", "category": "x"],
             ], as: InteropIndexedNote.self)
 
-        // Re-sync id 1 with changed fields — must update the same row, not create a new one.
         try await context.sync(item: ["id": 1, "title": "A2", "category": "y"], as: InteropIndexedNote.self)
 
         let notes = try context.fetch(FetchDescriptor<InteropIndexedNote>())
@@ -76,11 +71,6 @@ final class SyncFeatureInteropTests: XCTestCase {
             notes.first { $0.id == 1 }?.title, "A2", "upsert-by-id must still update in place")
     }
 
-    /// A unique constraint on a *non-identity* property breaks SwiftSync's core invariant
-    /// (one row per `syncIdentity`). When sync inserts an identity-distinct row whose unique
-    /// field collides with an existing row, SwiftData performs a constraint-based upsert and
-    /// silently overwrites/destroys the other row — local data ends up disagreeing with the
-    /// backend, with no error. Put uniqueness only on the sync identity.
     @MainActor
     func testUniqueOnNonIdentityFieldCausesSilentSyncDataLoss() async throws {
         XCTExpectFailure(
@@ -93,7 +83,7 @@ final class SyncFeatureInteropTests: XCTestCase {
                 configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
 
         try await context.sync(item: ["id": 1, "email": "a@x.com", "name": "Alice"], as: InteropUniqueEmailUser.self)
-        // id 2 is a distinct record per SwiftSync identity, but collides on the unique email.
+        // Distinct sync identity (id 2), but collides on the unique email.
         try await context.sync(item: ["id": 2, "email": "a@x.com", "name": "Bob"], as: InteropUniqueEmailUser.self)
 
         let users = try context.fetch(FetchDescriptor<InteropUniqueEmailUser>())
@@ -101,9 +91,6 @@ final class SyncFeatureInteropTests: XCTestCase {
         XCTAssertTrue(users.contains { $0.id == 1 }, "the original row must not be destroyed")
     }
 
-    /// Compound `#Unique` across non-identity fields has the same hazard as a single-field
-    /// unique constraint: an identity-distinct row that collides on the compound key destroys
-    /// the existing row during sync.
     @MainActor
     func testCompoundUniqueOnSyncedFieldsCausesSilentSyncDataLoss() async throws {
         XCTExpectFailure(
@@ -123,10 +110,6 @@ final class SyncFeatureInteropTests: XCTestCase {
         XCTAssertTrue(events.contains { $0.id == 1 }, "the original row must not be destroyed")
     }
 
-    // MARK: - Guardrail: SyncContainer refuses the data-loss footgun at init
-
-    /// `#Index` on a non-identity field is safe, so a `SyncContainer` built from such a model
-    /// initialises normally.
     @MainActor
     func testSyncContainerAcceptsIndexAndIdentityUniqueModel() throws {
         XCTAssertNoThrow(
@@ -135,8 +118,6 @@ final class SyncFeatureInteropTests: XCTestCase {
                 configurations: ModelConfiguration(isStoredInMemoryOnly: true)))
     }
 
-    /// A `@Syncable` model with `@Attribute(.unique)` on a non-identity field must be rejected at
-    /// `SyncContainer` init — same guardrail style as the many-to-many inverse check.
     @MainActor
     func testSyncContainerRejectsUniqueOnNonIdentityField() throws {
         XCTAssertThrowsError(
@@ -153,7 +134,6 @@ final class SyncFeatureInteropTests: XCTestCase {
         }
     }
 
-    /// Compound `#Unique` across non-identity fields is rejected at `SyncContainer` init.
     @MainActor
     func testSyncContainerRejectsCompoundUniqueOnNonIdentityFields() throws {
         XCTAssertThrowsError(

--- a/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncQueryPublisherTests.swift
@@ -30,7 +30,7 @@ final class PubUser {
     }
 }
 
-// Unrelated to PubTask/PubUser — used to verify no spurious reloads across type boundaries.
+// Used to verify a sync of one type triggers no reload on a query of another.
 @Syncable
 @Model
 final class PubUnrelatedTag {
@@ -45,16 +45,12 @@ final class PubUnrelatedTag {
 
 final class SyncQueryPublisherTests: XCTestCase {
 
-    // MARK: - Helpers
-
     @MainActor
     private func makeContainer(modelTypes: any PersistentModel.Type...) throws -> SyncContainer {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let modelContainer = try ModelContainer(for: Schema(modelTypes), configurations: config)
         return SyncContainer(modelContainer)
     }
-
-    // MARK: - Basic population
 
     @MainActor
     func testPublisherEmitsInitialRows() throws {
@@ -72,8 +68,6 @@ final class SyncQueryPublisherTests: XCTestCase {
 
         XCTAssertEqual(publisher.rows.map(\.id), ["t1", "t2"])
     }
-
-    // MARK: - Reactive reload after sync
 
     @MainActor
     func testPublisherReloadsAfterSync() async throws {
@@ -124,8 +118,6 @@ final class SyncQueryPublisherTests: XCTestCase {
         XCTAssertEqual(publisher.rows.first?.title, "New Title")
     }
 
-    // MARK: - Predicate filtering
-
     @MainActor
     func testPublisherWithPredicateFiltersRows() async throws {
         let syncContainer = try makeContainer(modelTypes: PubTask.self, PubUser.self)
@@ -151,8 +143,6 @@ final class SyncQueryPublisherTests: XCTestCase {
 
         XCTAssertEqual(publisher.rows.map(\.id).sorted(), ["t1", "t3"])
     }
-
-    // MARK: - No spurious reload for unrelated types
 
     @MainActor
     func testPublisherDoesNotReloadForUnrelatedTypeChange() async throws {
@@ -180,8 +170,6 @@ final class SyncQueryPublisherTests: XCTestCase {
 
         XCTAssertEqual(publisher.rows.map(\.id), originalRows)
     }
-
-    // MARK: - postFetchFilter (relationship)
 
     @MainActor
     func testPublisherWithToOneRelationshipIDFilter() async throws {
@@ -280,8 +268,6 @@ final class SyncQueryPublisherTests: XCTestCase {
         XCTAssertEqual(publisher.rows.first?.title, "Updated")
     }
 
-    // MARK: - Current rows surface
-
     @MainActor
     func testRowsReflectLatestValues() async throws {
         let syncContainer = try makeContainer(modelTypes: PubTask.self, PubUser.self)
@@ -363,20 +349,17 @@ final class SyncQueryPublisherTests: XCTestCase {
         XCTFail("Timed out waiting for condition: \(description)")
     }
 
-    // MARK: - single-object writes land in place
-
     @MainActor
     func testSingleItemSyncUpdatesRegisteredRowInPlace() async throws {
         let container = try makeContainer(modelTypes: PubTask.self)
         container.mainContext.insert(PubTask(id: "t1", title: "Original"))
         try container.mainContext.save()
 
-        // A live query / SwiftUI view holds the registered main-context instance.
+        // Stands in for a live query/view holding the registered main-context instance.
         let row = try XCTUnwrap(
             container.mainContext.fetch(FetchDescriptor<PubTask>()).first { $0.id == "t1" })
 
-        // A single-object sync applies on the main context, so the edit lands on the already-registered
-        // instance at once (no cross-context merge to wait on).
+        // Single-object sync applies on the main context, so the edit lands in place — no merge to await.
         try await container.sync(item: ["id": "t1", "title": "Edited"], as: PubTask.self)
 
         XCTAssertEqual(row.title, "Edited")

--- a/SwiftSync/Tests/SwiftSyncTests/SyncRelationshipIntegrityTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncRelationshipIntegrityTests.swift
@@ -8,7 +8,7 @@ import XCTest
 final class MissingInverseRegressionTag {
     @Attribute(.unique) var id: Int
     var name: String
-    // Intentionally missing explicit inverse to reproduce the bug we saw in Demo.
+    // Intentionally no explicit inverse — reproduces the Demo bug; don't "fix" it.
     var tasks: [MissingInverseRegressionTask]
 
     init(id: Int, name: String, tasks: [MissingInverseRegressionTask] = []) {
@@ -206,11 +206,8 @@ extension ExplicitInverseRegressionTask: SyncUpdatableModel {
     }
 }
 
-// MARK: - Models for syncMarkChanged spy tests
-
-// Models that mirror the Demo pattern: Task owns a to-many relationship to User
-// where User has NO back-reference property. This is the one-sided relationship
-// pattern believed to trigger SwiftData's dirty-tracking gap on iOS persistent stores.
+// One-sided to-many (User has no back-reference) — the pattern that triggers SwiftData's
+// dirty-tracking gap on iOS persistent stores.
 @Model
 final class OneSidedUser {
     @Attribute(.unique) var id: Int
@@ -228,8 +225,7 @@ final class OneSidedTask {
     var title: String
     var syncChangeToken: Int
 
-    // No explicit inverse — OneSidedUser has no back-reference to OneSidedTask.
-    // This mirrors Task.reviewers / Task.watchers in the Demo.
+    // No explicit inverse, mirroring Task.reviewers / Task.watchers in the Demo.
     @Relationship var members: [OneSidedUser]
 
     init(id: Int, title: String, syncChangeToken: Int = 0, members: [OneSidedUser] = []) {
@@ -265,8 +261,7 @@ extension OneSidedUser: SyncUpdatableModel {
 }
 
 extension OneSidedTask: SyncUpdatableModel {
-    // Spy counter — incremented by syncMarkChanged() so tests can assert it was called.
-    // nonisolated(unsafe) because it is mutated from test code without actor isolation.
+    // Spy counter incremented by syncMarkChanged(); nonisolated(unsafe) as test code mutates it unisolated.
     nonisolated(unsafe) static var syncMarkChangedCallCount: Int = 0
 
     typealias SyncID = Int
@@ -424,20 +419,13 @@ extension OneSidedNestedTask: SyncUpdatableModel {
     }
 }
 
-// MARK: - syncMarkChanged call-site tests
-
-/// Verifies syncApplyToManyForeignKeys calls syncMarkChanged() at the right times.
-/// Spy-based so the contract is testable on macOS (notification behavior differs per platform).
+/// Spy-based so the contract is testable on macOS — notification behavior differs per platform.
 final class SyncMarkChangedCallSiteTests: XCTestCase {
     override func setUp() {
         super.setUp()
         OneSidedTask.syncMarkChangedCallCount = 0
     }
 
-    // Verifies the core contract: syncApplyToManyForeignKeys must call syncMarkChanged()
-    // on the owning model whenever the to-many membership actually changes.
-    //
-    // This test is RED without the fix (count is 0, expected 1) and GREEN after it.
     func testSyncApplyToManyForeignKeysCallsSyncMarkChangedAfterMembershipChange() async throws {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(
@@ -446,7 +434,6 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         )
         let context = ModelContext(container)
 
-        // Seed two users and a task with no members.
         try await context.sync(
             payload: [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"]], as: OneSidedUser.self)
         try await context.sync(
@@ -455,14 +442,11 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         let task = try XCTUnwrap(context.fetch(FetchDescriptor<OneSidedTask>()).first)
         XCTAssertEqual(task.members.count, 0, "precondition: task starts with no members")
 
-        // Reset spy before the sync under test.
         OneSidedTask.syncMarkChangedCallCount = 0
 
-        // Sync a to-many membership change: [] → [1, 2]. No scalar (title) changes.
+        // Membership change [] → [1, 2] with title unchanged, so only the relationship triggers the mark.
         try await context.sync(payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]], as: OneSidedTask.self)
 
-        // syncApplyToManyForeignKeys must have called syncMarkChanged() exactly once.
-        // Without the fix this count is 0 — the test fails, reproducing the bug contract.
         XCTAssertEqual(
             OneSidedTask.syncMarkChangedCallCount, 1,
             "syncApplyToManyForeignKeys must call syncMarkChanged() after a membership change "
@@ -470,12 +454,9 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
                 + "Count was \(OneSidedTask.syncMarkChangedCallCount), expected 1."
         )
 
-        // Relationship data must also be correct after the sync.
         XCTAssertEqual(Set(task.members.map(\.id)), Set([1, 2]))
     }
 
-    // Verifies syncMarkChanged() is NOT called when membership is unchanged —
-    // no spurious dirty-marks when nothing actually changed.
     func testSyncApplyToManyForeignKeysDoesNotCallSyncMarkChangedWhenUnchanged() async throws {
         let config = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(
@@ -486,12 +467,10 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
 
         try await context.sync(
             payload: [["id": 1, "name": "Alice"], ["id": 2, "name": "Bob"]], as: OneSidedUser.self)
-        // Seed with existing membership [1, 2].
         try await context.sync(payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]], as: OneSidedTask.self)
 
         OneSidedTask.syncMarkChangedCallCount = 0
 
-        // Sync with the same membership — no actual change.
         try await context.sync(payload: [["id": 10, "title": "Task 10", "member_ids": [1, 2]]], as: OneSidedTask.self)
 
         XCTAssertEqual(
@@ -633,11 +612,8 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
         let task = try XCTUnwrap(context.fetch(FetchDescriptor<OneSidedTask>()).first)
         XCTAssertEqual(task.members.map(\.id).sorted(), [1, 2])
 
-        // A direct withObservationTracking observer of the to-many relationship must be
-        // notified when membership-changing sync mutates it. onChange fires synchronously
-        // during the mutation, so the flag is set by the time the sync's await returns;
-        // asserting it directly avoids the polling/re-registration that flakes under
-        // concurrent test-suite load.
+        // onChange fires synchronously during the mutation, so the flag is set by the time the sync's
+        // await returns — asserting it directly avoids the polling/re-registration that flakes under load.
         let observedChange = ObservationFlag()
         withObservationTracking {
             _ = task.members.map(\.id).sorted()
@@ -655,8 +631,7 @@ final class SyncMarkChangedCallSiteTests: XCTestCase {
     }
 }
 
-/// Thread-safe one-shot flag. `withObservationTracking`'s `onChange` is `@Sendable` and may
-/// fire off the main actor, so the box guards its state with a lock.
+/// `onChange` is `@Sendable` and may fire off the main actor, so the flag guards its state with a lock.
 private final class ObservationFlag: @unchecked Sendable {
     private let lock = NSLock()
     private var fired = false
@@ -673,8 +648,6 @@ private final class ObservationFlag: @unchecked Sendable {
         return fired
     }
 }
-
-// MARK: -
 
 final class RelationshipIntegrityRegressionTests: XCTestCase {
     @MainActor
@@ -698,7 +671,7 @@ final class RelationshipIntegrityRegressionTests: XCTestCase {
                 ["id": 3, "name": "Tag 3"],
             ], as: MissingInverseRegressionTag.self)
 
-        // Mirrors the demo flow: a single-task sync happens first after a mutation.
+        // Repro needs the demo ordering: a single-task sync first…
         try await context.sync(
             payload: [
                 [
@@ -708,7 +681,7 @@ final class RelationshipIntegrityRegressionTests: XCTestCase {
                 ]
             ], as: MissingInverseRegressionTask.self)
 
-        // Then a task-list batch sync arrives with another task sharing one tag.
+        // …then a batch sync whose second task shares tag 2 — the membership the bug drops.
         try await context.sync(
             payload: [
                 ["id": 10, "title": "Task 10", "tag_ids": [1, 2]],

--- a/SwiftSync/Tests/SwiftSyncTests/SyncRelationshipOperationsTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncRelationshipOperationsTests.swift
@@ -1,58 +1,8 @@
-// RelationshipOperationsTests.swift
-//
-// Tests for SyncRelationshipOperations — the bitmask that controls which
-// relationship mutations the sync engine is allowed to perform on a given
-// sync call.
-//
-// ## Background
-//
-// `SyncRelationshipOperations` is an OptionSet with three flags:
-//   - `.insert`  — set relationships when a row is newly created
-//   - `.update`  — re-link or mutate relationships on an existing row
-//   - `.delete`  — clear relationships (set to nil / remove members)
-//   - `.all`     — convenience combining all three (the default)
-//
-// The sync engine checks these flags at two layers:
-//
-// 1. **API.swift entry point** — decides whether to call
-//    `applyRelationships` at all based on new-row vs existing-row:
-//    - Existing row: only calls `applyRelationships` if the mask
-//      contains `.update` or `.delete`.
-//    - Newly inserted row: only calls `applyRelationships` if the
-//      mask contains `.insert`.
-//
-// 2. **Free helper functions** (`syncApplyToOneForeignKey`, etc.) —
-//    perform fine-grained checks per flag to decide whether to link,
-//    clear, create, or mutate related objects.
-//
-// ## Why this exists
-//
-// Phased sync workflows sometimes need to insert rows without wiring
-// up their relationships (e.g., when related objects haven't been synced
-// yet and FK lookups would fail). Passing `relationshipOperations: [.insert]`
-// allows the first pass to create rows and set relationships only on
-// newly inserted rows, while a later pass with `.update` re-wires
-// existing rows.
-//
-// ## Historical note
-//
-// These tests originally lived in IntegrationTests.swift alongside the
-// `OpsCompany` and `OpsEmployee` models. The models are hand-written
-// (not @Syncable) to exercise the `operations:` parameter threading
-// manually. They formerly conformed to the now-removed
-// `SyncRelationshipUpdatableModel` protocol, which has been collapsed
-// into `SyncUpdatableModel`.
-
 import SwiftData
 import XCTest
 
 @testable import SwiftSync
 
-// MARK: - Test Models
-
-/// A minimal company model with no relationships, used as the FK target
-/// for `OpsEmployee`. Hand-written (not @Syncable) to keep the operations
-/// test surface explicit.
 @Model
 final class OpsCompany {
     @Attribute(.unique) var id: Int
@@ -64,10 +14,6 @@ final class OpsCompany {
     }
 }
 
-/// An employee model with an optional to-one FK to `OpsCompany`.
-/// Hand-written (not @Syncable) so the `applyRelationships` implementation
-/// can explicitly thread the `operations:` parameter and use `strictValue`
-/// for type-safe FK resolution.
 @Model
 final class OpsEmployee {
     @Attribute(.unique) var id: Int
@@ -80,8 +26,6 @@ final class OpsEmployee {
         self.company = company
     }
 }
-
-// MARK: - SyncUpdatableModel Conformances
 
 extension OpsCompany: SyncUpdatableModel {
     typealias SyncID = Int
@@ -131,12 +75,6 @@ extension OpsEmployee: SyncUpdatableModel {
     }
 }
 
-/// Hand-written `applyRelationships` that explicitly checks the operations
-/// mask before performing any FK mutation. This mirrors what the @Syncable
-/// macro generates via `syncApplyToOneForeignKey`, but done manually so
-/// the test can validate the engine's operation-gating behavior at the
-/// API.swift layer (which decides whether to call `applyRelationships`
-/// at all based on the mask and whether the row is new or existing).
 extension OpsEmployee {
     func applyRelationships(
         _ payload: SyncPayload,
@@ -164,7 +102,7 @@ extension OpsEmployee {
         }
 
         guard let companyID: Int = payload.strictValue(for: "company_id") else {
-            // Strict foreign-key typing: mismatched key type is ignored.
+            // Strict FK typing: a mismatched key type is ignored, not coerced.
             return false
         }
 
@@ -182,27 +120,8 @@ extension OpsEmployee {
     }
 }
 
-// MARK: - Tests
-
 final class RelationshipOperationsTests: XCTestCase {
 
-    /// Validates that the `relationshipOperations` bitmask correctly gates
-    /// relationship mutations based on whether a row is newly inserted vs
-    /// already existing.
-    ///
-    /// Scenario (phased sync):
-    /// 1. Sync a company (id=10).
-    /// 2. Sync an employee with `relationshipOperations: [.insert]` and
-    ///    `company_id: 10`. Because the employee is newly inserted and
-    ///    `.insert` is in the mask, the FK **is** resolved.
-    /// 3. Re-sync the same employee with `relationshipOperations: [.insert]`
-    ///    and `company_id: NSNull()`. The employee already exists, so the
-    ///    engine checks `isDisjoint(with: [.update, .delete])` — since
-    ///    `[.insert]` IS disjoint, `applyRelationships` is never called.
-    ///    The FK **stays** linked.
-    /// 4. Re-sync with `relationshipOperations: [.update]` and
-    ///    `company_id: NSNull()`. Now `.update` passes the disjoint check,
-    ///    `applyRelationships` fires, and the FK **is** cleared.
     @MainActor
     func testRelationshipOperationsSkipRelationshipUpdatesWhenUpdateFlagMissing() async throws {
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)

--- a/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncTests.swift
@@ -468,7 +468,6 @@ extension Team {
                 }
                 desiredMembers = resolvedMembers
             } else {
-                // Explicit null for members means clear membership.
                 desiredMembers = []
             }
             if members.map(\.id) != desiredMembers.map(\.id) {
@@ -544,7 +543,6 @@ extension Employee {
         in context: ModelContext,
         isolation: isolated (any Actor)? = #isolation
     ) async throws -> Bool {
-        // Support to-one by foreign key scalar (company_id).
         guard payload.contains("company_id") else { return false }
 
         let companyID: Int? = payload.value(for: "company_id")
@@ -616,7 +614,6 @@ extension UserWithNotes {
         in context: ModelContext,
         isolation: isolated (any Actor)? = #isolation
     ) async throws -> Bool {
-        // Support to-many by foreign key scalar array (notes_ids).
         guard payload.contains("notes_ids") else { return false }
 
         let desiredIDs: [Int]
@@ -1032,8 +1029,7 @@ extension UniqueEmailNote: SyncUpdatableModel {
     }
 }
 
-// InferredNote: non-unique id – uses the inferred sync overload.
-// Without @Attribute(.unique) on id, the behavior is scoped by parent (two parents → two rows).
+// Without @Attribute(.unique) on id, sync is scoped by parent (two parents → two rows).
 @Model
 final class InferredNote {
     var id: Int
@@ -1426,10 +1422,6 @@ final class SyncTests: XCTestCase {
 
     @MainActor
     func testSyncAppliesNestedRemoteKeyFieldsOnUpdate() async throws {
-        // Regression: apply(_:) must update fields mapped via @RemoteKey with dot-notation
-        // (e.g. @RemoteKey("status.id"), @RemoteKey("status.label")) when the payload contains
-        // a nested dict. Previously these fields were silently skipped on update because
-        // apply(_:) did not traverse nested dicts for @RemoteKey dot-paths.
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: StatusItem.self, configurations: configuration)
         let context = ModelContext(container)
@@ -1641,7 +1633,6 @@ final class SyncTests: XCTestCase {
         let container = try ModelContainer(for: Profile.self, OptionalDateProfile.self, configurations: configuration)
         let context = ModelContext(container)
 
-        // Required Date field defaults to epoch on invalid input.
         try await context.sync(
             payload: [
                 [
@@ -1654,7 +1645,6 @@ final class SyncTests: XCTestCase {
         XCTAssertEqual(requiredRows.count, 1)
         XCTAssertEqual(requiredRows.first?.updatedAt, Date(timeIntervalSince1970: 0))
 
-        // Optional Date field stays nil on invalid input.
         try await context.sync(
             payload: [
                 [
@@ -1972,7 +1962,6 @@ final class SyncTests: XCTestCase {
 
     @MainActor
     func testSyncToManyObjectArrayNullClearsRelationshipSetAndMatchesEmptySemantics() async throws {
-        // Snapshot A: clear with empty array.
         let configurationA = ModelConfiguration(isStoredInMemoryOnly: true)
         let containerA = try ModelContainer(for: UserTagsByObjects.self, Tag.self, configurations: configurationA)
         let contextA = ModelContext(containerA)
@@ -1997,7 +1986,6 @@ final class SyncTests: XCTestCase {
             ], as: UserTagsByObjects.self)
         let usersA = try contextA.fetch(FetchDescriptor<UserTagsByObjects>())
 
-        // Snapshot B: clear with null.
         let configurationB = ModelConfiguration(isStoredInMemoryOnly: true)
         let containerB = try ModelContainer(for: UserTagsByObjects.self, Tag.self, configurations: configurationB)
         let contextB = ModelContext(containerB)
@@ -2153,7 +2141,7 @@ final class SyncTests: XCTestCase {
         XCTAssertEqual(employees.count, 1)
         XCTAssertEqual(employees[0].company?.id, 10)
 
-        // Strict FK typing: string payload for Int FK should be ignored.
+        // Strict FK typing: a string payload for an Int FK is ignored, not coerced.
         try await context.sync(
             payload: [
                 [
@@ -2165,7 +2153,6 @@ final class SyncTests: XCTestCase {
         employees = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertEqual(employees[0].company?.id, 10)
 
-        // Missing key should not clear existing relationship.
         try await context.sync(
             payload: [
                 [
@@ -2177,7 +2164,7 @@ final class SyncTests: XCTestCase {
         XCTAssertEqual(employees[0].name, "Ava Updated")
         XCTAssertEqual(employees[0].company?.id, 10)
 
-        // Unknown FK keeps current relation unchanged.
+        // An FK to a row that doesn't exist leaves the current relation unchanged.
         try await context.sync(
             payload: [
                 [
@@ -2189,7 +2176,6 @@ final class SyncTests: XCTestCase {
         employees = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertEqual(employees[0].company?.id, 10)
 
-        // Explicit null clears relation.
         try await context.sync(
             payload: [
                 [
@@ -2314,7 +2300,6 @@ final class SyncTests: XCTestCase {
         XCTAssertEqual(tasks.count, 1)
         XCTAssertEqual(Set(tasks[0].tags.map(\.id)), Set([1, 2]))
 
-        // Missing key should preserve current to-many links.
         try await context.sync(
             payload: [
                 [
@@ -2326,7 +2311,6 @@ final class SyncTests: XCTestCase {
         XCTAssertEqual(tasks[0].title, "Task A Updated")
         XCTAssertEqual(Set(tasks[0].tags.map(\.id)), Set([1, 2]))
 
-        // Explicit null clears links.
         try await context.sync(
             payload: [
                 [
@@ -2447,13 +2431,11 @@ final class SyncTests: XCTestCase {
         let objectGraph = try await runManyToManyObjectsScenario()
         let idsGraph = try await runManyToManyIDsScenario()
 
-        // No duplicate join edges in either graph.
         XCTAssertEqual(objectGraph[1]?.count, 2)
         XCTAssertEqual(objectGraph[2]?.count, 1)
         XCTAssertEqual(idsGraph[1]?.count, 2)
         XCTAssertEqual(idsGraph[2]?.count, 1)
 
-        // Same add/remove outcomes after update payload.
         XCTAssertFalse(objectGraph[1]?.contains(1) ?? true)
         XCTAssertFalse(idsGraph[1]?.contains(1) ?? true)
         XCTAssertTrue(objectGraph[1]?.contains(4) ?? false)
@@ -2506,7 +2488,6 @@ final class SyncTests: XCTestCase {
                 ["id": 3, "text": "b3"],
             ], as: SuperNote.self, parent: userB, relationship: \SuperNote.superUser)
 
-        // Sync user A scope with one child; user B scope must remain untouched.
         try await context.sync(
             payload: [
                 ["id": 1, "text": "a1-updated"]
@@ -2684,9 +2665,8 @@ final class SyncTests: XCTestCase {
             }
         }
 
-        // The first call acquires SyncContainer's FIFO serializer and parks mid-apply (the id==1 hook),
-        // so it holds the mutex while blocked; the second call queues strictly behind it and its write
-        // lands last. Without serialization the two writes would race and the winner would be undefined.
+        // First call parks mid-apply (id==1 hook) holding the FIFO serializer, so the second queues behind
+        // it and its write lands last. Without serialization the two writes would race for an undefined winner.
         let firstTask = Task {
             let payload: [Any] = [
                 ["id": 1, "full_name": "Refresh User"],
@@ -3859,13 +3839,11 @@ final class SyncTests: XCTestCase {
 
         try await context.sync(payload: [["id": 1, "name": "Ava"]], as: AutoEmployee.self)
 
-        // String "10" should NOT coerce to Int 10 for strict FK typing.
         try await context.sync(payload: [["id": 1, "name": "Ava", "company_id": "10"]], as: AutoEmployee.self)
 
         var rows = try context.fetch(FetchDescriptor<AutoEmployee>())
         XCTAssertNil(rows.first?.company)
 
-        // Integer 10 matches the expected type and should resolve the FK.
         try await context.sync(payload: [["id": 1, "name": "Ava", "company_id": 10]], as: AutoEmployee.self)
 
         rows = try context.fetch(FetchDescriptor<AutoEmployee>())

--- a/SwiftSync/Tests/SwiftSyncTests/SyncedQueryTests.swift
+++ b/SwiftSync/Tests/SwiftSyncTests/SyncedQueryTests.swift
@@ -13,7 +13,7 @@ final class SyncedQueryTests: XCTestCase {
         let published = SyncedQueryPublisher(
             InferredTask.self, in: container, sortBy: [SortDescriptor(\InferredTask.id)]
         ) {
-            // a real screen would sync here; success is all this test needs
+            // Empty by design: the load closure normally syncs; this test only needs it to succeed.
         }
 
         XCTAssertEqual(published.phase, .idle)


### PR DESCRIPTION
Ran the comment-audit bar at full aggression across the whole first-party tree — **doc comments included** — and stripped everything the code already says.

**Net: −336 comment lines** (479 deleted / 143 kept-or-reflowed, 47 files).

## What died
- **Signature-restating docstrings** (`///`), public or not — `@SyncQuery`/`@SyncModel`/publisher-family navigation docs, `init`/getter docs that re-say the name.
- **Narration & step labels** — `// insert`, `// Reconnect:`, `// Act`/`// given-when-then`, assertion restatement (the test names + messages carry it).
- **Decoration** — every `// MARK:` (22 of them).
- **Snapshot rot & duplicated rationale** — counts, "currently", and whys repeated at call sites.

## What survived (the narrow bar)
Only what the code genuinely can't express, trimmed to the load-bearing clause:
- external / wire-protocol facts (server LWW, upsert-by-id, payload `absent vs null` semantics);
- non-obvious whys (token-advances-only-on-clean-pass, capture-before-upload, per-pass inbox annotation);
- framework gotchas (SwiftData history `.preserveValueOnDeletion`, `@unchecked Sendable` soundness, `nil != "inbound"` is SQL NULL);
- justifications for suspicious code (force-casts, empty closures, force-unwraps that are intentional);
- the repo-required UI-test "why this costly test earns its place" rationales.

## Verification
Behavior-neutral (comment-only + reflow). SwiftSync 190, DemoCore 44, DemoBackend 32, demo app builds, DemoUITests 3/3 — all green.